### PR TITLE
IM - Load table into workspace uses workspace client

### DIFF
--- a/libs/input-mapping/composer.json
+++ b/libs/input-mapping/composer.json
@@ -20,7 +20,7 @@
         "php": ">=7.4",
         "ext-json": "*",
         "keboola/php-file-storage-utils": "^0.2.2",
-        "keboola/storage-api-client": "^14.0",
+        "keboola/storage-api-client": "^14.4",
         "keboola/storage-api-php-client-branch-wrapper": "^3.1",
         "symfony/config": "^4.4|^5.4",
         "symfony/finder": "^4.4|^5.4",


### PR DESCRIPTION
V IM jsme volali přímo Storage API abysme se vyhnuli interní implementaci clienta handlování async tásků (čekání na dokončení jobu)

Nová verze https://github.com/keboola/storage-api-php-client/releases/tag/v14.4.0 má už i metody pouze pro zafrontování loadu.