### PR TITLE
fix bad merge

### DIFF
--- a/azure-pipelines.tags.yml
+++ b/azure-pipelines.tags.yml
@@ -48,6 +48,7 @@ jobs:
       libraryPath: libs/staging-provider
       tagPrefix: staging-provider/
   - template: azure-pipelines/jobs/split-library.yml
+    parameters:
       condition: startsWith(variables['Build.SourceBranch'], 'refs/tags/output-mapping/')
       sourceRepo: platform-libraries
       targetRepo: output-mapping-erik


### PR DESCRIPTION
@ErikZigo I cancelled the CI because it would interfere with the other run.  This is just a fix of the tagging pipeline that I broke when fixing merge confilcts