### PR TITLE
MAR-17 Extract Azure API Client to a separate lib (part 3)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,9 @@
 version: "3.4"
 
 services:
+  mockserver:
+    image: mockserver/mockserver:5.13.2
+
   dev: &dev
     profiles: [ ci, dev ]
     build: &dev-build
@@ -36,6 +39,8 @@ services:
     working_dir: /code/libs/azure-api-client
     volumes:
       - .:/code
+    depends_on:
+      - mockserver
 
   dev-input-mapping:
     profiles: [dev]

--- a/libs/azure-api-client/azure-pipelines.tests.yml
+++ b/libs/azure-api-client/azure-pipelines.tests.yml
@@ -2,5 +2,5 @@ jobs:
   - template: ../../azure-pipelines/jobs/run-tests.yml
     parameters:
       displayName: Tests
-      serviceName: dev81
-      testCommand: bash -c 'cd libs/azure-api-client && composer install && composer ci'
+      serviceName: dev-azure-api-client
+      testCommand: bash -c 'composer install && composer ci'

--- a/libs/azure-api-client/composer.json
+++ b/libs/azure-api-client/composer.json
@@ -36,7 +36,8 @@
         "keboola/coding-standard": "^14.0",
         "phpstan/phpstan": "^1.9",
         "phpstan/phpstan-phpunit": "^1.3",
-        "sempro/phpunit-pretty-print": "^1.4"
+        "sempro/phpunit-pretty-print": "^1.4",
+        "symfony/http-client": "^6.2"
     },
     "scripts": {
         "ci": [

--- a/libs/azure-api-client/src/Authentication/AuthenticatorInterface.php
+++ b/libs/azure-api-client/src/Authentication/AuthenticatorInterface.php
@@ -4,12 +4,8 @@ declare(strict_types=1);
 
 namespace Keboola\AzureApiClient\Authentication;
 
-use Keboola\AzureApiClient\GuzzleClientFactory;
-
 interface AuthenticatorInterface
 {
-    public function __construct(GuzzleClientFactory $clientFactory);
-
     public function getAuthenticationToken(string $resource): string;
 
     public function checkUsability(): void;

--- a/libs/azure-api-client/src/AzureApiClient.php
+++ b/libs/azure-api-client/src/AzureApiClient.php
@@ -51,8 +51,15 @@ class AzureApiClient
     /**
      * @return ($expectResponse is true ? array : null)
      */
-    public function sendRequest(Request $request, bool $expectResponse = true): ?array
-    {
+    public function sendRequest(
+        string $method,
+        string $uri,
+        array $headers = [],
+        $body = null,
+        bool $expectResponse = true
+    ): ?array {
+        $request = new Request($method, $uri, $headers, $body);
+
         try {
             if (empty($this->token)) {
                 $this->token = $this->authenticator->getAuthenticationToken($this->resource);

--- a/libs/azure-api-client/src/GuzzleClientFactory.php
+++ b/libs/azure-api-client/src/GuzzleClientFactory.php
@@ -25,11 +25,9 @@ class GuzzleClientFactory
     private const AZURE_THROTTLING_CODE = 429;
     private const ALLOWED_OPTIONS = ['backoffMaxTries', 'userAgent', 'handler', 'logger'];
 
-    private LoggerInterface $logger;
-
-    public function __construct(LoggerInterface $logger)
-    {
-        $this->logger = $logger;
+    public function __construct(
+        private readonly LoggerInterface $logger,
+    ) {
     }
 
     public function getLogger(): LoggerInterface

--- a/libs/azure-api-client/src/Marketplace/MarketplaceApiClient.php
+++ b/libs/azure-api-client/src/Marketplace/MarketplaceApiClient.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Keboola\AzureApiClient\Marketplace;
 
-use GuzzleHttp\Psr7\Request;
 use Keboola\AzureApiClient\AzureApiClient;
 use Keboola\AzureApiClient\AzureApiClientFactory;
 use Keboola\AzureApiClient\Marketplace\Model\ActivateSubscriptionRequest;
@@ -13,7 +12,7 @@ use Keboola\AzureApiClient\Marketplace\Model\Subscription;
 
 class MarketplaceApiClient
 {
-    private function __construct(
+    public function __construct(
         private readonly AzureApiClient $azureApiClient,
     ) {
     }
@@ -26,33 +25,33 @@ class MarketplaceApiClient
 
     public function resolveSubscription(string $marketplaceToken): ResolveSubscriptionResult
     {
-        $responseData = $this->azureApiClient->sendRequest(new Request(
+        $responseData = $this->azureApiClient->sendRequest(
             'POST',
             '/api/saas/subscriptions/resolve?api-version=2018-08-31',
             [
                 'x-ms-marketplace-token' => $marketplaceToken,
-            ]
-        ));
+            ],
+        );
 
         return ResolveSubscriptionResult::fromResponseData($responseData);
     }
 
     public function getSubscription(string $subscriptionId): Subscription
     {
-        $responseData = $this->azureApiClient->sendRequest(new Request(
+        $responseData = $this->azureApiClient->sendRequest(
             'GET',
             sprintf(
                 '/api/saas/subscriptions/%s?api-version=2018-08-31',
                 urlencode($subscriptionId),
             ),
-        ));
+        );
 
         return Subscription::fromResponseData($responseData);
     }
 
     public function activateSubscription(ActivateSubscriptionRequest $parameters): void
     {
-        $this->azureApiClient->sendRequest(new Request(
+        $this->azureApiClient->sendRequest(
             'POST',
             sprintf(
                 '/api/saas/subscriptions/%s/activate?api-version=2018-08-31',
@@ -65,15 +64,16 @@ class MarketplaceApiClient
                 'planId' => $parameters->planId,
                 'quantity' => $parameters->quantity,
             ], JSON_THROW_ON_ERROR),
-        ), false);
+            false,
+        );
     }
 
     public function updateOperationStatus(string $subscriptionId, string $operationId, OperationStatus $status): void
     {
-        $this->azureApiClient->sendRequest(new Request(
+        $this->azureApiClient->sendRequest(
             'PATCH',
             sprintf(
-                '/api/saas/subscriptions/%s/operations%s?api-version=2018-08-31',
+                '/api/saas/subscriptions/%s/operations/%s?api-version=2018-08-31',
                 urlencode($subscriptionId),
                 urlencode($operationId),
             ),
@@ -83,6 +83,7 @@ class MarketplaceApiClient
             (string) json_encode([
                 'status' => $status->value,
             ], JSON_THROW_ON_ERROR),
-        ), false);
+            false,
+        );
     }
 }

--- a/libs/azure-api-client/src/Marketplace/MeteringServiceApiClient.php
+++ b/libs/azure-api-client/src/Marketplace/MeteringServiceApiClient.php
@@ -4,8 +4,10 @@ declare(strict_types=1);
 
 namespace Keboola\AzureApiClient\Marketplace;
 
+use GuzzleHttp\Psr7\Request;
 use Keboola\AzureApiClient\AzureApiClient;
 use Keboola\AzureApiClient\AzureApiClientFactory;
+use Keboola\AzureApiClient\Marketplace\Model\ReportUsageEventsBatchResult;
 use Keboola\AzureApiClient\Marketplace\Model\UsageEvent;
 use Keboola\AzureApiClient\Marketplace\Model\UsageEventResult;
 
@@ -31,17 +33,18 @@ class MeteringServiceApiClient
      */
     public function reportUsageEventsBatch(array $events): array
     {
-        $responseData = $this->azureApiClient->sendRequest(
-            'POST',
-            'batchUsageEvent?api-version=2018-08-31',
-            [
-                'Content-Type' => 'application/json',
-            ],
-            json_encode([
-                'request' => $events,
-            ], JSON_THROW_ON_ERROR),
-        );
-
-        return array_map(UsageEventResult::fromResponseData(...), $responseData['result']);
+        return $this->azureApiClient->sendRequestAndMapResponse(
+            new Request(
+                'POST',
+                'batchUsageEvent?api-version=2018-08-31',
+                [
+                    'Content-Type' => 'application/json',
+                ],
+                json_encode([
+                    'request' => $events,
+                ], JSON_THROW_ON_ERROR),
+            ),
+            ReportUsageEventsBatchResult::class,
+        )->result;
     }
 }

--- a/libs/azure-api-client/src/Marketplace/MeteringServiceApiClient.php
+++ b/libs/azure-api-client/src/Marketplace/MeteringServiceApiClient.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Keboola\AzureApiClient\Marketplace;
 
-use GuzzleHttp\Psr7\Request;
 use Keboola\AzureApiClient\AzureApiClient;
 use Keboola\AzureApiClient\AzureApiClientFactory;
 use Keboola\AzureApiClient\Marketplace\Model\UsageEvent;
@@ -12,7 +11,7 @@ use Keboola\AzureApiClient\Marketplace\Model\UsageEventResult;
 
 class MeteringServiceApiClient
 {
-    private function __construct(
+    public function __construct(
         private readonly AzureApiClient $azureApiClient,
     ) {
     }
@@ -32,7 +31,7 @@ class MeteringServiceApiClient
      */
     public function reportUsageEventsBatch(array $events): array
     {
-        $responseData = $this->azureApiClient->sendRequest(new Request(
+        $responseData = $this->azureApiClient->sendRequest(
             'POST',
             'batchUsageEvent?api-version=2018-08-31',
             [
@@ -41,7 +40,7 @@ class MeteringServiceApiClient
             json_encode([
                 'request' => $events,
             ], JSON_THROW_ON_ERROR),
-        ));
+        );
 
         return array_map(UsageEventResult::fromResponseData(...), $responseData['result']);
     }

--- a/libs/azure-api-client/src/Marketplace/Model/ActivateSubscriptionRequest.php
+++ b/libs/azure-api-client/src/Marketplace/Model/ActivateSubscriptionRequest.php
@@ -9,7 +9,7 @@ class ActivateSubscriptionRequest
     public function __construct(
         public readonly string $subscriptionId,
         public readonly string $planId,
-        public readonly ?string $quantity = null,
+        public readonly null|string|int|float $quantity = null,
     ) {
     }
 }

--- a/libs/azure-api-client/src/Marketplace/Model/ReportUsageEventsBatchResult.php
+++ b/libs/azure-api-client/src/Marketplace/Model/ReportUsageEventsBatchResult.php
@@ -6,21 +6,18 @@ namespace Keboola\AzureApiClient\Marketplace\Model;
 
 use Keboola\AzureApiClient\ResponseModelInterface;
 
-final class UsageEventError implements ResponseModelInterface
+final class ReportUsageEventsBatchResult implements ResponseModelInterface
 {
     public function __construct(
-        public readonly string $code,
-        public readonly string $message,
-        public readonly ?array $additionalInfo,
+        /** @var UsageEventResult[] */
+        public readonly array $result,
     ) {
     }
 
     public static function fromResponseData(array $data): static
     {
         return new self(
-            $data['code'],
-            $data['message'],
-            $data['additionalInfo'] ?? null,
+            array_map(UsageEventResult::fromResponseData(...), $data['result']),
         );
     }
 }

--- a/libs/azure-api-client/src/Marketplace/Model/ResolveSubscriptionResult.php
+++ b/libs/azure-api-client/src/Marketplace/Model/ResolveSubscriptionResult.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace Keboola\AzureApiClient\Marketplace\Model;
 
-class ResolveSubscriptionResult
+use Keboola\AzureApiClient\ResponseModelInterface;
+
+final class ResolveSubscriptionResult implements ResponseModelInterface
 {
     public function __construct(
         public readonly string $id,
@@ -16,7 +18,7 @@ class ResolveSubscriptionResult
     ) {
     }
 
-    public static function fromResponseData(array $data): self
+    public static function fromResponseData(array $data): static
     {
         return new self(
             $data['id'],

--- a/libs/azure-api-client/src/Marketplace/Model/Subscription.php
+++ b/libs/azure-api-client/src/Marketplace/Model/Subscription.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace Keboola\AzureApiClient\Marketplace\Model;
 
-class Subscription
+use Keboola\AzureApiClient\ResponseModelInterface;
+
+final class Subscription implements ResponseModelInterface
 {
     public function __construct(
         public readonly string $id,
@@ -17,7 +19,7 @@ class Subscription
     ) {
     }
 
-    public static function fromResponseData(array $data): self
+    public static function fromResponseData(array $data): static
     {
         return new self(
             $data['id'],

--- a/libs/azure-api-client/src/Marketplace/Model/Subscription.php
+++ b/libs/azure-api-client/src/Marketplace/Model/Subscription.php
@@ -12,7 +12,7 @@ class Subscription
         public readonly string $offerId,
         public readonly string $planId,
         public readonly string $name,
-        public readonly ?int $quantity,
+        public readonly null|string|int|float $quantity,
         public readonly string $saasSubscriptionStatus,
     ) {
     }

--- a/libs/azure-api-client/src/Marketplace/Model/UsageEventResult.php
+++ b/libs/azure-api-client/src/Marketplace/Model/UsageEventResult.php
@@ -5,8 +5,9 @@ declare(strict_types=1);
 namespace Keboola\AzureApiClient\Marketplace\Model;
 
 use DateTimeImmutable;
+use Keboola\AzureApiClient\ResponseModelInterface;
 
-class UsageEventResult
+final class UsageEventResult implements ResponseModelInterface
 {
     public function __construct(
         public readonly ?string $usageEventId,
@@ -21,7 +22,7 @@ class UsageEventResult
     ) {
     }
 
-    public static function fromResponseData(array $data): self
+    public static function fromResponseData(array $data): static
     {
         return new self(
             $data['usageEventId'] ?? null,

--- a/libs/azure-api-client/src/ResponseModelInterface.php
+++ b/libs/azure-api-client/src/ResponseModelInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Keboola\AzureApiClient;
+
+interface ResponseModelInterface
+{
+    public static function fromResponseData(array $data): static;
+}

--- a/libs/azure-api-client/tests/AzureApiClientFunctionalTest.php
+++ b/libs/azure-api-client/tests/AzureApiClientFunctionalTest.php
@@ -1,0 +1,142 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Keboola\AzureApiClient\Tests;
+
+use Keboola\AzureApiClient\Authentication\AuthenticatorFactory;
+use Keboola\AzureApiClient\Authentication\AuthenticatorInterface;
+use Keboola\AzureApiClient\AzureApiClient;
+use Keboola\AzureApiClient\GuzzleClientFactory;
+use Monolog\Logger;
+use PHPUnit\Framework\TestCase;
+
+class AzureApiClientFunctionalTest extends TestCase
+{
+    public function testSendGetRequest(): void
+    {
+        $mockserver = new Mockserver();
+        $mockserver->reset();
+        $mockserver->expect([
+            'httpRequest' => [
+                'method' => 'GET',
+                'path' => '/foo/bar',
+                'headers' => [
+                    'Authorization' => 'Bearer auth-token',
+                ],
+            ],
+            'httpResponse' => [
+                'statusCode' => 200,
+                'body' => json_encode(['foo' => 'bar']),
+            ],
+        ]);
+
+        $logger = new Logger('test');
+        $authenticatorFactory = $this->createAuthenticatorFactory('auth-token');
+        $guzzleClientFactory = new GuzzleClientFactory($logger);
+
+        $apiClient = new AzureApiClient(
+            $mockserver->getServerUrl(),
+            'my-api',
+            $guzzleClientFactory,
+            $authenticatorFactory,
+            $logger,
+        );
+
+        $response = $apiClient->sendRequest('GET', 'foo/bar');
+        self::assertSame(['foo' => 'bar'], $response);
+    }
+
+    public function testSendPostRequestWithResponse(): void
+    {
+        $mockserver = new Mockserver();
+        $mockserver->reset();
+        $mockserver->expect([
+            'httpRequest' => [
+                'method' => 'POST',
+                'path' => '/foo/bar',
+                'headers' => [
+                    'Authorization' => 'Bearer auth-token',
+                    'Content-Type' => 'application/json',
+                ],
+                'body' => '{"foo":"baz"}'
+            ],
+            'httpResponse' => [
+                'statusCode' => 200,
+                'body' => json_encode(['foo' => 'bar']),
+            ],
+        ]);
+
+        $logger = new Logger('test');
+        $authenticatorFactory = $this->createAuthenticatorFactory('auth-token');
+        $guzzleClientFactory = new GuzzleClientFactory($logger);
+
+        $apiClient = new AzureApiClient(
+            $mockserver->getServerUrl(),
+            'my-api',
+            $guzzleClientFactory,
+            $authenticatorFactory,
+            $logger,
+        );
+
+        $response = $apiClient->sendRequest(
+            'POST',
+            'foo/bar',
+            ['Content-Type' => 'application/json'],
+            '{"foo":"baz"}',
+            true,
+        );
+        self::assertSame(['foo' => 'bar'], $response);
+    }
+
+    public function testSendPostRequestWithoutResponse(): void
+    {
+        $mockserver = new Mockserver();
+        $mockserver->reset();
+        $mockserver->expect([
+            'httpRequest' => [
+                'method' => 'DELETE',
+                'path' => '/foo/bar',
+                'headers' => [
+                    'Authorization' => 'Bearer auth-token',
+                ],
+                'body' => ''
+            ],
+            'httpResponse' => [
+                'statusCode' => 200,
+            ],
+        ]);
+
+        $logger = new Logger('test');
+        $authenticatorFactory = $this->createAuthenticatorFactory('auth-token');
+        $guzzleClientFactory = new GuzzleClientFactory($logger);
+
+        $apiClient = new AzureApiClient(
+            $mockserver->getServerUrl(),
+            'my-api',
+            $guzzleClientFactory,
+            $authenticatorFactory,
+            $logger,
+        );
+
+        $response = $apiClient->sendRequest(
+            'DELETE',
+            'foo/bar',
+            [],
+            null,
+            false,
+        );
+        self::assertNull($response);
+    }
+
+    public function createAuthenticatorFactory(string $authToken): AuthenticatorFactory
+    {
+        $authenticator = $this->createMock(AuthenticatorInterface::class);
+        $authenticator->method('getAuthenticationToken')->willReturn($authToken);
+
+        $authenticatorFactory = $this->createMock(AuthenticatorFactory::class);
+        $authenticatorFactory->method('getAuthenticator')->willReturn($authenticator);
+
+        return $authenticatorFactory;
+    }
+}

--- a/libs/azure-api-client/tests/DummyTestResponse.php
+++ b/libs/azure-api-client/tests/DummyTestResponse.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Keboola\AzureApiClient\Tests;
+
+use Keboola\AzureApiClient\ResponseModelInterface;
+
+final class DummyTestResponse implements ResponseModelInterface
+{
+    public function __construct(
+        public readonly string $foo,
+    ) {
+    }
+
+    public static function fromResponseData(array $data): static
+    {
+        return new self(
+            $data['foo'],
+        );
+    }
+}

--- a/libs/azure-api-client/tests/Marketplace/MarketplaceApiClientTest.php
+++ b/libs/azure-api-client/tests/Marketplace/MarketplaceApiClientTest.php
@@ -1,0 +1,154 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Keboola\AzureApiClient\Tests\Marketplace;
+
+use Keboola\AzureApiClient\AzureApiClient;
+use Keboola\AzureApiClient\AzureApiClientFactory;
+use Keboola\AzureApiClient\Marketplace\MarketplaceApiClient;
+use Keboola\AzureApiClient\Marketplace\Model\ActivateSubscriptionRequest;
+use Keboola\AzureApiClient\Marketplace\Model\ResolveSubscriptionResult;
+use Keboola\AzureApiClient\Marketplace\Model\Subscription;
+use Keboola\AzureApiClient\Marketplace\OperationStatus;
+use Keboola\AzureApiClient\Tests\ReflectionPropertyAccessTestCase;
+use PHPUnit\Framework\TestCase;
+
+class MarketplaceApiClientTest extends TestCase
+{
+    use ReflectionPropertyAccessTestCase;
+
+    public function testCreateClient(): void
+    {
+        $azureApiClient = $this->createMock(AzureApiClient::class);
+
+        $clientFactory = $this->createMock(AzureApiClientFactory::class);
+        $clientFactory->expects(self::once())
+            ->method('getClient')
+            ->with('https://marketplaceapi.microsoft.com', '20e940b3-4c77-4b0b-9a53-9e16a1b010a7')
+            ->willReturn($azureApiClient)
+        ;
+
+        $client = MarketplaceApiClient::create($clientFactory);
+
+        self::assertSame($azureApiClient, self::getPrivatePropertyValue($client, 'azureApiClient'));
+    }
+
+    public function testResolveSubscription(): void
+    {
+        $apiResponse = [
+            'id' => 'subscription-id',
+            'subscriptionName' => 'subscription-name',
+            'offerId' => 'offer-id',
+            'planId' => 'plan-id',
+            'subscription' => [
+                'id' => 'subscription-id',
+                'publisherId' => 'publisher-id',
+                'offerId' => 'offer-id',
+                'planId' => 'plan-id',
+                'name' => 'subscription-name',
+                'quantity' => 1,
+                'saasSubscriptionStatus' => 'status',
+            ],
+        ];
+
+        $azureApiClient = $this->createMock(AzureApiClient::class);
+        $azureApiClient->expects(self::once())
+            ->method('sendRequest')
+            ->with(
+                'POST',
+                '/api/saas/subscriptions/resolve?api-version=2018-08-31',
+                [
+                    'x-ms-marketplace-token' => 'marketplace-token',
+                ]
+            )
+            ->willReturn($apiResponse)
+        ;
+
+        $client = new MarketplaceApiClient($azureApiClient);
+        $result = $client->resolveSubscription('marketplace-token');
+
+        self::assertEquals(ResolveSubscriptionResult::fromResponseData($apiResponse), $result);
+    }
+
+    public function testGetSubscription(): void
+    {
+        $apiResponse = [
+            'id' => 'subscription id',
+            'publisherId' => 'publisher-id',
+            'offerId' => 'offer-id',
+            'planId' => 'plan-id',
+            'name' => 'subscription-name',
+            'quantity' => 1,
+            'saasSubscriptionStatus' => 'status',
+        ];
+
+        $azureApiClient = $this->createMock(AzureApiClient::class);
+        $azureApiClient->expects(self::once())
+            ->method('sendRequest')
+            ->with(
+                'GET',
+                '/api/saas/subscriptions/subscription+id?api-version=2018-08-31',
+            )
+            ->willReturn($apiResponse)
+        ;
+
+        $client = new MarketplaceApiClient($azureApiClient);
+        $result = $client->getSubscription('subscription id');
+
+        self::assertEquals(Subscription::fromResponseData($apiResponse), $result);
+    }
+
+    public function testActivateSubscription(): void
+    {
+        $azureApiClient = $this->createMock(AzureApiClient::class);
+        $azureApiClient->expects(self::once())
+            ->method('sendRequest')
+            ->with(
+                'POST',
+                '/api/saas/subscriptions/subscription+id/activate?api-version=2018-08-31',
+                [
+                    'Content-Type' => 'application/json',
+                ],
+                json_encode([
+                    'planId' => 'plan-id',
+                    'quantity' => 1,
+                ]),
+                false,
+            )
+        ;
+
+        $client = new MarketplaceApiClient($azureApiClient);
+        $client->activateSubscription(new ActivateSubscriptionRequest(
+            'subscription id',
+            'plan-id',
+            1,
+        ));
+    }
+
+    public function testUpdateOperationStatus(): void
+    {
+        $azureApiClient = $this->createMock(AzureApiClient::class);
+        $azureApiClient->expects(self::once())
+            ->method('sendRequest')
+            ->with(
+                'PATCH',
+                '/api/saas/subscriptions/subscription+id/operations/operation+id?api-version=2018-08-31',
+                [
+                    'Content-Type' => 'application/json',
+                ],
+                json_encode([
+                    'status' => 'Success',
+                ]),
+                false,
+            )
+        ;
+
+        $client = new MarketplaceApiClient($azureApiClient);
+        $client->updateOperationStatus(
+            'subscription id',
+            'operation id',
+            OperationStatus::SUCCESS,
+        );
+    }
+}

--- a/libs/azure-api-client/tests/Marketplace/MeteringServiceApiClientTest.php
+++ b/libs/azure-api-client/tests/Marketplace/MeteringServiceApiClientTest.php
@@ -1,0 +1,121 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Keboola\AzureApiClient\Tests\Marketplace;
+
+use DateTimeImmutable;
+use Keboola\AzureApiClient\AzureApiClient;
+use Keboola\AzureApiClient\AzureApiClientFactory;
+use Keboola\AzureApiClient\Marketplace\MeteringServiceApiClient;
+use Keboola\AzureApiClient\Marketplace\Model\UsageEvent;
+use Keboola\AzureApiClient\Marketplace\Model\UsageEventResult;
+use Keboola\AzureApiClient\Tests\ReflectionPropertyAccessTestCase;
+use PHPUnit\Framework\TestCase;
+
+class MeteringServiceApiClientTest extends TestCase
+{
+    use ReflectionPropertyAccessTestCase;
+
+    public function testCreateClient(): void
+    {
+        $azureApiClient = $this->createMock(AzureApiClient::class);
+
+        $clientFactory = $this->createMock(AzureApiClientFactory::class);
+        $clientFactory->expects(self::once())
+            ->method('getClient')
+            ->with('https://marketplaceapi.microsoft.com/api/', '20e940b3-4c77-4b0b-9a53-9e16a1b010a7')
+            ->willReturn($azureApiClient)
+        ;
+
+        $client = MeteringServiceApiClient::create($clientFactory);
+
+        self::assertSame($azureApiClient, self::getPrivatePropertyValue($client, 'azureApiClient'));
+    }
+
+    public function testReportUsageEventsBatch(): void
+    {
+        $apiResponse = [
+            'result' => [
+                [
+                    'usageEventId' => 'event-1',
+                    'status' => 'Accepted',
+                    'messageTime' => '2023-01-02T14:00:00Z',
+                    'resourceId' => 'resource-1',
+                    'planId' => 'plan-1',
+                    'dimension' => 'dim-1',
+                    'quantity' => 1.0,
+                    'effectiveStartTime' => '2023-01-01T12:00:00Z',
+                ],
+                [
+                    'usageEventId' => 'event-1',
+                    'status' => 'Duplicate',
+                    'error' => [
+                        'code' => 'err-code',
+                        'message' => 'err-message',
+                    ],
+                    'messageTime' => '2023-01-02T14:00:00Z',
+                    'resourceId' => 'resource-1',
+                    'planId' => 'plan-1',
+                    'dimension' => 'dim-1',
+                    'quantity' => 1.0,
+                    'effectiveStartTime' => '2023-01-01T12:00:00Z',
+                ],
+            ]
+        ];
+
+        $azureApiClient = $this->createMock(AzureApiClient::class);
+        $azureApiClient->expects(self::once())
+            ->method('sendRequest')
+            ->with(
+                'POST',
+                'batchUsageEvent?api-version=2018-08-31',
+                [
+                    'Content-Type' => 'application/json',
+                ],
+                json_encode([
+                    'request' => [
+                        [
+                            'resourceId' => 'resource-1',
+                            'planId' => 'plan-1',
+                            'dimension' => 'dim-1',
+                            'quantity' => 1.0,
+                            'effectiveStartTime' => '2023-01-01T12:00:00+00:00',
+                        ],
+                        [
+                            'resourceId' => 'resource-2',
+                            'planId' => 'plan-2',
+                            'dimension' => 'dim-2',
+                            'quantity' => 2.5,
+                            'effectiveStartTime' => '2023-01-02T12:00:00+00:00',
+                        ],
+                    ]
+                ])
+            )
+            ->willReturn($apiResponse)
+        ;
+
+        $client = new MeteringServiceApiClient($azureApiClient);
+        $result = $client->reportUsageEventsBatch([
+            new UsageEvent(
+                'resource-1',
+                'plan-1',
+                'dim-1',
+                1.0,
+                new DateTimeImmutable('2023-01-01T12:00:00Z'),
+            ),
+            new UsageEvent(
+                'resource-2',
+                'plan-2',
+                'dim-2',
+                2.5,
+                new DateTimeImmutable('2023-01-02T12:00:00Z'),
+            ),
+        ]);
+
+        self::assertEquals([
+            UsageEventResult::fromResponseData($apiResponse['result'][0]),
+            UsageEventResult::fromResponseData($apiResponse['result'][1]),
+        ], $result);
+    }
+}

--- a/libs/azure-api-client/tests/Marketplace/Model/ReportUsageEventsBatchResultTest.php
+++ b/libs/azure-api-client/tests/Marketplace/Model/ReportUsageEventsBatchResultTest.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Keboola\AzureApiClient\Tests\Marketplace\Model;
+
+use Keboola\AzureApiClient\Marketplace\Model\ReportUsageEventsBatchResult;
+use Keboola\AzureApiClient\Marketplace\Model\UsageEventResult;
+use PHPUnit\Framework\TestCase;
+
+class ReportUsageEventsBatchResultTest extends TestCase
+{
+    public function testFromResponseData(): void
+    {
+        // https://learn.microsoft.com/en-us/azure/marketplace/marketplace-metering-service-apis#responses-1
+        $responseData = [
+            'count' => 2,
+            'result' => [
+                [
+                    'usageEventId' => '<guid>',
+                    'status' => 'Accepted',
+                    'messageTime' => '2020-01-12T13:19:35.3458658Z',
+                    'resourceId' => '<guid1>',
+                    'quantity' => 5,
+                    'dimension' => 'dim1',
+                    'effectiveStartTime' => '2018-12-01T08:30:14',
+                    'planId' => 'plan1',
+                ],
+                [
+                    'status' => 'Duplicate',
+                    'messageTime' => '0001-01-01T00:00:00',
+                    'error' => [
+                        'additionalInfo' => [
+                            'acceptedMessage' => [
+                                'usageEventId' => '<guid>',
+                                'status' => 'Duplicate',
+                                'messageTime' => '2020-01-12T13:19:35.3458658Z',
+                                'resourceId' => '<guid2>',
+                                'quantity' => 1,
+                                'dimension' => 'email',
+                                'effectiveStartTime' => '2020-01-12T11:03:28.14Z',
+                                'planId' => 'gold',
+                            ],
+                        ],
+                        'message' => 'This usage event already exist.',
+                        'code' => 'Conflict',
+                    ],
+                    'resourceId' => '<guid2>',
+                    'quantity' => 1,
+                    'dimension' => 'email',
+                    'effectiveStartTime' => '2020-01-12T11:03:28.14Z',
+                    'planId' => 'gold',
+                ],
+            ],
+        ];
+
+        $result = ReportUsageEventsBatchResult::fromResponseData($responseData);
+
+        self::assertCount(2, $result->result);
+        self::assertEquals(UsageEventResult::fromResponseData($responseData['result'][0]), $result->result[0]);
+        self::assertEquals(UsageEventResult::fromResponseData($responseData['result'][1]), $result->result[1]);
+    }
+}

--- a/libs/azure-api-client/tests/Marketplace/Model/ResolveSubscriptionResultTest.php
+++ b/libs/azure-api-client/tests/Marketplace/Model/ResolveSubscriptionResultTest.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Keboola\AzureApiClient\Tests\Marketplace\Model;
+
+use Keboola\AzureApiClient\Marketplace\Model\ResolveSubscriptionResult;
+use Keboola\AzureApiClient\Marketplace\Model\Subscription;
+use PHPUnit\Framework\TestCase;
+
+class ResolveSubscriptionResultTest extends TestCase
+{
+    public function testFromResponseData(): void
+    {
+        // example data from https://learn.microsoft.com/en-us/azure/marketplace/partner-center-portal/pc-saas-fulfillment-subscription-api#post-httpsmarketplaceapimicrosoftcomapisaassubscriptionsresolveapi-versionapiversion
+        $responseData = [
+            'id' => '<guid>',
+            'subscriptionName' => 'Contoso Cloud Solution',
+            'offerId' => 'offer1',
+            'planId' => 'silver',
+            'quantity' => 20,
+            'subscription' => [
+                'id' => '<guid>',
+                'publisherId' => 'contoso',
+                'offerId' => 'offer1',
+                'name' => 'Contoso Cloud Solution',
+                'saasSubscriptionStatus' => ' PendingFulfillmentStart ',
+                'beneficiary' => [
+                    'emailId' => 'test@test.com',
+                    'objectId' => '<guid>',
+                    'tenantId' => '<guid>',
+                    'puid' => '<ID of the user>',
+                ],
+                'purchaser' => [
+                    'emailId' => 'test@test.com',
+                    'objectId' => '<guid>',
+                    'tenantId' => '<guid>',
+                    'puid' => '<ID of the user>',
+                ],
+                'planId' => 'silver',
+                'term' => [
+                    'termUnit' => 'P1M',
+                    'startDate' => '2022-03-07T00:00:00Z',
+                    'endDate' => '2022-04-06T00:00:00Z',
+                ],
+                'autoRenew' => true,
+                'isTest' => true,
+                'isFreeTrial' => false,
+                'allowedCustomerOperations' => [
+                    'Delete',
+                    'Update',
+                    'Read',
+                ],
+                'sandboxType' => 'None',
+                'lastModified' => '0001-01-01T00:00:00',
+                'quantity' => 5,
+                'sessionMode' => 'None',
+            ],
+        ];
+
+        $result = ResolveSubscriptionResult::fromResponseData($responseData);
+
+        self::assertSame($responseData['id'], $result->id);
+        self::assertSame($responseData['subscriptionName'], $result->subscriptionName);
+        self::assertSame($responseData['offerId'], $result->offerId);
+        self::assertSame($responseData['planId'], $result->planId);
+        self::assertEquals(Subscription::fromResponseData($responseData['subscription']), $result->subscription);
+        self::assertSame($responseData, $result->rawData);
+    }
+}

--- a/libs/azure-api-client/tests/Marketplace/Model/SubscriptionTest.php
+++ b/libs/azure-api-client/tests/Marketplace/Model/SubscriptionTest.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Keboola\AzureApiClient\Tests\Marketplace\Model;
+
+use Keboola\AzureApiClient\Marketplace\Model\Subscription;
+use PHPUnit\Framework\TestCase;
+
+class SubscriptionTest extends TestCase
+{
+    public function testFromResponseData(): void
+    {
+        // example data from https://learn.microsoft.com/en-us/azure/marketplace/partner-center-portal/pc-saas-fulfillment-subscription-api#post-httpsmarketplaceapimicrosoftcomapisaassubscriptionsresolveapi-versionapiversion
+        $responseData = [
+            'id' => '<guid>',
+            'publisherId' => 'contoso',
+            'offerId' => 'offer1',
+            'name' => 'Contoso Cloud Solution',
+            'saasSubscriptionStatus' => ' PendingFulfillmentStart ',
+            'beneficiary' => [
+                'emailId' => 'test@test.com',
+                'objectId' => '<guid>',
+                'tenantId' => '<guid>',
+                'puid' => '<ID of the user>',
+            ],
+            'purchaser' => [
+                'emailId' => 'test@test.com',
+                'objectId' => '<guid>',
+                'tenantId' => '<guid>',
+                'puid' => '<ID of the user>',
+            ],
+            'planId' => 'silver',
+            'term' => [
+                'termUnit' => 'P1M',
+                'startDate' => '2022-03-07T00:00:00Z',
+                'endDate' => '2022-04-06T00:00:00Z',
+            ],
+            'autoRenew' => true,
+            'isTest' => true,
+            'isFreeTrial' => false,
+            'allowedCustomerOperations' => [
+                'Delete',
+                'Update',
+                'Read',
+            ],
+            'sandboxType' => 'None',
+            'lastModified' => '0001-01-01T00:00:00',
+            'quantity' => 5,
+            'sessionMode' => 'None',
+        ];
+
+        $result = Subscription::fromResponseData($responseData);
+
+        self::assertSame($responseData['id'], $result->id);
+        self::assertSame($responseData['publisherId'], $result->publisherId);
+        self::assertSame($responseData['offerId'], $result->offerId);
+        self::assertSame($responseData['planId'], $result->planId);
+        self::assertSame($responseData['name'], $result->name);
+        self::assertSame($responseData['quantity'], $result->quantity);
+        self::assertSame($responseData['saasSubscriptionStatus'], $result->saasSubscriptionStatus);
+    }
+}

--- a/libs/azure-api-client/tests/Marketplace/Model/UsageEventErrorTest.php
+++ b/libs/azure-api-client/tests/Marketplace/Model/UsageEventErrorTest.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Keboola\AzureApiClient\Tests\Marketplace\Model;
+
+use Keboola\AzureApiClient\Marketplace\Model\UsageEventError;
+use PHPUnit\Framework\TestCase;
+
+class UsageEventErrorTest extends TestCase
+{
+    public function testFromResponseData(): void
+    {
+        // https://learn.microsoft.com/en-us/azure/marketplace/marketplace-metering-service-apis#responses
+        $responseData = [
+            'message' => 'One or more errors have occurred.',
+            'target' => 'usageEventRequest',
+            'details' => [
+                [
+                    'message' => 'The resourceId is required.',
+                    'target' => 'ResourceId',
+                    'code' => 'BadArgument',
+                ],
+            ],
+            'code' => 'BadArgument',
+        ];
+
+        $result = UsageEventError::fromResponseData($responseData);
+
+        self::assertSame($responseData['code'], $result->code);
+        self::assertSame($responseData['message'], $result->message);
+        self::assertNull($result->additionalInfo);
+    }
+
+    public function testFromResponseDataWithAdditionalInfo(): void
+    {
+        // https://learn.microsoft.com/en-us/azure/marketplace/marketplace-metering-service-apis#responses
+        $responseData = [
+            'additionalInfo' => [
+                'acceptedMessage' => [
+                    'usageEventId' => '<guid>',
+                    'status' => 'Duplicate',
+                    'messageTime' => '2020-01-12T13:19:35.3458658Z',
+                    'resourceId' => '<guid>',
+                    'quantity' => 1,
+                    'dimension' => 'dim1',
+                    'effectiveStartTime' => '2020-01-12T11:03:28.14Z',
+                    'planId' => 'plan1',
+                ],
+            ],
+            'message' => 'This usage event already exist.',
+            'code' => 'Conflict',
+        ];
+
+        $result = UsageEventError::fromResponseData($responseData);
+
+        self::assertSame($responseData['code'], $result->code);
+        self::assertSame($responseData['message'], $result->message);
+        self::assertSame($responseData['additionalInfo'], $result->additionalInfo);
+    }
+}

--- a/libs/azure-api-client/tests/Marketplace/Model/UsageEventResultTest.php
+++ b/libs/azure-api-client/tests/Marketplace/Model/UsageEventResultTest.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Keboola\AzureApiClient\Tests\Marketplace\Model;
+
+use DateTimeImmutable;
+use Keboola\AzureApiClient\Marketplace\Model\UsageEventError;
+use Keboola\AzureApiClient\Marketplace\Model\UsageEventResult;
+use PHPUnit\Framework\TestCase;
+
+class UsageEventResultTest extends TestCase
+{
+    public function testFromResponseData(): void
+    {
+        // https://learn.microsoft.com/en-us/azure/marketplace/marketplace-metering-service-apis#responses-1
+        $responseData = [
+            'usageEventId' => '<guid>',
+            'status' => 'Accepted',
+            'messageTime' => '2020-01-12T13:19:35.3458658Z',
+            'resourceId' => '<guid1>',
+            'quantity' => 5.0,
+            'dimension' => 'dim1',
+            'effectiveStartTime' => '2018-12-01T08:30:14',
+            'planId' => 'plan1',
+        ];
+
+        $result = UsageEventResult::fromResponseData($responseData);
+
+        self::assertSame($responseData['usageEventId'], $result->usageEventId);
+        self::assertNull($result->error);
+        self::assertSame($responseData['status'], $result->status);
+        self::assertEquals(new DateTimeImmutable($responseData['messageTime']), $result->messageTime);
+        self::assertSame($responseData['resourceId'], $result->resourceId);
+        self::assertSame($responseData['planId'], $result->planId);
+        self::assertSame($responseData['dimension'], $result->dimension);
+        self::assertSame((float) $responseData['quantity'], $result->quantity);
+        self::assertEquals(new DateTimeImmutable($responseData['effectiveStartTime']), $result->effectiveStartTime);
+    }
+
+    public function testFromResponseDataWithError(): void
+    {
+        // https://learn.microsoft.com/en-us/azure/marketplace/marketplace-metering-service-apis#responses-1
+        $responseData = [
+            'status' => 'Duplicate',
+            'messageTime' => '0001-01-01T00:00:00',
+            'error' => [
+                'additionalInfo' => [
+                    'acceptedMessage' => [
+                        'usageEventId' => '<guid>',
+                        'status' => 'Duplicate',
+                        'messageTime' => '2020-01-12T13:19:35.3458658Z',
+                        'resourceId' => '<guid2>',
+                        'quantity' => 1,
+                        'dimension' => 'email',
+                        'effectiveStartTime' => '2020-01-12T11:03:28.14Z',
+                        'planId' => 'gold',
+                    ],
+                ],
+                'message' => 'This usage event already exist.',
+                'code' => 'Conflict',
+            ],
+            'resourceId' => '<guid2>',
+            'quantity' => 1,
+            'dimension' => 'email',
+            'effectiveStartTime' => '2020-01-12T11:03:28.14Z',
+            'planId' => 'gold',
+        ];
+
+        $result = UsageEventResult::fromResponseData($responseData);
+
+        self::assertNull($result->usageEventId);
+        self::assertEquals(UsageEventError::fromResponseData($responseData['error']), $result->error);
+        self::assertSame($responseData['status'], $result->status);
+        self::assertEquals(new DateTimeImmutable($responseData['messageTime']), $result->messageTime);
+        self::assertSame($responseData['resourceId'], $result->resourceId);
+        self::assertSame($responseData['planId'], $result->planId);
+        self::assertSame($responseData['dimension'], $result->dimension);
+        self::assertSame((float) $responseData['quantity'], $result->quantity);
+        self::assertEquals(new DateTimeImmutable($responseData['effectiveStartTime']), $result->effectiveStartTime);
+    }
+}

--- a/libs/azure-api-client/tests/Mockserver.php
+++ b/libs/azure-api-client/tests/Mockserver.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Keboola\AzureApiClient\Tests;
+
+use Symfony\Component\HttpClient\HttpClient;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+
+class Mockserver
+{
+    private readonly string $serverUrl;
+    private HttpClientInterface $client;
+
+    public function __construct(string $serverUrl = 'http://mockserver:1080')
+    {
+        $this->serverUrl = rtrim($serverUrl, '/');
+        $this->client = HttpClient::createForBaseUri($this->serverUrl . '/mockserver');
+    }
+
+    public function getServerUrl(): string
+    {
+        return $this->serverUrl;
+    }
+
+    public function reset(): void
+    {
+        $this->client->request('PUT', 'reset');
+    }
+
+    /**
+     * @param array{
+     *     httpRequest: array{
+     *         method?: string,
+     *         path?: string,
+     *     },
+     *     httpResponse: array{
+     *         statusCode?: int,
+     *         headers?: array<string, string>,
+     *         body?: string,
+     *     },
+     * } $expectation
+     */
+    public function expect(array $expectation): void
+    {
+        $this->client->request('PUT', 'expectation', [
+            'body' => json_encode($expectation, JSON_THROW_ON_ERROR),
+        ]);
+    }
+
+    /**
+     * @param array{
+     *     method?: string,
+     *     path?: string,
+     * } $httpRequest
+     *
+     * @return list<array{
+     *     method: string,
+     *     path: string,
+     *     headers: array<string, string[]>,
+     * }>
+     */
+    public function fetchRecordedRequests(array $httpRequest): array
+    {
+        $response = $this->client->request('PUT', 'retrieve?type=REQUESTS', [
+            'body' => json_encode($httpRequest, JSON_THROW_ON_ERROR),
+        ]);
+
+        // @phpstan-ignore-next-line
+        return (array) json_decode($response->getContent(), true, 512, JSON_THROW_ON_ERROR);
+    }
+
+    /**
+     * @param array{
+     *     method?: string,
+     *     path?: string,
+     * } $httpRequest
+     */
+    public function hasRecordedRequest(array $httpRequest): bool
+    {
+        $records = $this->fetchRecordedRequests($httpRequest);
+        return count($records) > 0;
+    }
+}

--- a/libs/azure-api-client/tests/ReflectionPropertyAccessTestCase.php
+++ b/libs/azure-api-client/tests/ReflectionPropertyAccessTestCase.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Keboola\AzureApiClient\Tests;
+
+use ReflectionClass;
+use ReflectionException;
+use ReflectionProperty;
+
+trait ReflectionPropertyAccessTestCase
+{
+    protected static function setPrivatePropertyValue(object $object, string $property, mixed $value): void
+    {
+        $reflection = self::findPropertyOnClass(new ReflectionClass($object), $property);
+        $reflection->setAccessible(true);
+        $reflection->setValue($object, $value);
+        $reflection->setAccessible(false);
+    }
+
+    protected static function getPrivatePropertyValue(object $object, string $property): mixed
+    {
+        $reflection = self::findPropertyOnClass(new ReflectionClass($object), $property);
+        $reflection->setAccessible(true);
+        $value = $reflection->getValue($object);
+        $reflection->setAccessible(false);
+        return $value;
+    }
+
+    /**
+     * @param class-string $class
+     */
+    protected static function setPrivateStaticPropertyValue(string $class, string $property, mixed $value): void
+    {
+        $reflection = self::findPropertyOnClass(new ReflectionClass($class), $property);
+        $reflection->setAccessible(true);
+        $reflection->setValue($value);
+        $reflection->setAccessible(false);
+    }
+
+    /**
+     * @param class-string $class
+     */
+    protected static function getPrivateStaticPropertyValue(string $class, string $property): mixed
+    {
+        $reflection = self::findPropertyOnClass(new ReflectionClass($class), $property);
+        $reflection->setAccessible(true);
+        $value = $reflection->getValue();
+        $reflection->setAccessible(false);
+        return $value;
+    }
+
+    /**
+     * @param ReflectionClass<object> $class
+     */
+    private static function findPropertyOnClass(ReflectionClass $class, string $propertyName): ReflectionProperty
+    {
+        try {
+            return $class->getProperty($propertyName);
+        } catch (ReflectionException $e) {
+            $parent = $class->getParentClass();
+            if ($parent) {
+                return self::findPropertyOnClass($parent, $propertyName);
+            }
+
+            throw $e;
+        }
+    }
+}


### PR DESCRIPTION
https://keboola.atlassian.net/browse/MAR-17

* mapovani response na objekt presunute do base clienta
* par basic testu, ze se response spravne mapuji a ty API clienti posilaji zhruba ocekavane requesty

Jeste pripravuju ty infection testy, ale kdyz jsem zacal resit ty nepodchycene mutace, zavedlo me to zase na refactoring tech authenticatoru, tak to poslu jeste pozdeji zase jako separatni PR.