### PR TITLE
configuration-variables-resolver: require php >=7.4

### DIFF
--- a/libs/configuration-variables-resolver/composer.json
+++ b/libs/configuration-variables-resolver/composer.json
@@ -29,7 +29,7 @@
         }
     },
     "require": {
-        "php": "^7.4",
+        "php": ">=7.4",
         "ext-json": "*",
         "keboola/common-exceptions": "^1.1",
         "keboola/storage-api-client": "^13.4",


### PR DESCRIPTION
Make variables resolver usable in apps with php8