### PR TITLE
output-mapping - AbstractLoadTableTask - storageJobId is not nullable

### DIFF
--- a/libs/output-mapping/src/DeferredTasks/LoadTableTaskInterface.php
+++ b/libs/output-mapping/src/DeferredTasks/LoadTableTaskInterface.php
@@ -15,5 +15,5 @@ interface LoadTableTaskInterface
 
     public function getDestinationTableName(): string;
 
-    public function getStorageJobId(): ?string;
+    public function getStorageJobId(): string;
 }

--- a/libs/output-mapping/src/DeferredTasks/TableWriter/AbstractLoadTableTask.php
+++ b/libs/output-mapping/src/DeferredTasks/TableWriter/AbstractLoadTableTask.php
@@ -13,7 +13,7 @@ abstract class AbstractLoadTableTask implements LoadTableTaskInterface
 {
     protected MappingDestination $destination;
     protected array $options;
-    protected ?string $storageJobId;
+    protected string $storageJobId;
     /** @var MetadataInterface[] */
     protected array $metadata = [];
 
@@ -40,7 +40,7 @@ abstract class AbstractLoadTableTask implements LoadTableTaskInterface
         return $this->destination->getTableId();
     }
 
-    public function getStorageJobId(): ?string
+    public function getStorageJobId(): string
     {
         return $this->storageJobId;
     }


### PR DESCRIPTION
Fixes: https://keboola.atlassian.net/browse/PST-5

Používá se jenom tu https://github.com/keboola/platform-libraries/blob/dbf111be597cf91e27f067c8078400089f7b4baa/libs/output-mapping/src/DeferredTasks/LoadTableQueue.php#L60

V žádný apce jsem to nenašel. Když to nebude nastavené tak to prostě nově skončí app errorem.