### PR TITLE
[k8s-client] PS-3962 Allow setting custom namespace with in-cluster auth

### DIFF
--- a/libs/k8s-client/composer.json
+++ b/libs/k8s-client/composer.json
@@ -29,7 +29,8 @@
         "phpstan/phpstan": "^1.8",
         "phpstan/phpstan-phpunit": "^1.1",
         "phpunit/phpunit": "^9.5",
-        "sempro/phpunit-pretty-print": "^1.4"
+        "sempro/phpunit-pretty-print": "^1.4",
+        "symfony/filesystem": "^6.1"
     },
     "config": {
         "sort-packages": true,

--- a/libs/k8s-client/src/ClientFacadeFactory/InClusterClientFacadeFactory.php
+++ b/libs/k8s-client/src/ClientFacadeFactory/InClusterClientFacadeFactory.php
@@ -23,13 +23,13 @@ class InClusterClientFacadeFactory
         $this->credentialsPath = $credentialsPath;
     }
 
-    public function createClusterClient(): KubernetesApiClientFacade
+    public function createClusterClient(?string $namespace = null): KubernetesApiClientFacade
     {
         return $this->genericFactory->createClusterClient(
             self::IN_CLUSTER_API_URL,
             $this->readInClusterConfigFile('token'),
             $this->findInClusterConfigFile('ca.crt'),
-            $this->readInClusterConfigFile('namespace'),
+            $namespace ?? $this->readInClusterConfigFile('namespace'),
         );
     }
 
@@ -40,7 +40,7 @@ class InClusterClientFacadeFactory
 
         if ($fileContents === false) {
             throw new ConfigurationException(sprintf(
-                'Failed to read contents of in-cluster configuration file %s',
+                'Failed to read contents of in-cluster configuration file "%s"',
                 $filePath,
             ));
         }
@@ -54,7 +54,7 @@ class InClusterClientFacadeFactory
 
         if (!file_exists($filePath)) {
             throw new ConfigurationException(sprintf(
-                'In-cluster configuration file %s does not exist',
+                'In-cluster configuration file "%s" does not exist',
                 $filePath,
             ));
         }

--- a/libs/k8s-client/tests/ClientFacadeFactory/InClusterClientFacadeFactoryTest.php
+++ b/libs/k8s-client/tests/ClientFacadeFactory/InClusterClientFacadeFactoryTest.php
@@ -1,0 +1,141 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Keboola\K8sClient\Tests\ClientFacadeFactory;
+
+use Keboola\K8sClient\ClientFacadeFactory\GenericClientFacadeFactory;
+use Keboola\K8sClient\ClientFacadeFactory\InClusterClientFacadeFactory;
+use Keboola\K8sClient\Exception\ConfigurationException;
+use Keboola\K8sClient\KubernetesApiClientFacade;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Filesystem\Filesystem;
+
+class InClusterClientFacadeFactoryTest extends TestCase
+{
+    private readonly string $credentialsPath;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->credentialsPath = sys_get_temp_dir().'/k8s-creds-test';
+
+        $filesystem = new Filesystem();
+        $filesystem->remove($this->credentialsPath);
+
+        $filesystem->dumpFile($this->credentialsPath.'/token', 'token');
+        $filesystem->dumpFile($this->credentialsPath.'/ca.crt', 'server-cert');
+        $filesystem->dumpFile($this->credentialsPath.'/namespace', 'namespace');
+    }
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+        @rmdir($this->credentialsPath);
+    }
+
+    public function testCreateClusterClient(): void
+    {
+        $createdClient = $this->createMock(KubernetesApiClientFacade::class);
+
+        $genericFactory = $this->createMock(GenericClientFacadeFactory::class);
+        $genericFactory->expects(self::once())
+            ->method('createClusterClient')
+            ->with(
+                'https://kubernetes.default.svc',
+                'token',
+                $this->credentialsPath.'/ca.crt',
+                'namespace',
+            )
+            ->willReturn($createdClient)
+        ;
+
+        $factory = new InClusterClientFacadeFactory(
+            $genericFactory,
+            $this->credentialsPath,
+        );
+
+        $result = $factory->createClusterClient();
+        self::assertSame($createdClient, $result);
+    }
+
+    public function testCreateClusterClientWithMissingTokenFile(): void
+    {
+        unlink($this->credentialsPath.'/token');
+
+        $genericFactory = $this->createMock(GenericClientFacadeFactory::class);
+        $genericFactory->expects(self::never())->method('createClusterClient');
+
+        $factory = new InClusterClientFacadeFactory(
+            $genericFactory,
+            $this->credentialsPath,
+        );
+
+        $this->expectException(ConfigurationException::class);
+        $this->expectExceptionMessage('In-cluster configuration file "/tmp/k8s-creds-test/token" does not exist');
+
+        $factory->createClusterClient();
+    }
+
+    public function testCreateClusterClientWithMissingCertFile(): void
+    {
+        unlink($this->credentialsPath.'/ca.crt');
+
+        $genericFactory = $this->createMock(GenericClientFacadeFactory::class);
+        $genericFactory->expects(self::never())->method('createClusterClient');
+
+        $factory = new InClusterClientFacadeFactory(
+            $genericFactory,
+            $this->credentialsPath,
+        );
+
+        $this->expectException(ConfigurationException::class);
+        $this->expectExceptionMessage('In-cluster configuration file "/tmp/k8s-creds-test/ca.crt" does not exist');
+
+        $factory->createClusterClient();
+    }
+
+    public function testCreateClusterClientWithMissingNamespaceFile(): void
+    {
+        unlink($this->credentialsPath.'/namespace');
+
+        $genericFactory = $this->createMock(GenericClientFacadeFactory::class);
+        $genericFactory->expects(self::never())->method('createClusterClient');
+
+        $factory = new InClusterClientFacadeFactory(
+            $genericFactory,
+            $this->credentialsPath,
+        );
+
+        $this->expectException(ConfigurationException::class);
+        $this->expectExceptionMessage('In-cluster configuration file "/tmp/k8s-creds-test/namespace" does not exist');
+
+        $factory->createClusterClient();
+    }
+
+    public function testCreateClusterClientWithCustomNamespace(): void
+    {
+        $createdClient = $this->createMock(KubernetesApiClientFacade::class);
+
+        $genericFactory = $this->createMock(GenericClientFacadeFactory::class);
+        $genericFactory->expects(self::once())
+            ->method('createClusterClient')
+            ->with(
+                'https://kubernetes.default.svc',
+                'token',
+                $this->credentialsPath.'/ca.crt',
+                'custom-namespace',
+            )
+            ->willReturn($createdClient)
+        ;
+
+        $factory = new InClusterClientFacadeFactory(
+            $genericFactory,
+            $this->credentialsPath,
+        );
+
+        $result = $factory->createClusterClient('custom-namespace');
+        self::assertSame($createdClient, $result);
+    }
+}


### PR DESCRIPTION
https://keboola.atlassian.net/browse/PS-3962

Pro GELF logger potrebujeme mit moznost pracovat s jinym namespace, nez ve kterem bezi (logger bezi v `default` namespace, ale Pody, ktere loguji, jsou v `job-queue-jobs`). Zaroven `namespace` je jediny parametr, ktery dava smysl mit moznost pretizit i u te in-cluster auth.

Follow up: https://github.com/keboola/job-queue/pull/209