### PR TITLE
add isFailed flag for FileWriter

### DIFF
--- a/libs/output-mapping/src/Writer/FileWriter.php
+++ b/libs/output-mapping/src/Writer/FileWriter.php
@@ -33,8 +33,8 @@ class FileWriter extends AbstractWriter
         array $configuration,
         array $systemMetadata,
         string $storage,
-        array $tableFiles = [],
-        bool $isFailedJob = false
+        array $tableFiles,
+        bool $isFailedJob
     ): void {
         if ($isFailedJob) {
             return;

--- a/libs/output-mapping/src/Writer/FileWriter.php
+++ b/libs/output-mapping/src/Writer/FileWriter.php
@@ -24,14 +24,21 @@ class FileWriter extends AbstractWriter
      * @param array $systemMetadata Metadata identifying the source of the file
      * @param string $storage Currently any storage that is not ABS workspaces defaults to local
      * @param array $tableFiles For the use file storage only case, tags etc are provided here
+     * @param bool $isFailedJob Marks that the writer was called as part of a failed job and only
+     *  write_always OM is to be processed. Since this flag is not currently implemented for files,
+     *  it means that no files will be uploaded.
      */
     public function uploadFiles(
         string $source,
         array $configuration,
         array $systemMetadata,
         string $storage,
-        array $tableFiles = []
+        array $tableFiles = [],
+        bool $isFailedJob = false
     ): void {
+        if ($isFailedJob) {
+            return;
+        }
         if (!empty($systemMetadata) && empty($systemMetadata[self::SYSTEM_KEY_COMPONENT_ID])) {
             throw new OutputOperationException('Component Id must be set');
         }

--- a/libs/output-mapping/src/Writer/TableWriter.php
+++ b/libs/output-mapping/src/Writer/TableWriter.php
@@ -72,8 +72,8 @@ class TableWriter extends AbstractWriter
         array $configuration,
         array $systemMetadata,
         string $stagingStorageOutput,
-        bool $createTypedTables = false,
-        bool $isFailedJob = false
+        bool $createTypedTables,
+        bool $isFailedJob
     ): LoadTableQueue {
         if (empty($systemMetadata[AbstractWriter::SYSTEM_KEY_COMPONENT_ID])) {
             throw new OutputOperationException('Component Id must be set');

--- a/libs/output-mapping/tests/Writer/BaseWriterMetadataTest.php
+++ b/libs/output-mapping/tests/Writer/BaseWriterMetadataTest.php
@@ -75,7 +75,9 @@ abstract class BaseWriterMetadataTest extends BaseWriterTest
             'upload',
             $config,
             ['componentId' => 'testComponent'],
-            AbstractStrategyFactory::LOCAL
+            AbstractStrategyFactory::LOCAL,
+            false,
+            false
         );
         $jobIds = $tableQueue->waitForAll();
         self::assertCount(1, $jobIds);
@@ -148,7 +150,9 @@ abstract class BaseWriterMetadataTest extends BaseWriterTest
             'upload',
             $config,
             ['componentId' => 'testComponent'],
-            AbstractStrategyFactory::LOCAL
+            AbstractStrategyFactory::LOCAL,
+            false,
+            false
         );
         $jobIds = $tableQueue->waitForAll();
         self::assertCount(1, $jobIds);
@@ -218,7 +222,9 @@ abstract class BaseWriterMetadataTest extends BaseWriterTest
             'upload',
             $config,
             ['componentId' => 'testComponent'],
-            AbstractStrategyFactory::LOCAL
+            AbstractStrategyFactory::LOCAL,
+            false,
+            false
         );
         $jobIds = $tableQueue->waitForAll();
         self::assertCount(1, $jobIds);
@@ -299,7 +305,9 @@ abstract class BaseWriterMetadataTest extends BaseWriterTest
             'upload',
             $config,
             ['componentId' => 'testComponent'],
-            AbstractStrategyFactory::LOCAL
+            AbstractStrategyFactory::LOCAL,
+            false,
+            false
         );
         $jobIds = $tableQueue->waitForAll();
         self::assertCount(1, $jobIds);

--- a/libs/output-mapping/tests/Writer/Redshift/RedshiftWriterWorkspaceTest.php
+++ b/libs/output-mapping/tests/Writer/Redshift/RedshiftWriterWorkspaceTest.php
@@ -69,7 +69,9 @@ class RedshiftWriterWorkspaceTest extends BaseWriterWorkspaceTest
             '/',
             ['mapping' => $configs],
             ['componentId' => 'foo'],
-            AbstractStrategyFactory::WORKSPACE_REDSHIFT
+            AbstractStrategyFactory::WORKSPACE_REDSHIFT,
+            false,
+            false
         );
         $jobIds = $tableQueue->waitForAll();
         self::assertCount(2, $jobIds);

--- a/libs/output-mapping/tests/Writer/Redshift/StorageApiLocalTableWriterRedshiftTest.php
+++ b/libs/output-mapping/tests/Writer/Redshift/StorageApiLocalTableWriterRedshiftTest.php
@@ -39,7 +39,14 @@ class StorageApiLocalTableWriterRedshiftTest extends BaseWriterTest
         );
 
         $writer = new TableWriter($this->getStagingFactory());
-        $tableQueue =  $writer->uploadTables('/upload', [], ['componentId' => 'foo'], 'local');
+        $tableQueue =  $writer->uploadTables(
+            '/upload',
+            [],
+            ['componentId' => 'foo'],
+            'local',
+            false,
+            false
+        );
         $jobIds = $tableQueue->waitForAll();
         self::assertCount(1, $jobIds);
 
@@ -83,7 +90,9 @@ class StorageApiLocalTableWriterRedshiftTest extends BaseWriterTest
             '/upload',
             ['mapping' => $configs],
             ['componentId' => 'foo'],
-            'local'
+            'local',
+            false,
+            false
         );
         $jobIds = $tableQueue->waitForAll();
         self::assertCount(1, $jobIds);
@@ -93,7 +102,9 @@ class StorageApiLocalTableWriterRedshiftTest extends BaseWriterTest
             '/upload',
             ['mapping' => $configs],
             ['componentId' => 'foo'],
-            'local'
+            'local',
+            false,
+            false
         );
         $jobIds = $tableQueue->waitForAll();
         self::assertCount(1, $jobIds);

--- a/libs/output-mapping/tests/Writer/Redshift/StorageApiSlicedWriterRedshiftTest.php
+++ b/libs/output-mapping/tests/Writer/Redshift/StorageApiSlicedWriterRedshiftTest.php
@@ -56,7 +56,9 @@ class StorageApiSlicedWriterRedshiftTest extends BaseWriterTest
             'upload',
             ['mapping' => $configs],
             ['componentId' => 'foo'],
-            AbstractStrategyFactory::LOCAL
+            AbstractStrategyFactory::LOCAL,
+            false,
+            false
         );
         $jobIds = $tableQueue->waitForAll();
         self::assertCount(1, $jobIds);
@@ -114,7 +116,9 @@ class StorageApiSlicedWriterRedshiftTest extends BaseWriterTest
             'upload',
             ['mapping' => $configs],
             ['componentId' => 'foo'],
-            AbstractStrategyFactory::LOCAL
+            AbstractStrategyFactory::LOCAL,
+            false,
+            false
         );
         $jobIds = $tableQueue->waitForAll();
         self::assertCount(1, $jobIds);
@@ -160,7 +164,9 @@ class StorageApiSlicedWriterRedshiftTest extends BaseWriterTest
             'upload',
             ['mapping' => $configs],
             ['componentId' => 'foo'],
-            AbstractStrategyFactory::LOCAL
+            AbstractStrategyFactory::LOCAL,
+            false,
+            false
         );
         $jobIds = $tableQueue->waitForAll();
         self::assertCount(1, $jobIds);
@@ -199,7 +205,9 @@ class StorageApiSlicedWriterRedshiftTest extends BaseWriterTest
             'upload',
             ['mapping' => $configs],
             ['componentId' => 'foo'],
-            AbstractStrategyFactory::LOCAL
+            AbstractStrategyFactory::LOCAL,
+            false,
+            false
         );
         $jobIds = $tableQueue->waitForAll();
         self::assertCount(1, $jobIds);
@@ -233,7 +241,9 @@ class StorageApiSlicedWriterRedshiftTest extends BaseWriterTest
             'upload',
             ['mapping' => $configs],
             ['componentId' => 'foo'],
-            AbstractStrategyFactory::LOCAL
+            AbstractStrategyFactory::LOCAL,
+            false,
+            false
         );
         $jobIds = $tableQueue->waitForAll();
         self::assertCount(1, $jobIds);
@@ -272,7 +282,9 @@ class StorageApiSlicedWriterRedshiftTest extends BaseWriterTest
             'upload',
             ['mapping' => $configs],
             ['componentId' => 'foo'],
-            AbstractStrategyFactory::LOCAL
+            AbstractStrategyFactory::LOCAL,
+            false,
+            false
         );
         $jobIds = $tableQueue->waitForAll();
         self::assertCount(1, $jobIds);
@@ -307,7 +319,9 @@ class StorageApiSlicedWriterRedshiftTest extends BaseWriterTest
             'upload',
             ['mapping' => $configs],
             ['componentId' => 'foo'],
-            AbstractStrategyFactory::LOCAL
+            AbstractStrategyFactory::LOCAL,
+            false,
+            false
         );
     }
 
@@ -341,7 +355,9 @@ class StorageApiSlicedWriterRedshiftTest extends BaseWriterTest
             'upload',
             ['mapping' => $configs],
             ['componentId' => 'foo'],
-            AbstractStrategyFactory::LOCAL
+            AbstractStrategyFactory::LOCAL,
+            false,
+            false
         );
         $jobIds = $tableQueue->waitForAll();
         self::assertCount(1, $jobIds);
@@ -384,7 +400,9 @@ class StorageApiSlicedWriterRedshiftTest extends BaseWriterTest
             'upload',
             ['mapping' => $configs],
             ['componentId' => 'foo'],
-            AbstractStrategyFactory::LOCAL
+            AbstractStrategyFactory::LOCAL,
+            false,
+            false
         );
         $jobIds = $tableQueue->waitForAll();
         self::assertCount(1, $jobIds);
@@ -430,7 +448,9 @@ class StorageApiSlicedWriterRedshiftTest extends BaseWriterTest
             'upload',
             ['mapping' => $configs],
             ['componentId' => 'foo'],
-            AbstractStrategyFactory::LOCAL
+            AbstractStrategyFactory::LOCAL,
+            false,
+            false
         );
         $jobIds = $tableQueue->waitForAll();
         self::assertCount(2, $jobIds);
@@ -483,7 +503,9 @@ class StorageApiSlicedWriterRedshiftTest extends BaseWriterTest
             'upload',
             ['mapping' => $configs],
             ['componentId' => 'foo'],
-            AbstractStrategyFactory::LOCAL
+            AbstractStrategyFactory::LOCAL,
+            false,
+            false
         );
         $jobIds = $tableQueue->waitForAll();
         self::assertCount(1, $jobIds);

--- a/libs/output-mapping/tests/Writer/SnowflakeWriterMetadataTest.php
+++ b/libs/output-mapping/tests/Writer/SnowflakeWriterMetadataTest.php
@@ -81,7 +81,9 @@ class SnowflakeWriterMetadataTest extends BaseWriterMetadataTest
             'upload',
             $config,
             $systemMetadata,
-            AbstractStrategyFactory::LOCAL
+            AbstractStrategyFactory::LOCAL,
+            false,
+            false
         );
         $jobIds = $tableQueue->waitForAll();
         self::assertCount(1, $jobIds);
@@ -114,7 +116,14 @@ class SnowflakeWriterMetadataTest extends BaseWriterMetadataTest
         self::assertEquals($expectedColumnMetadata, $this->getMetadataValues($idColMetadata));
 
         // check metadata update
-        $tableQueue =  $writer->uploadTables('upload', $config, $systemMetadata, 'local');
+        $tableQueue =  $writer->uploadTables(
+            'upload',
+            $config,
+            $systemMetadata,
+            'local',
+            false,
+            false
+        );
         $jobIds = $tableQueue->waitForAll();
         self::assertCount(1, $jobIds);
 
@@ -154,7 +163,9 @@ class SnowflakeWriterMetadataTest extends BaseWriterMetadataTest
             'upload',
             $config,
             $systemMetadata,
-            AbstractStrategyFactory::LOCAL
+            AbstractStrategyFactory::LOCAL,
+            false,
+            false
         );
         $this->expectException(InvalidOutputException::class);
         $this->expectExceptionMessage('Failed to load table ' . self::INPUT_BUCKET . '".table55a": Load error: ' .
@@ -219,7 +230,9 @@ class SnowflakeWriterMetadataTest extends BaseWriterMetadataTest
             '/upload',
             $config,
             $systemMetadata,
-            AbstractStrategyFactory::LOCAL
+            AbstractStrategyFactory::LOCAL,
+            false,
+            false
         );
         $jobIds = $tableQueue->waitForAll();
         self::assertCount(1, $jobIds);
@@ -253,7 +266,14 @@ class SnowflakeWriterMetadataTest extends BaseWriterMetadataTest
         self::assertEquals($expectedColumnMetadata, $this->getMetadataValues($idColMetadata));
 
         // check metadata update
-        $tableQueue =  $writer->uploadTables('/upload', $config, $systemMetadata, 'local');
+        $tableQueue =  $writer->uploadTables(
+            '/upload',
+            $config,
+            $systemMetadata,
+            'local',
+            false,
+            false
+        );
         $jobIds = $tableQueue->waitForAll();
         self::assertCount(1, $jobIds);
 

--- a/libs/output-mapping/tests/Writer/StorageApiFileWriterTest.php
+++ b/libs/output-mapping/tests/Writer/StorageApiFileWriterTest.php
@@ -114,6 +114,45 @@ class StorageApiFileWriterTest extends BaseWriterTest
         self::assertTrue($file3['isPublic']);
     }
 
+    public function testWriteFilesFailedJob(): void
+    {
+        $root = $this->tmp->getTmpFolder();
+        file_put_contents($root . '/upload/file1', 'test');
+
+        $systemMetadata = [
+            'componentId' => 'testComponent',
+            'configurationId' => 'metadata-write-test',
+            'configurationRowId' => '12345',
+            'branchId' => '1234',
+            'runId' => '999',
+        ];
+
+        $configs = [
+            [
+                'source' => 'file1',
+                'tags' => [self::FILE_TAG],
+            ],
+        ];
+
+        $writer = new FileWriter($this->getStagingFactory());
+
+        $writer->uploadFiles(
+            '/upload',
+            ['mapping' => $configs],
+            $systemMetadata,
+            AbstractStrategyFactory::LOCAL,
+            [],
+            true
+        );
+        sleep(1);
+
+        $options = new ListFilesOptions();
+        $options->setTags([self::FILE_TAG]);
+        $files = $this->clientWrapper->getBasicClient()->listFiles($options);
+        // no files should be uploaded since, isFailedJob was true and write_always is not implemented for files
+        self::assertCount(0, $files);
+    }
+
     public function testWriteFilesOutputMapping(): void
     {
         $root = $this->tmp->getTmpFolder();

--- a/libs/output-mapping/tests/Writer/StorageApiFileWriterTest.php
+++ b/libs/output-mapping/tests/Writer/StorageApiFileWriterTest.php
@@ -70,7 +70,9 @@ class StorageApiFileWriterTest extends BaseWriterTest
             '/upload',
             ['mapping' => $configs],
             $systemMetadata,
-            AbstractStrategyFactory::LOCAL
+            AbstractStrategyFactory::LOCAL,
+            [],
+            false
         );
         sleep(1);
 
@@ -167,7 +169,14 @@ class StorageApiFileWriterTest extends BaseWriterTest
 
         $writer = new FileWriter($this->getStagingFactory());
 
-        $writer->uploadFiles('/upload', ['mapping' => $configs], [], AbstractStrategyFactory::LOCAL);
+        $writer->uploadFiles(
+            '/upload',
+            ['mapping' => $configs],
+            [],
+            AbstractStrategyFactory::LOCAL,
+            [],
+            false
+        );
         sleep(1);
 
         $options = new ListFilesOptions();
@@ -227,7 +236,14 @@ class StorageApiFileWriterTest extends BaseWriterTest
             'runId' => '999',
         ];
 
-        $writer->uploadFiles('/upload', ['mapping' => $configs], $systemMetadata, AbstractStrategyFactory::LOCAL);
+        $writer->uploadFiles(
+            '/upload',
+            ['mapping' => $configs],
+            $systemMetadata,
+            AbstractStrategyFactory::LOCAL,
+            [],
+            false
+        );
         sleep(1);
 
         $options = new ListFilesOptions();
@@ -278,7 +294,9 @@ class StorageApiFileWriterTest extends BaseWriterTest
             'upload',
             ['mapping' => $configs],
             ['componentId' => 'foo'],
-            AbstractStrategyFactory::LOCAL
+            AbstractStrategyFactory::LOCAL,
+            [],
+            false
         );
         sleep(1);
 
@@ -318,7 +336,14 @@ class StorageApiFileWriterTest extends BaseWriterTest
         $writer->setFormat('json');
         $this->expectException(InvalidOutputException::class);
         $this->expectExceptionMessage('json');
-        $writer->uploadFiles('/upload', ['mapping' => $configs], [], AbstractStrategyFactory::LOCAL);
+        $writer->uploadFiles(
+            '/upload',
+            ['mapping' => $configs],
+            [],
+            AbstractStrategyFactory::LOCAL,
+            [],
+            false
+        );
     }
 
     public function testWriteFilesInvalidYaml(): void
@@ -339,7 +364,14 @@ class StorageApiFileWriterTest extends BaseWriterTest
         $writer->setFormat('json');
         $this->expectException(InvalidOutputException::class);
         $this->expectExceptionMessage('json');
-        $writer->uploadFiles('upload', ['mapping' => $configs], [], AbstractStrategyFactory::LOCAL);
+        $writer->uploadFiles(
+            'upload',
+            ['mapping' => $configs],
+            [],
+            AbstractStrategyFactory::LOCAL,
+            [],
+            false
+        );
     }
 
     public function testWriteFilesOutputMappingMissing(): void
@@ -362,7 +394,14 @@ class StorageApiFileWriterTest extends BaseWriterTest
         $this->expectException(InvalidOutputException::class);
         $this->expectExceptionMessage("File 'file2' not found");
         $this->expectExceptionCode(404);
-        $writer->uploadFiles('upload', ['mapping' => $configs], [], AbstractStrategyFactory::LOCAL);
+        $writer->uploadFiles(
+            'upload',
+            ['mapping' => $configs],
+            [],
+            AbstractStrategyFactory::LOCAL,
+            [],
+            false
+        );
     }
 
     public function testWriteFilesOrphanedManifest(): void
@@ -375,7 +414,14 @@ class StorageApiFileWriterTest extends BaseWriterTest
         $writer = new FileWriter($this->getStagingFactory());
         $this->expectException(InvalidOutputException::class);
         $this->expectExceptionMessage("Found orphaned file manifest: 'file1.manifest'");
-        $writer->uploadFiles('/upload', [], [], AbstractStrategyFactory::LOCAL);
+        $writer->uploadFiles(
+            '/upload',
+            [],
+            [],
+            AbstractStrategyFactory::LOCAL,
+            [],
+            false
+        );
     }
 
     public function testWriteFilesNoComponentId(): void
@@ -383,7 +429,14 @@ class StorageApiFileWriterTest extends BaseWriterTest
         $writer = new FileWriter($this->getStagingFactory());
         $this->expectException(OutputOperationException::class);
         $this->expectExceptionMessage('Component Id must be set');
-        $writer->uploadFiles('/upload', [], ['configurationId' => '123'], AbstractStrategyFactory::LOCAL);
+        $writer->uploadFiles(
+            '/upload',
+            [],
+            ['configurationId' => '123'],
+            AbstractStrategyFactory::LOCAL,
+            [],
+            false
+        );
     }
 
     public function testTagProcessedFiles(): void
@@ -468,7 +521,8 @@ class StorageApiFileWriterTest extends BaseWriterTest
             [],
             $systemMetadata,
             AbstractStrategyFactory::LOCAL,
-            $tableFiles
+            $tableFiles,
+            false
         );
         sleep(1);
 

--- a/libs/output-mapping/tests/Writer/StorageApiHeadlessWriterTest.php
+++ b/libs/output-mapping/tests/Writer/StorageApiHeadlessWriterTest.php
@@ -40,7 +40,9 @@ class StorageApiHeadlessWriterTest extends BaseWriterTest
             'upload',
             ['mapping' => $configs],
             ['componentId' => 'foo'],
-            AbstractStrategyFactory::LOCAL
+            AbstractStrategyFactory::LOCAL,
+            false,
+            false
         );
         $jobIds = $tableQueue->waitForAll();
         self::assertCount(1, $jobIds);
@@ -78,7 +80,9 @@ class StorageApiHeadlessWriterTest extends BaseWriterTest
             'upload',
             ['mapping' => $configs],
             ['componentId' => 'foo'],
-            AbstractStrategyFactory::LOCAL
+            AbstractStrategyFactory::LOCAL,
+            false,
+            false
         );
         $jobIds = $tableQueue->waitForAll();
         self::assertCount(1, $jobIds);
@@ -118,7 +122,9 @@ class StorageApiHeadlessWriterTest extends BaseWriterTest
             'upload',
             ['mapping' => $configs],
             ['componentId' => 'foo'],
-            AbstractStrategyFactory::LOCAL
+            AbstractStrategyFactory::LOCAL,
+            false,
+            false
         );
         $jobIds = $tableQueue->waitForAll();
         self::assertCount(1, $jobIds);
@@ -154,7 +160,9 @@ class StorageApiHeadlessWriterTest extends BaseWriterTest
             'upload',
             [],
             ['componentId' => 'foo'],
-            AbstractStrategyFactory::LOCAL
+            AbstractStrategyFactory::LOCAL,
+            false,
+            false
         );
         $jobIds = $tableQueue->waitForAll();
         self::assertCount(1, $jobIds);
@@ -200,7 +208,9 @@ class StorageApiHeadlessWriterTest extends BaseWriterTest
             'upload',
             ['mapping' => $configs],
             ['componentId' => 'foo'],
-            AbstractStrategyFactory::LOCAL
+            AbstractStrategyFactory::LOCAL,
+            false,
+            false
         );
         $jobIds = $tableQueue->waitForAll();
         self::assertCount(1, $jobIds);

--- a/libs/output-mapping/tests/Writer/StorageApiLocalTableWriterTest.php
+++ b/libs/output-mapping/tests/Writer/StorageApiLocalTableWriterTest.php
@@ -62,7 +62,9 @@ class StorageApiLocalTableWriterTest extends BaseWriterTest
             'upload',
             ['mapping' => $configs],
             ['componentId' => 'foo'],
-            'local'
+            'local',
+            false,
+            false
         );
         $jobIds = $tableQueue->waitForAll();
         self::assertCount(2, $jobIds);
@@ -141,7 +143,9 @@ class StorageApiLocalTableWriterTest extends BaseWriterTest
             'upload',
             ['mapping' => $configs],
             ['componentId' => 'foo'],
-            'local'
+            'local',
+            false,
+            false
         );
         $jobIds = $tableQueue->waitForAll();
         self::assertCount(2, $jobIds);
@@ -207,7 +211,9 @@ class StorageApiLocalTableWriterTest extends BaseWriterTest
             '/upload',
             ['mapping' => $configs],
             ['componentId' => 'foo', 'branchId' => $branchId],
-            'local'
+            'local',
+            false,
+            false
         );
         $jobIds = $tableQueue->waitForAll();
         self::assertCount(2, $jobIds);
@@ -249,7 +255,9 @@ class StorageApiLocalTableWriterTest extends BaseWriterTest
             '/upload',
             ['mapping' => $configs],
             ['componentId' => 'foo'],
-            'local'
+            'local',
+            false,
+            false
         );
         $jobIds = $tableQueue->waitForAll();
         self::assertCount(1, $jobIds);
@@ -259,7 +267,9 @@ class StorageApiLocalTableWriterTest extends BaseWriterTest
             '/upload',
             ['mapping' => $configs],
             ['componentId' => 'foo'],
-            'local'
+            'local',
+            false,
+            false
         );
         $jobIds = $tableQueue->waitForAll();
         self::assertCount(1, $jobIds);
@@ -291,7 +301,9 @@ class StorageApiLocalTableWriterTest extends BaseWriterTest
             '/upload',
             ['mapping' => $configs],
             ['componentId' => 'foo'],
-            'local'
+            'local',
+            false,
+            false
         );
         $jobIds = $tableQueue->waitForAll();
         self::assertCount(1, $jobIds);
@@ -318,7 +330,9 @@ class StorageApiLocalTableWriterTest extends BaseWriterTest
             '/upload',
             ['mapping' => $configs],
             ['componentId' => 'foo'],
-            'local'
+            'local',
+            false,
+            false
         );
 
         $this->expectException(InvalidOutputException::class);
@@ -353,7 +367,9 @@ class StorageApiLocalTableWriterTest extends BaseWriterTest
             '/upload',
             ['mapping' => $configs],
             ['componentId' => 'foo'],
-            'local'
+            'local',
+            false,
+            false
         );
         $jobIds = $tableQueue->waitForAll();
         self::assertCount(1, $jobIds);
@@ -379,7 +395,14 @@ class StorageApiLocalTableWriterTest extends BaseWriterTest
         $writer = new TableWriter($this->getStagingFactory());
         $this->expectException(InvalidOutputException::class);
         $this->expectExceptionMessage('Invalid type for path');
-        $writer->uploadTables('/upload', [], ['componentId' => 'foo'], 'local');
+        $writer->uploadTables(
+            '/upload',
+            [],
+            ['componentId' => 'foo'],
+            'local',
+            false,
+            false
+        );
     }
 
     public function testWriteTableManifestCsvDefaultBackend(): void
@@ -396,7 +419,14 @@ class StorageApiLocalTableWriterTest extends BaseWriterTest
 
         $writer = new TableWriter($this->getStagingFactory());
 
-        $tableQueue =  $writer->uploadTables('/upload', [], ['componentId' => 'foo'], 'local');
+        $tableQueue =  $writer->uploadTables(
+            '/upload',
+            [],
+            ['componentId' => 'foo'],
+            'local',
+            false,
+            false
+        );
         $jobIds = $tableQueue->waitForAll();
         self::assertCount(1, $jobIds);
 
@@ -425,7 +455,14 @@ class StorageApiLocalTableWriterTest extends BaseWriterTest
         $writer = new TableWriter($this->getStagingFactory());
         $this->expectException(InvalidOutputException::class);
         $this->expectExceptionMessage('Found orphaned table manifest: "table.csv.manifest"');
-        $writer->uploadTables('/upload', [], ['componentId' => 'foo'], 'local');
+        $writer->uploadTables(
+            '/upload',
+            [],
+            ['componentId' => 'foo'],
+            'local',
+            false,
+            false
+        );
     }
 
     public function testWriteTableOutputMappingMissing(): void
@@ -443,7 +480,9 @@ class StorageApiLocalTableWriterTest extends BaseWriterTest
             '/upload',
             ['mapping' => $configs],
             ['componentId' => 'foo'],
-            'local'
+            'local',
+            false,
+            false
         );
     }
 
@@ -452,7 +491,14 @@ class StorageApiLocalTableWriterTest extends BaseWriterTest
         $writer = new TableWriter($this->getStagingFactory());
         $this->expectException(OutputOperationException::class);
         $this->expectExceptionMessage('Component Id must be set');
-        $writer->uploadTables('/upload', [], [], 'local');
+        $writer->uploadTables(
+            '/upload',
+            [],
+            [],
+            'local',
+            false,
+            false
+        );
     }
 
     public function testWriteTableIncrementalWithDeleteDefault(): void
@@ -480,7 +526,9 @@ class StorageApiLocalTableWriterTest extends BaseWriterTest
             '/upload',
             ['mapping' => $configs],
             ['componentId' => 'foo'],
-            'local'
+            'local',
+            false,
+            false
         );
         $jobIds = $tableQueue->waitForAll();
         self::assertCount(1, $jobIds);
@@ -491,7 +539,9 @@ class StorageApiLocalTableWriterTest extends BaseWriterTest
             '/upload',
             ['mapping' => $configs],
             ['componentId' => 'foo'],
-            'local'
+            'local',
+            false,
+            false
         );
         $jobIds = $tableQueue->waitForAll();
         self::assertCount(1, $jobIds);
@@ -533,7 +583,9 @@ class StorageApiLocalTableWriterTest extends BaseWriterTest
             '/upload',
             ['bucket' => self::OUTPUT_BUCKET],
             ['componentId' => 'foo'],
-            'local'
+            'local',
+            false,
+            false
         );
         $jobIds = $tableQueue->waitForAll();
         self::assertCount(1, $jobIds);
@@ -559,7 +611,9 @@ class StorageApiLocalTableWriterTest extends BaseWriterTest
             '/upload',
             ['bucket' => self::OUTPUT_BUCKET],
             ['componentId' => 'foo'],
-            'local'
+            'local',
+            false,
+            false
         );
         $jobIds = $tableQueue->waitForAll();
         self::assertCount(1, $jobIds);
@@ -588,7 +642,9 @@ class StorageApiLocalTableWriterTest extends BaseWriterTest
                 ],
             ],
             ['componentId' => 'foo'],
-            'local'
+            'local',
+            false,
+            false
         );
         $jobIds = $tableQueue->waitForAll();
         self::assertCount(1, $jobIds);
@@ -614,7 +670,9 @@ class StorageApiLocalTableWriterTest extends BaseWriterTest
                 ],
             ],
             ['componentId' => 'foo'],
-            'local'
+            'local',
+            false,
+            false
         );
         $tableQueue->waitForAll();
 
@@ -631,7 +689,9 @@ class StorageApiLocalTableWriterTest extends BaseWriterTest
                 ],
             ],
             ['componentId' => 'foo'],
-            'local'
+            'local',
+            false,
+            false
         );
         $jobIds = $tableQueue->waitForAll();
         self::assertCount(1, $jobIds);
@@ -659,7 +719,9 @@ class StorageApiLocalTableWriterTest extends BaseWriterTest
                 ],
             ],
             ['componentId' => 'foo'],
-            'local'
+            'local',
+            false,
+            false
         );
         $tableQueue->waitForAll();
         $tableInfo = $this->clientWrapper->getBasicClient()->getTable(self::OUTPUT_BUCKET . '.table12');
@@ -678,7 +740,9 @@ class StorageApiLocalTableWriterTest extends BaseWriterTest
                 ],
             ],
             ['componentId' => 'foo'],
-            'local'
+            'local',
+            false,
+            false
         );
         $jobIds = $tableQueue->waitForAll();
         self::assertCount(1, $jobIds);
@@ -707,7 +771,9 @@ class StorageApiLocalTableWriterTest extends BaseWriterTest
                 ],
             ],
             ['componentId' => 'foo'],
-            'local'
+            'local',
+            false,
+            false
         );
         $jobIds = $tableQueue->waitForAll();
         self::assertCount(1, $jobIds);
@@ -717,7 +783,14 @@ class StorageApiLocalTableWriterTest extends BaseWriterTest
             $root . '/upload/table11.csv.manifest',
             '{"destination": "' . self::OUTPUT_BUCKET . '.table11","primary_key": [""]}'
         );
-        $tableQueue =  $writer->uploadTables('upload', [], ['componentId' => 'foo'], 'local');
+        $tableQueue =  $writer->uploadTables(
+            'upload',
+            [],
+            ['componentId' => 'foo'],
+            'local',
+            false,
+            false
+        );
         $jobIds = $tableQueue->waitForAll();
         self::assertCount(1, $jobIds);
         self::assertFalse(
@@ -750,7 +823,9 @@ class StorageApiLocalTableWriterTest extends BaseWriterTest
             'upload',
             $configuration,
             ['componentId' => 'foo'],
-            'local'
+            'local',
+            false,
+            false
         );
         $tableQueue->waitForAll();
 
@@ -779,7 +854,9 @@ class StorageApiLocalTableWriterTest extends BaseWriterTest
             'upload',
             $configuration,
             ['componentId' => 'foo'],
-            'local'
+            'local',
+            false,
+            false
         );
 
         $this->expectException(InvalidOutputException::class);
@@ -818,7 +895,9 @@ class StorageApiLocalTableWriterTest extends BaseWriterTest
             'upload',
             $configuration,
             ['componentId' => 'foo'],
-            'local'
+            'local',
+            false,
+            false
         );
         $tableQueue->waitForAll();
 
@@ -848,7 +927,9 @@ class StorageApiLocalTableWriterTest extends BaseWriterTest
             'upload',
             $configuration,
             ['componentId' => 'foo'],
-            'local'
+            'local',
+            false,
+            false
         );
         try {
             $tableQueue->waitForAll();
@@ -905,7 +986,9 @@ class StorageApiLocalTableWriterTest extends BaseWriterTest
             '/upload',
             ['mapping' => $configs],
             ['componentId' => 'foo', 'branchId' => $branchId],
-            AbstractStrategyFactory::LOCAL
+            AbstractStrategyFactory::LOCAL,
+            false,
+            false
         );
         $jobIds = $tableQueue->waitForAll();
         self::assertCount(1, $jobIds);
@@ -932,7 +1015,9 @@ class StorageApiLocalTableWriterTest extends BaseWriterTest
             '/upload',
             ['mapping' => $configs],
             ['componentId' => 'foo'],
-            AbstractStrategyFactory::LOCAL
+            AbstractStrategyFactory::LOCAL,
+            false,
+            false
         );
     }
 
@@ -972,7 +1057,9 @@ class StorageApiLocalTableWriterTest extends BaseWriterTest
             '/upload',
             ['mapping' => $configs],
             ['componentId' => 'foo', 'branchId' => $branchId],
-            AbstractStrategyFactory::LOCAL
+            AbstractStrategyFactory::LOCAL,
+            false,
+            false
         );
         $jobIds = $tableQueue->waitForAll();
         self::assertCount(1, $jobIds);
@@ -1009,7 +1096,9 @@ class StorageApiLocalTableWriterTest extends BaseWriterTest
             '/upload',
             ['mapping' => $configs],
             ['componentId' => 'foo'],
-            AbstractStrategyFactory::LOCAL
+            AbstractStrategyFactory::LOCAL,
+            false,
+            false
         );
     }
 
@@ -1147,7 +1236,9 @@ class StorageApiLocalTableWriterTest extends BaseWriterTest
             'upload',
             ['bucket' => $defaultBucket, 'mapping' => $mapping],
             ['componentId' => 'foo'],
-            'local'
+            'local',
+            false,
+            false
         );
         $tableQueue->waitForAll();
     }
@@ -1207,7 +1298,9 @@ class StorageApiLocalTableWriterTest extends BaseWriterTest
             '/upload',
             ['bucket' => $defaultBucket],
             ['componentId' => 'foo'],
-            'local'
+            'local',
+            false,
+            false
         );
         $jobIds = $tableQueue->waitForAll();
         self::assertCount(1, $jobIds);
@@ -1268,7 +1361,9 @@ class StorageApiLocalTableWriterTest extends BaseWriterTest
             '/upload',
             ['bucket' => $defaultBucket],
             ['componentId' => 'foo'],
-            'local'
+            'local',
+            false,
+            false
         );
     }
 
@@ -1290,7 +1385,14 @@ class StorageApiLocalTableWriterTest extends BaseWriterTest
         $this->expectException(OutputOperationException::class);
         $this->expectExceptionMessage('Component Id must be set');
 
-        $tableWriter->uploadTables('upload', [], [], 'local');
+        $tableWriter->uploadTables(
+            'upload',
+            [],
+            [],
+            'local',
+            false,
+            false
+        );
     }
 
     public function testLocalTableUploadChecksForOrphanedManifests(): void
@@ -1303,7 +1405,14 @@ class StorageApiLocalTableWriterTest extends BaseWriterTest
         $this->expectException(InvalidOutputException::class);
         $this->expectExceptionMessage('Found orphaned table manifest: "table.csv.manifest"');
 
-        $tableWriter->uploadTables('upload', [], ['componentId' => 'foo'], 'local');
+        $tableWriter->uploadTables(
+            'upload',
+            [],
+            ['componentId' => 'foo'],
+            'local',
+            false,
+            false
+        );
     }
 
     public function testLocalTableUploadChecksForUnusedMappingEntries(): void
@@ -1313,14 +1422,21 @@ class StorageApiLocalTableWriterTest extends BaseWriterTest
         $this->expectException(InvalidOutputException::class);
         $this->expectExceptionMessage('Table sources not found: "unknown.csv"');
 
-        $tableWriter->uploadTables('upload', [
-            'mapping' => [
-                [
-                    'source' => 'unknown.csv',
-                    'destination' => 'unknown',
+        $tableWriter->uploadTables(
+            'upload',
+            [
+                'mapping' => [
+                    [
+                        'source' => 'unknown.csv',
+                        'destination' => 'unknown',
+                    ],
                 ],
             ],
-        ], ['componentId' => 'foo'], 'local');
+            ['componentId' => 'foo'],
+            'local',
+            false,
+            false
+        );
     }
 
     public function testLocalTableUploadChecksForWriteAlwaysMappingEntries(): void
@@ -1403,7 +1519,9 @@ class StorageApiLocalTableWriterTest extends BaseWriterTest
                 ],
             ],
             ['componentId' => 'foo'],
-            'local'
+            'local',
+            false,
+            false
         );
         $jobIds = $tableQueue->waitForAll();
         $this->assertCount(1, $jobIds);
@@ -1422,7 +1540,9 @@ class StorageApiLocalTableWriterTest extends BaseWriterTest
                 ],
             ],
             ['componentId' => 'foo'],
-            'local'
+            'local',
+            false,
+            false
         );
 
         $jobIds = $tableQueue->waitForAll();
@@ -1448,7 +1568,9 @@ class StorageApiLocalTableWriterTest extends BaseWriterTest
                 ],
             ],
             ['componentId' => 'foo'],
-            'local'
+            'local',
+            false,
+            false
         );
         $jobIds = $tableQueue->waitForAll();
         $this->assertCount(1, $jobIds);
@@ -1467,7 +1589,9 @@ class StorageApiLocalTableWriterTest extends BaseWriterTest
                 ],
             ],
             ['componentId' => 'foo'],
-            'local'
+            'local',
+            false,
+            false
         );
         $jobIds = $tableQueue->waitForAll();
         $this->assertCount(1, $jobIds);

--- a/libs/output-mapping/tests/Writer/StorageApiSlicedWriterTest.php
+++ b/libs/output-mapping/tests/Writer/StorageApiSlicedWriterTest.php
@@ -55,7 +55,9 @@ class StorageApiSlicedWriterTest extends BaseWriterTest
             'upload',
             ['mapping' => $configs],
             ['componentId' => 'foo'],
-            AbstractStrategyFactory::LOCAL
+            AbstractStrategyFactory::LOCAL,
+            false,
+            false
         );
         $jobIds = $tableQueue->waitForAll();
         self::assertCount(1, $jobIds);
@@ -113,7 +115,9 @@ class StorageApiSlicedWriterTest extends BaseWriterTest
             'upload',
             ['mapping' => $configs],
             ['componentId' => 'foo'],
-            AbstractStrategyFactory::LOCAL
+            AbstractStrategyFactory::LOCAL,
+            false,
+            false
         );
         $jobIds = $tableQueue->waitForAll();
         self::assertCount(1, $jobIds);
@@ -159,7 +163,9 @@ class StorageApiSlicedWriterTest extends BaseWriterTest
             'upload',
             ['mapping' => $configs],
             ['componentId' => 'foo'],
-            AbstractStrategyFactory::LOCAL
+            AbstractStrategyFactory::LOCAL,
+            false,
+            false
         );
         $jobIds = $tableQueue->waitForAll();
         self::assertCount(1, $jobIds);
@@ -198,7 +204,9 @@ class StorageApiSlicedWriterTest extends BaseWriterTest
             'upload',
             ['mapping' => $configs],
             ['componentId' => 'foo'],
-            AbstractStrategyFactory::LOCAL
+            AbstractStrategyFactory::LOCAL,
+            false,
+            false
         );
         $jobIds = $tableQueue->waitForAll();
         self::assertCount(1, $jobIds);
@@ -232,7 +240,9 @@ class StorageApiSlicedWriterTest extends BaseWriterTest
             'upload',
             ['mapping' => $configs],
             ['componentId' => 'foo'],
-            AbstractStrategyFactory::LOCAL
+            AbstractStrategyFactory::LOCAL,
+            false,
+            false
         );
         $jobIds = $tableQueue->waitForAll();
         self::assertCount(1, $jobIds);
@@ -271,7 +281,9 @@ class StorageApiSlicedWriterTest extends BaseWriterTest
             'upload',
             ['mapping' => $configs],
             ['componentId' => 'foo'],
-            AbstractStrategyFactory::LOCAL
+            AbstractStrategyFactory::LOCAL,
+            false,
+            false
         );
         $jobIds = $tableQueue->waitForAll();
         self::assertCount(1, $jobIds);
@@ -306,7 +318,9 @@ class StorageApiSlicedWriterTest extends BaseWriterTest
             'upload',
             ['mapping' => $configs],
             ['componentId' => 'foo'],
-            AbstractStrategyFactory::LOCAL
+            AbstractStrategyFactory::LOCAL,
+            false,
+            false
         );
     }
 
@@ -340,7 +354,9 @@ class StorageApiSlicedWriterTest extends BaseWriterTest
             'upload',
             ['mapping' => $configs],
             ['componentId' => 'foo'],
-            AbstractStrategyFactory::LOCAL
+            AbstractStrategyFactory::LOCAL,
+            false,
+            false
         );
         $jobIds = $tableQueue->waitForAll();
         self::assertCount(1, $jobIds);
@@ -383,7 +399,9 @@ class StorageApiSlicedWriterTest extends BaseWriterTest
             'upload',
             ['mapping' => $configs],
             ['componentId' => 'foo'],
-            AbstractStrategyFactory::LOCAL
+            AbstractStrategyFactory::LOCAL,
+            false,
+            false
         );
         $jobIds = $tableQueue->waitForAll();
         self::assertCount(1, $jobIds);
@@ -429,7 +447,9 @@ class StorageApiSlicedWriterTest extends BaseWriterTest
             'upload',
             ['mapping' => $configs],
             ['componentId' => 'foo'],
-            AbstractStrategyFactory::LOCAL
+            AbstractStrategyFactory::LOCAL,
+            false,
+            false
         );
         $jobIds = $tableQueue->waitForAll();
         self::assertCount(2, $jobIds);
@@ -482,7 +502,9 @@ class StorageApiSlicedWriterTest extends BaseWriterTest
             'upload',
             ['mapping' => $configs],
             ['componentId' => 'foo'],
-            AbstractStrategyFactory::LOCAL
+            AbstractStrategyFactory::LOCAL,
+            false,
+            false
         );
         $jobIds = $tableQueue->waitForAll();
         self::assertCount(1, $jobIds);

--- a/libs/output-mapping/tests/Writer/TableDefinitionTest.php
+++ b/libs/output-mapping/tests/Writer/TableDefinitionTest.php
@@ -68,7 +68,8 @@ class TableDefinitionTest extends BaseWriterTest
             ],
             ['componentId' => 'foo'],
             'local',
-            true
+            true,
+            false
         );
         $jobIds = $tableQueue->waitForAll();
         self::assertCount(1, $jobIds);
@@ -109,7 +110,8 @@ class TableDefinitionTest extends BaseWriterTest
             ],
             ['componentId' => 'foo'],
             'local',
-            true
+            true,
+            false
         );
     }
 
@@ -140,7 +142,8 @@ class TableDefinitionTest extends BaseWriterTest
             ],
             ['componentId' => 'foo'],
             'local',
-            true
+            true,
+            false
         );
         $jobIds = $tableQueue->waitForAll();
         self::assertCount(1, $jobIds);
@@ -314,7 +317,8 @@ class TableDefinitionTest extends BaseWriterTest
             ],
             ['componentId' => 'foo'],
             'local',
-            true
+            true,
+            false
         );
         $jobIds = $tableQueue->waitForAll();
         self::assertCount(1, $jobIds);
@@ -446,7 +450,8 @@ class TableDefinitionTest extends BaseWriterTest
             ],
             ['componentId' => 'foo'],
             'local',
-            true
+            true,
+            false
         );
         $jobIds = $tableQueue->waitForAll();
         self::assertCount(1, $jobIds);

--- a/libs/output-mapping/tests/Writer/Workspace/AbsWriterWorkspaceTest.php
+++ b/libs/output-mapping/tests/Writer/Workspace/AbsWriterWorkspaceTest.php
@@ -139,7 +139,9 @@ class AbsWriterWorkspaceTest extends BaseWriterWorkspaceTest
             'someday',
             ['mapping' => $configs],
             ['componentId' => 'foo'],
-            'workspace-abs'
+            'workspace-abs',
+            false,
+            false
         );
         $jobIds = $tableQueue->waitForAll();
         self::assertCount(1, $jobIds);
@@ -205,7 +207,9 @@ class AbsWriterWorkspaceTest extends BaseWriterWorkspaceTest
             'data/out/tables/',
             ['mapping' => $configs],
             ['componentId' => 'foo'],
-            'workspace-abs'
+            'workspace-abs',
+            false,
+            false
         );
         $jobIds = $tableQueue->waitForAll();
         self::assertCount(1, $jobIds);
@@ -288,7 +292,9 @@ class AbsWriterWorkspaceTest extends BaseWriterWorkspaceTest
             'data/out/tables/',
             ['mapping' => $configs],
             ['componentId' => 'foo'],
-            'workspace-abs'
+            'workspace-abs',
+            false,
+            false
         );
         $jobIds = $tableQueue->waitForAll();
         self::assertCount(2, $jobIds);
@@ -376,7 +382,9 @@ class AbsWriterWorkspaceTest extends BaseWriterWorkspaceTest
             '/upload',
             ['mapping' => $configs],
             $systemMetadata,
-            AbstractStrategyFactory::WORKSPACE_ABS
+            AbstractStrategyFactory::WORKSPACE_ABS,
+            [],
+            false
         );
         sleep(1);
 

--- a/libs/output-mapping/tests/Writer/Workspace/SynapseWriterWorkspaceTest.php
+++ b/libs/output-mapping/tests/Writer/Workspace/SynapseWriterWorkspaceTest.php
@@ -78,7 +78,9 @@ class SynapseWriterWorkspaceTest extends BaseWriterWorkspaceTest
             '/',
             ['mapping' => $configs],
             ['componentId' => 'foo'],
-            AbstractStrategyFactory::WORKSPACE_SYNAPSE
+            AbstractStrategyFactory::WORKSPACE_SYNAPSE,
+            false,
+            false
         );
         $jobIds = $tableQueue->waitForAll();
         self::assertCount(2, $jobIds);

--- a/libs/output-mapping/tests/Writer/Workspace/WriterWorkspaceTest.php
+++ b/libs/output-mapping/tests/Writer/Workspace/WriterWorkspaceTest.php
@@ -79,7 +79,9 @@ class WriterWorkspaceTest extends BaseWriterWorkspaceTest
             '/',
             ['mapping' => $configs],
             ['componentId' => 'foo'],
-            'workspace-snowflake'
+            'workspace-snowflake',
+            false,
+            false
         );
         $jobIds = $tableQueue->waitForAll();
         self::assertCount(2, $jobIds);
@@ -137,7 +139,9 @@ class WriterWorkspaceTest extends BaseWriterWorkspaceTest
             '/',
             ['mapping' => $configs],
             ['componentId' => 'foo'],
-            'workspace-snowflake'
+            'workspace-snowflake',
+            false,
+            false
         );
         $tableQueue->waitForAll();
     }
@@ -158,7 +162,9 @@ class WriterWorkspaceTest extends BaseWriterWorkspaceTest
             '/',
             ['mapping' => $configs],
             ['componentId' => 'foo'],
-            'workspace-snowflake'
+            'workspace-snowflake',
+            false,
+            false
         );
         $tableQueue->waitForAll();
     }
@@ -218,7 +224,9 @@ class WriterWorkspaceTest extends BaseWriterWorkspaceTest
             '/',
             ['mapping' => $configs],
             ['componentId' => 'foo'],
-            'workspace-snowflake'
+            'workspace-snowflake',
+            false,
+            false
         );
         $jobIds = $tableQueue->waitForAll();
         self::assertCount(1, $jobIds);
@@ -277,7 +285,9 @@ class WriterWorkspaceTest extends BaseWriterWorkspaceTest
             '/',
             ['mapping' => $configs],
             ['componentId' => 'foo'],
-            'workspace-snowflake'
+            'workspace-snowflake',
+            false,
+            false
         );
     }
 
@@ -310,7 +320,9 @@ class WriterWorkspaceTest extends BaseWriterWorkspaceTest
             '/',
             ['mapping' => $configs],
             ['componentId' => 'foo'],
-            'workspace-snowflake'
+            'workspace-snowflake',
+            false,
+            false
         );
     }
 
@@ -349,7 +361,9 @@ class WriterWorkspaceTest extends BaseWriterWorkspaceTest
             '/',
             ['mapping' => $configs, 'bucket' => self::OUTPUT_BUCKET],
             ['componentId' => 'foo'],
-            'workspace-snowflake'
+            'workspace-snowflake',
+            false,
+            false
         );
         $jobIds = $tableQueue->waitForAll();
         self::assertCount(1, $jobIds);
@@ -426,7 +440,9 @@ class WriterWorkspaceTest extends BaseWriterWorkspaceTest
             '/',
             ['mapping' => $configs],
             ['componentId' => 'foo', 'branchId' => $branchId],
-            'workspace-snowflake'
+            'workspace-snowflake',
+            false,
+            false
         );
         $jobIds = $tableQueue->waitForAll();
         self::assertCount(2, $jobIds);
@@ -483,7 +499,9 @@ class WriterWorkspaceTest extends BaseWriterWorkspaceTest
             '/',
             ['mapping' => $configs],
             ['componentId' => 'foo'],
-            'workspace-snowflake'
+            'workspace-snowflake',
+            false,
+            false
         );
         $jobIds = $tableQueue->waitForAll();
         self::assertCount(2, $jobIds);


### PR DESCRIPTION
currently it completely skips fileUploads
https://keboola.atlassian.net/browse/PST-773

Protože tohleto https://github.com/keboola/docker-bundle/pull/705 se blbě testuje, tak jsem ten flag udělal povinnej, protože tim odpadá množství chyb, kde se to může zapomenout. Když už to je teda BC break, tak jsem udělal povinnej ten stejnej flag i na tables