### PR TITLE
PS-3878 Provide `account` with Snowflake credentials

### DIFF
--- a/libs/staging-provider/src/Staging/Workspace/SnowflakeWorkspaceStaging.php
+++ b/libs/staging-provider/src/Staging/Workspace/SnowflakeWorkspaceStaging.php
@@ -8,4 +8,33 @@ class SnowflakeWorkspaceStaging extends WorkspaceStaging
     {
         return 'snowflake';
     }
+
+    public function getCredentials()
+    {
+        $credentials = parent::getCredentials();
+        $credentials['account'] = $this->parseAccount($credentials['host']);
+
+        return $credentials;
+    }
+
+    /**
+     * Parses `account` from `host`
+     *
+     * Based on how Snowflake Python Connector handles account resolution.
+     * https://github.com/snowflakedb/snowflake-connector-python/blob/main/src/snowflake/connector/util_text.py#L242
+     */
+    private function parseAccount(string $host): string
+    {
+        $hostParts = explode('.', $host);
+
+        if (count($hostParts) <= 1) {
+            return $host;
+        }
+
+        if ($hostParts[1] !== 'global') {
+            return $hostParts[0];
+        }
+
+        return substr($hostParts[0], 0, strrpos($hostParts[0], '-'));
+    }
 }

--- a/libs/staging-provider/tests/Provider/WorkspaceStagingProviderTest.php
+++ b/libs/staging-provider/tests/Provider/WorkspaceStagingProviderTest.php
@@ -43,6 +43,7 @@ class WorkspaceStagingProviderTest extends TestCase
             'schema' => 'schema',
             'user' => 'user',
             'password' => 'password',
+            'account' => 'host',
         ];
 
         $workspacesApiClient = $this->createMock(Workspaces::class);

--- a/libs/staging-provider/tests/Staging/Workspace/SnowflakeWorkspaceStagingTest.php
+++ b/libs/staging-provider/tests/Staging/Workspace/SnowflakeWorkspaceStagingTest.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Keboola\StagingProvider\Tests\Staging\Workspace;
+
+use Keboola\StagingProvider\Staging\Workspace\SnowflakeWorkspaceStaging;
+use PHPUnit\Framework\TestCase;
+
+class SnowflakeWorkspaceStagingTest extends TestCase
+{
+    /** @dataProvider provideAccountTestData */
+    public function testGetCredentialsWithAccount(string $host, string $expectedAccount): void
+    {
+        $staging = new SnowflakeWorkspaceStaging([
+            'connection' => [
+                'backend' => 'snowflake',
+                'host' => $host,
+                'warehouse' => 'warehouse',
+                'database' => 'database',
+                'schema' => 'schema',
+                'user' => 'user',
+                'password' => 'password',
+            ],
+        ]);
+
+        $credentials = $staging->getCredentials();
+        self::assertSame($expectedAccount, $credentials['account']);
+    }
+
+    public function provideAccountTestData(): iterable
+    {
+        yield 'localhost' => [
+            'host' => 'localhost',
+            'account' => 'localhost',
+        ];
+
+        yield 'keboola.snowflakecomputing.com' => [
+            'host' => 'keboola.snowflakecomputing.com',
+            'account' => 'keboola',
+        ];
+
+        yield 'test.west-us-2.azure.snowflakecomputing.com' => [
+            'host' => 'test.west-us-2.azure.snowflakecomputing.com',
+            'account' => 'test',
+        ];
+    }
+}

--- a/libs/staging-provider/tests/Staging/WorkspaceStagingTest.php
+++ b/libs/staging-provider/tests/Staging/WorkspaceStagingTest.php
@@ -77,6 +77,7 @@ class WorkspaceStagingTest extends TestCase
             'schema' => 'schema',
             'user' => 'user',
             'password' => 'password',
+            'account' => 'host',
         ];
 
         $workspace = new SnowflakeWorkspaceStaging([

--- a/libs/staging-provider/tests/WorkspaceProviderFactory/ExistingDatabaseWorkspaceProviderFactoryTest.php
+++ b/libs/staging-provider/tests/WorkspaceProviderFactory/ExistingDatabaseWorkspaceProviderFactoryTest.php
@@ -27,6 +27,7 @@ class ExistingDatabaseWorkspaceProviderFactoryTest extends TestCase
                 'database' => 'someDatabase',
                 'schema' => 'someSchema',
                 'user' => 'someUser',
+                'account' => 'someHost',
             ],
         ]);
 
@@ -48,6 +49,7 @@ class ExistingDatabaseWorkspaceProviderFactoryTest extends TestCase
                 'schema' => 'someSchema',
                 'user' => 'someUser',
                 'warehouse' => 'someWarehouse',
+                'account' => 'someHost',
             ],
             $credentials
         );


### PR DESCRIPTION
https://keboola.atlassian.net/browse/PS-3878

Snowpark potrebuje pro pripojeni k Snowflake `account`, ktery my nikde nepouzivame, ale da se odvodit z `host`. Aspon podle oficialni snowflake lib a toho, co jsme videl.