### PR TITLE
Sort libs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,40 +29,10 @@ FROM base AS dev
 WORKDIR /code
 
 
-FROM base AS input-mapping
+FROM base AS api-bundle
 ARG COMPOSER_MIRROR_PATH_REPOS=1
 ARG COMPOSER_HOME=/tmp/composer
-ENV LIB_NAME=input-mapping
-ENV LIB_HOME=/code/${LIB_NAME}
-WORKDIR ${LIB_HOME}
-
-COPY libs/${LIB_NAME}/composer.json ./
-RUN --mount=type=bind,target=/libs,source=libs \
-    --mount=type=cache,id=composer,target=${COMPOSER_HOME} \
-    composer install $COMPOSER_FLAGS
-
-COPY libs/${LIB_NAME} ./
-
-
-FROM base AS staging-provider
-ARG COMPOSER_MIRROR_PATH_REPOS=1
-ARG COMPOSER_HOME=/tmp/composer
-ENV LIB_NAME=staging-provider
-ENV LIB_HOME=/code/${LIB_NAME}
-WORKDIR ${LIB_HOME}
-
-COPY libs/${LIB_NAME}/composer.json ./
-RUN --mount=type=bind,target=/libs,source=libs \
-    --mount=type=cache,id=composer,target=${COMPOSER_HOME} \
-    composer install $COMPOSER_FLAGS
-
-COPY libs/${LIB_NAME} ./
-
-
-FROM base AS output-mapping
-ARG COMPOSER_MIRROR_PATH_REPOS=1
-ARG COMPOSER_HOME=/tmp/composer
-ENV LIB_NAME=output-mapping
+ENV LIB_NAME=api-bundle
 ENV LIB_HOME=/code/${LIB_NAME}
 WORKDIR ${LIB_HOME}
 
@@ -89,6 +59,36 @@ RUN --mount=type=bind,target=/libs,source=libs \
 COPY libs/${LIB_NAME} ./
 
 
+FROM base AS input-mapping
+ARG COMPOSER_MIRROR_PATH_REPOS=1
+ARG COMPOSER_HOME=/tmp/composer
+ENV LIB_NAME=input-mapping
+ENV LIB_HOME=/code/${LIB_NAME}
+WORKDIR ${LIB_HOME}
+
+COPY libs/${LIB_NAME}/composer.json ./
+RUN --mount=type=bind,target=/libs,source=libs \
+    --mount=type=cache,id=composer,target=${COMPOSER_HOME} \
+    composer install $COMPOSER_FLAGS
+
+COPY libs/${LIB_NAME} ./
+
+
+FROM base AS output-mapping
+ARG COMPOSER_MIRROR_PATH_REPOS=1
+ARG COMPOSER_HOME=/tmp/composer
+ENV LIB_NAME=output-mapping
+ENV LIB_HOME=/code/${LIB_NAME}
+WORKDIR ${LIB_HOME}
+
+COPY libs/${LIB_NAME}/composer.json ./
+RUN --mount=type=bind,target=/libs,source=libs \
+    --mount=type=cache,id=composer,target=${COMPOSER_HOME} \
+    composer install $COMPOSER_FLAGS
+
+COPY libs/${LIB_NAME} ./
+
+
 FROM base AS settle
 ARG COMPOSER_MIRROR_PATH_REPOS=1
 ARG COMPOSER_HOME=/tmp/composer
@@ -103,10 +103,11 @@ RUN --mount=type=bind,target=/libs,source=libs \
 
 COPY libs/${LIB_NAME} ./
 
-FROM base AS api-bundle
+
+FROM base AS staging-provider
 ARG COMPOSER_MIRROR_PATH_REPOS=1
 ARG COMPOSER_HOME=/tmp/composer
-ENV LIB_NAME=api-bundle
+ENV LIB_NAME=staging-provider
 ENV LIB_HOME=/code/${LIB_NAME}
 WORKDIR ${LIB_HOME}
 

--- a/azure-pipelines.tags.yml
+++ b/azure-pipelines.tags.yml
@@ -10,10 +10,18 @@ pool:
 
 resources:
   repositories:
+    - repository: api-bundle
+      type: github
+      endpoint: keboola
+      name: keboola/api-bundle
     - repository: azure-api-client
       type: github
       endpoint: keboola
       name: keboola/azure-api-client
+    - repository: configuration-variables-resolver
+      type: github
+      endpoint: keboola
+      name: keboola/configuration-variables-resolver
     - repository: input-mapping
       type: github
       endpoint: keboola
@@ -26,30 +34,22 @@ resources:
       type: github
       endpoint: keboola
       name: keboola/logging-bundle
-    - repository: staging-provider
-      type: github
-      endpoint: keboola
-      name: keboola/staging-provider
     - repository: output-mapping
       type: github
       endpoint: keboola
       name: keboola/output-mapping
-    - repository: configuration-variables-resolver
-      type: github
-      endpoint: keboola
-      name: keboola/configuration-variables-resolver
-    - repository: settle
-      type: github
-      endpoint: keboola
-      name: keboola/settle
-    - repository: api-bundle
-      type: github
-      endpoint: keboola
-      name: keboola/api-bundle
     - repository: permission-checker
       type: github
       endpoint: keboola
       name: keboola/permission-checker
+    - repository: settle
+      type: github
+      endpoint: keboola
+      name: keboola/settle
+    - repository: staging-provider
+      type: github
+      endpoint: keboola
+      name: keboola/staging-provider
 
 variables:
   DOCKER_BUILDKIT: 1
@@ -58,11 +58,27 @@ variables:
 jobs:
   - template: azure-pipelines/jobs/split-library.yml
     parameters:
+      condition: startsWith(variables['Build.SourceBranch'], 'refs/tags/api-bundle/')
+      sourceRepo: platform-libraries
+      targetRepo: api-bundle
+      libraryPath: libs/api-bundle
+      tagPrefix: api-bundle/
+
+  - template: azure-pipelines/jobs/split-library.yml
+    parameters:
       condition: startsWith(variables['Build.SourceBranch'], 'refs/tags/azure-api-client/')
       sourceRepo: platform-libraries
       targetRepo: azure-api-client
       libraryPath: libs/azure-api-client
       tagPrefix: azure-api-client/
+
+  - template: azure-pipelines/jobs/split-library.yml
+    parameters:
+      condition: startsWith(variables['Build.SourceBranch'], 'refs/tags/configuration-variables-resolver/')
+      sourceRepo: platform-libraries
+      targetRepo: configuration-variables-resolver
+      libraryPath: libs/configuration-variables-resolver
+      tagPrefix: configuration-variables-resolver/
 
   - template: azure-pipelines/jobs/split-library.yml
     parameters:
@@ -90,14 +106,6 @@ jobs:
 
   - template: azure-pipelines/jobs/split-library.yml
     parameters:
-      condition: startsWith(variables['Build.SourceBranch'], 'refs/tags/staging-provider/')
-      sourceRepo: platform-libraries
-      targetRepo: staging-provider
-      libraryPath: libs/staging-provider
-      tagPrefix: staging-provider/
-
-  - template: azure-pipelines/jobs/split-library.yml
-    parameters:
       condition: startsWith(variables['Build.SourceBranch'], 'refs/tags/output-mapping/')
       sourceRepo: platform-libraries
       targetRepo: output-mapping
@@ -106,11 +114,11 @@ jobs:
 
   - template: azure-pipelines/jobs/split-library.yml
     parameters:
-      condition: startsWith(variables['Build.SourceBranch'], 'refs/tags/configuration-variables-resolver/')
+      condition: startsWith(variables['Build.SourceBranch'], 'refs/tags/permission-checker/')
       sourceRepo: platform-libraries
-      targetRepo: configuration-variables-resolver
-      libraryPath: libs/configuration-variables-resolver
-      tagPrefix: configuration-variables-resolver/
+      targetRepo: permission-checker
+      libraryPath: libs/permission-checker
+      tagPrefix: permission-checker/
 
   - template: azure-pipelines/jobs/split-library.yml
     parameters:
@@ -122,16 +130,8 @@ jobs:
 
   - template: azure-pipelines/jobs/split-library.yml
     parameters:
-      condition: startsWith(variables['Build.SourceBranch'], 'refs/tags/api-bundle/')
+      condition: startsWith(variables['Build.SourceBranch'], 'refs/tags/staging-provider/')
       sourceRepo: platform-libraries
-      targetRepo: api-bundle
-      libraryPath: libs/api-bundle
-      tagPrefix: api-bundle/
-
-  - template: azure-pipelines/jobs/split-library.yml
-    parameters:
-      condition: startsWith(variables['Build.SourceBranch'], 'refs/tags/permission-checker/')
-      sourceRepo: platform-libraries
-      targetRepo: permission-checker
-      libraryPath: libs/permission-checker
-      tagPrefix: permission-checker/
+      targetRepo: staging-provider
+      libraryPath: libs/staging-provider
+      tagPrefix: staging-provider/

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -10,10 +10,18 @@ pool:
 
 resources:
   repositories:
+    - repository: api-bundle
+      type: github
+      endpoint: keboola
+      name: keboola/api-bundle
     - repository: azure-api-client
       type: github
       endpoint: keboola
       name: keboola/azure-api-client
+    - repository: configuration-variables-resolver
+      type: github
+      endpoint: keboola
+      name: keboola/configuration-variables-resolver
     - repository: input-mapping
       type: github
       endpoint: keboola
@@ -26,10 +34,6 @@ resources:
       type: github
       endpoint: keboola
       name: keboola/logging-bundle
-    - repository: staging-provider
-      type: github
-      endpoint: keboola
-      name: keboola/staging-provider
     - repository: output-mapping
       type: github
       endpoint: keboola
@@ -38,18 +42,14 @@ resources:
       type: github
       endpoint: keboola
       name: keboola/permission-checker
-    - repository: configuration-variables-resolver
-      type: github
-      endpoint: keboola
-      name: keboola/configuration-variables-resolver
     - repository: settle
       type: github
       endpoint: keboola
       name: keboola/settle
-    - repository: api-bundle
+    - repository: staging-provider
       type: github
       endpoint: keboola
-      name: keboola/api-bundle
+      name: keboola/staging-provider
 
 variables:
   DOCKER_BUILDKIT: 1
@@ -65,16 +65,16 @@ stages:
         steps:
           - script: |
               ./bin/ci-find-changes.sh main \
+                apiBundle:libs/api-bundle \
                 azureApiClient:libs/azure-api-client \
+                configurationVariablesResolver:libs/configuration-variables-resolver \
                 inputMapping:libs/input-mapping \
                 k8sClient:libs/k8s-client \
                 loggingBundle:libs/logging-bundle \
-                stagingProvider:libs/staging-provider \
                 outputMapping:libs/output-mapping \
                 permissionChecker:libs/permission-checker \
-                configurationVariablesResolver:libs/configuration-variables-resolver \
                 settle:libs/settle \
-                apiBundle:libs/api-bundle
+                stagingProvider:libs/staging-provider
             displayName: 'Find changes'
             name: findChanges
 
@@ -91,6 +91,14 @@ stages:
             artifact: docker-images
             displayName: Publish artifacts
 
+  - stage: tests_apiBundle
+    displayName: Tests - API Bundle
+    lockBehavior: sequential
+    dependsOn: build
+    condition: and(succeeded(), dependencies.build.outputs['checkChanges.findChanges.changedProjects_apiBundle'])
+    jobs:
+      - template: libs/api-bundle/azure-pipelines.tests.yml
+
   - stage: tests_azureApiClient
     displayName: Tests - Azure API Client
     lockBehavior: sequential
@@ -99,7 +107,15 @@ stages:
     jobs:
       - template: libs/azure-api-client/azure-pipelines.tests.yml
 
-  - stage: tests_input_mapping
+  - stage: tests_configurationVariablesResolver
+    displayName: Tests - Variables Resolver
+    lockBehavior: sequential
+    dependsOn: build
+    condition: and(succeeded(), dependencies.build.outputs['checkChanges.findChanges.changedProjects_configurationVariablesResolver'])
+    jobs:
+      - template: libs/configuration-variables-resolver/azure-pipelines.tests.yml
+
+  - stage: tests_inputMapping
     displayName: Tests - Input Mapping
     lockBehavior: sequential
     dependsOn: build
@@ -123,7 +139,7 @@ stages:
     jobs:
       - template: libs/logging-bundle/azure-pipelines.tests.yml
 
-  - stage: tests_output_mapping
+  - stage: tests_outputMapping
     displayName: Tests - Output Mapping
     lockBehavior: sequential
     dependsOn: build
@@ -139,22 +155,6 @@ stages:
     jobs:
       - template: libs/permission-checker/azure-pipelines.tests.yml
 
-  - stage: tests_staging_provider
-    displayName: Tests - Staging Provider
-    lockBehavior: sequential
-    dependsOn: build
-    condition: and(succeeded(), dependencies.build.outputs['checkChanges.findChanges.changedProjects_stagingProvider'])
-    jobs:
-      - template: libs/staging-provider/azure-pipelines.tests.yml
-
-  - stage: tests_configuration_variables_resolver
-    displayName: Tests - Variables Resolver
-    lockBehavior: sequential
-    dependsOn: build
-    condition: and(succeeded(), dependencies.build.outputs['checkChanges.findChanges.changedProjects_configurationVariablesResolver'])
-    jobs:
-      - template: libs/configuration-variables-resolver/azure-pipelines.tests.yml
-
   - stage: tests_settle
     displayName: Tests - Settle
     lockBehavior: sequential
@@ -163,39 +163,39 @@ stages:
     jobs:
       - template: libs/settle/azure-pipelines.tests.yml
 
-  - stage: tests_api_bundle
-    displayName: Tests - API Bundle
+  - stage: tests_stagingProvider
+    displayName: Tests - Staging Provider
     lockBehavior: sequential
     dependsOn: build
-    condition: and(succeeded(), dependencies.build.outputs['checkChanges.findChanges.changedProjects_apiBundle'])
+    condition: and(succeeded(), dependencies.build.outputs['checkChanges.findChanges.changedProjects_stagingProvider'])
     jobs:
-      - template: libs/api-bundle/azure-pipelines.tests.yml
+      - template: libs/staging-provider/azure-pipelines.tests.yml
 
   - stage: testsResults
     displayName: Wait for tests results
     dependsOn:
+      - tests_apiBundle
       - tests_azureApiClient
-      - tests_input_mapping
+      - tests_configurationVariablesResolver
+      - tests_inputMapping
       - tests_k8sClient
       - tests_loggingBundle
-      - tests_output_mapping
+      - tests_outputMapping
       - tests_permissionChecker
-      - tests_staging_provider
-      - tests_configuration_variables_resolver
       - tests_settle
-      - tests_api_bundle
+      - tests_stagingProvider
     condition: |
       and(
+        in(dependencies.tests_apiBundle.result, 'Succeeded', 'Skipped'),
         in(dependencies.tests_azureApiClient.result, 'Succeeded', 'Skipped'),
-        in(dependencies.tests_input_mapping.result, 'Succeeded', 'Skipped'),
+        in(dependencies.tests_configurationVariablesResolver.result, 'Succeeded', 'Skipped'),
+        in(dependencies.tests_inputMapping.result, 'Succeeded', 'Skipped'),
         in(dependencies.tests_k8sClient.result, 'Succeeded', 'Skipped'),
         in(dependencies.tests_loggingBundle.result, 'Succeeded', 'Skipped'),
-        in(dependencies.tests_output_mapping.result, 'Succeeded', 'Skipped'),
+        in(dependencies.tests_outputMapping.result, 'Succeeded', 'Skipped'),
         in(dependencies.tests_permissionChecker.result, 'Succeeded', 'Skipped'),
-        in(dependencies.tests_staging_provider.result, 'Succeeded', 'Skipped'),
-        in(dependencies.tests_configuration_variables_resolver.result, 'Succeeded', 'Skipped'),
         in(dependencies.tests_settle.result, 'Succeeded', 'Skipped'),
-        in(dependencies.tests_api_bundle.result, 'Succeeded', 'Skipped')
+        in(dependencies.tests_stagingProvider.result, 'Succeeded', 'Skipped')
       )
     jobs:
       - job:
@@ -209,11 +209,27 @@ stages:
     jobs:
       - template: azure-pipelines/jobs/split-library.yml
         parameters:
+          condition: and(succeeded(), stageDependencies.build.checkChanges.outputs['findChanges.changedProjects_apiBundle'])
+          sourceRepo: platform-libraries
+          targetRepo: api-bundle
+          libraryPath: libs/api-bundle
+          tagPrefix: api-bundle/
+
+      - template: azure-pipelines/jobs/split-library.yml
+        parameters:
           condition: and(succeeded(), stageDependencies.build.checkChanges.outputs['findChanges.changedProjects_azureApiClient'])
           sourceRepo: platform-libraries
           targetRepo: azure-api-client
           libraryPath: libs/azure-api-client
           tagPrefix: azure-api-client/
+
+      - template: azure-pipelines/jobs/split-library.yml
+        parameters:
+          condition: and(succeeded(), stageDependencies.build.checkChanges.outputs['findChanges.changedProjects_configurationVariablesResolver'])
+          sourceRepo: platform-libraries
+          targetRepo: configuration-variables-resolver
+          libraryPath: libs/configuration-variables-resolver
+          tagPrefix: configuration-variables-resolver/
 
       - template: azure-pipelines/jobs/split-library.yml
         parameters:
@@ -241,14 +257,6 @@ stages:
 
       - template: azure-pipelines/jobs/split-library.yml
         parameters:
-          condition: and(succeeded(), stageDependencies.build.checkChanges.outputs['findChanges.changedProjects_stagingProvider'])
-          sourceRepo: platform-libraries
-          targetRepo: staging-provider
-          libraryPath: libs/staging-provider
-          tagPrefix: staging-provider/
-
-      - template: azure-pipelines/jobs/split-library.yml
-        parameters:
           condition: and(succeeded(), stageDependencies.build.checkChanges.outputs['findChanges.changedProjects_outputMapping'])
           sourceRepo: platform-libraries
           targetRepo: output-mapping
@@ -265,14 +273,6 @@ stages:
 
       - template: azure-pipelines/jobs/split-library.yml
         parameters:
-          condition: and(succeeded(), stageDependencies.build.checkChanges.outputs['findChanges.changedProjects_configurationVariablesResolver'])
-          sourceRepo: platform-libraries
-          targetRepo: configuration-variables-resolver
-          libraryPath: libs/configuration-variables-resolver
-          tagPrefix: configuration-variables-resolver/
-
-      - template: azure-pipelines/jobs/split-library.yml
-        parameters:
           condition: and(succeeded(), stageDependencies.build.checkChanges.outputs['findChanges.changedProjects_settle'])
           sourceRepo: platform-libraries
           targetRepo: settle
@@ -281,8 +281,8 @@ stages:
 
       - template: azure-pipelines/jobs/split-library.yml
         parameters:
-          condition: and(succeeded(), stageDependencies.build.checkChanges.outputs['findChanges.changedProjects_apiBundle'])
+          condition: and(succeeded(), stageDependencies.build.checkChanges.outputs['findChanges.changedProjects_stagingProvider'])
           sourceRepo: platform-libraries
-          targetRepo: api-bundle
-          libraryPath: libs/api-bundle
-          tagPrefix: api-bundle/
+          targetRepo: staging-provider
+          libraryPath: libs/staging-provider
+          tagPrefix: staging-provider/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -50,9 +50,16 @@ services:
     depends_on:
       - mockserver
 
-  dev-permission-checker:
-    <<: *dev81
-    working_dir: /code/libs/permission-checker
+  dev-configuration-variables-resolver:
+    profiles: [ dev ]
+    build:
+      context: .
+      target: dev
+    working_dir: /code/libs/configuration-variables-resolver
+    environment:
+      - STORAGE_API_TOKEN
+      - STORAGE_API_TOKEN_MASTER
+      - STORAGE_API_URL
 
   dev-input-mapping:
     profiles: [dev]
@@ -62,20 +69,6 @@ services:
     working_dir: /code/libs/input-mapping
     volumes:
       - .:/code
-    environment:
-      - STORAGE_API_TOKEN
-      - STORAGE_API_TOKEN_MASTER
-      - STORAGE_API_URL
-      - RUN_SYNAPSE_TESTS
-      - SYNAPSE_STORAGE_API_TOKEN
-      - SYNAPSE_STORAGE_API_URL
-
-  ci-input-mapping:
-    profiles: [ci]
-    image: keboola/input-mapping
-    build:
-      context: .
-      target: input-mapping
     environment:
       - STORAGE_API_TOKEN
       - STORAGE_API_TOKEN_MASTER
@@ -94,21 +87,6 @@ services:
     volumes:
       - .:/code
 
-  dev-staging-provider:
-    profiles: [dev]
-    build:
-      context: .
-      target: dev
-    working_dir: /code/libs/staging-provider
-    volumes:
-      - .:/code
-    environment:
-      - STORAGE_API_TOKEN
-      - STORAGE_API_URL
-      - RUN_SYNAPSE_TESTS
-      - SYNAPSE_STORAGE_API_TOKEN
-      - SYNAPSE_STORAGE_API_URL
-
   dev-output-mapping:
     profiles: [dev]
     build:
@@ -125,14 +103,60 @@ services:
       - SYNAPSE_STORAGE_API_TOKEN
       - SYNAPSE_STORAGE_API_URL
 
-  ci-staging-provider:
-    profiles: [ci]
-    image: keboola/staging-provider
+  dev-permission-checker:
+    <<: *dev81
+    working_dir: /code/libs/permission-checker
+
+  dev-settle:
+    profiles: [ dev ]
     build:
       context: .
-      target: staging-provider
+      target: dev
+    working_dir: /code/libs/settle
+
+  dev-staging-provider:
+    profiles: [dev]
+    build:
+      context: .
+      target: dev
+    working_dir: /code/libs/staging-provider
+    volumes:
+      - .:/code
     environment:
       - STORAGE_API_TOKEN
+      - STORAGE_API_URL
+      - RUN_SYNAPSE_TESTS
+      - SYNAPSE_STORAGE_API_TOKEN
+      - SYNAPSE_STORAGE_API_URL
+
+
+  ci-api-bundle:
+    profiles: [ ci ]
+    image: keboola/api-bundle
+    build:
+      context: .
+      target: api-bundle
+
+  ci-configuration-variables-resolver:
+    profiles: [ ci ]
+    image: keboola/configuration-variables-resolver
+    build:
+      context: .
+      target: configuration-variables-resolver
+    environment:
+      - STORAGE_API_TOKEN
+      - STORAGE_API_TOKEN_MASTER
+      - STORAGE_API_URL
+
+  ci-input-mapping:
+    profiles: [ci]
+    image: keboola/input-mapping
+    build:
+      context: .
+      target: input-mapping
+    environment:
+      - STORAGE_API_TOKEN
+      - STORAGE_API_TOKEN_MASTER
       - STORAGE_API_URL
       - RUN_SYNAPSE_TESTS
       - SYNAPSE_STORAGE_API_TOKEN
@@ -152,35 +176,6 @@ services:
       - SYNAPSE_STORAGE_API_TOKEN
       - SYNAPSE_STORAGE_API_URL
 
-  dev-configuration-variables-resolver:
-    profiles: [ dev ]
-    build:
-      context: .
-      target: dev
-    working_dir: /code/libs/configuration-variables-resolver
-    environment:
-      - STORAGE_API_TOKEN
-      - STORAGE_API_TOKEN_MASTER
-      - STORAGE_API_URL
-
-  ci-configuration-variables-resolver:
-    profiles: [ ci ]
-    image: keboola/configuration-variables-resolver
-    build:
-      context: .
-      target: configuration-variables-resolver
-    environment:
-      - STORAGE_API_TOKEN
-      - STORAGE_API_TOKEN_MASTER
-      - STORAGE_API_URL
-
-  dev-settle:
-    profiles: [ dev ]
-    build:
-      context: .
-      target: dev
-    working_dir: /code/libs/settle
-
   ci-settle:
     profiles: [ ci ]
     image: keboola/settle
@@ -188,9 +183,15 @@ services:
       context: .
       target: settle
 
-  ci-api-bundle:
-    profiles: [ ci ]
-    image: keboola/api-bundle
+  ci-staging-provider:
+    profiles: [ci]
+    image: keboola/staging-provider
     build:
       context: .
-      target: api-bundle
+      target: staging-provider
+    environment:
+      - STORAGE_API_TOKEN
+      - STORAGE_API_URL
+      - RUN_SYNAPSE_TESTS
+      - SYNAPSE_STORAGE_API_TOKEN
+      - SYNAPSE_STORAGE_API_URL

--- a/libs/input-mapping/tests/Functional/DownloadTablesWorkspaceAbsTest.php
+++ b/libs/input-mapping/tests/Functional/DownloadTablesWorkspaceAbsTest.php
@@ -170,6 +170,10 @@ class DownloadTablesWorkspaceAbsTest extends AbstractTestCase
     #[NeedsTestTables]
     public function testUseViewFails(): void
     {
+        if (time() > 1) {
+            $this->markTestSkipped('TODO fix test https://keboola.atlassian.net/browse/PST-961');
+        }
+
         $logger = new TestLogger();
         $reader = new Reader($this->getWorkspaceStagingFactory(
             null,

--- a/libs/input-mapping/tests/Functional/DownloadTablesWorkspaceRedshiftTest.php
+++ b/libs/input-mapping/tests/Functional/DownloadTablesWorkspaceRedshiftTest.php
@@ -110,6 +110,10 @@ class DownloadTablesWorkspaceRedshiftTest extends AbstractTestCase
     #[NeedsTestTables]
     public function testUseViewFails(): void
     {
+        if (time() > 1) {
+            $this->markTestSkipped('TODO fix test https://keboola.atlassian.net/browse/PST-961');
+        }
+
         $logger = new TestLogger();
         $reader = new Reader(
             $this->getWorkspaceStagingFactory(

--- a/libs/input-mapping/tests/Functional/DownloadTablesWorkspaceSnowflakeTest.php
+++ b/libs/input-mapping/tests/Functional/DownloadTablesWorkspaceSnowflakeTest.php
@@ -321,6 +321,10 @@ class DownloadTablesWorkspaceSnowflakeTest extends AbstractTestCase
     #[NeedsTestTables]
     public function testUseViewFails(): void
     {
+        if (time() > 1) {
+            $this->markTestSkipped('TODO fix test https://keboola.atlassian.net/browse/PST-961');
+        }
+
         $logger = new TestLogger();
         $reader = new Reader($this->getWorkspaceStagingFactory(logger: $logger));
         $configuration = new InputTableOptionsList([


### PR DESCRIPTION
Priprava pred https://keboola.atlassian.net/browse/SOX-65

Pokazdy, kdyz pridavam novou libku do Platform Libraries se zasekam na tom, kam ji hodit do `docker-compose`, `azure-pipelines` apod. Seradil jsem to vsude podle abecedy, tak snad do budoucna by to melo trochu usnadnit vykop nove libky.

Nezavisle na tom se objevily failujici testy v IM, protoze Conneciton releasnulo podporu pro view mapping na dalsi backendy. Related failujici testy jsem zatim skipnul a udelal issue na proper reseni https://keboola.atlassian.net/browse/PST-961

Tady je pipeline, ktera prosla cela zelena, krome IM, kde se objevil ten problem s testy https://dev.azure.com/keboola-dev/Platform%20Libraries/_build/results?buildId=35362&view=results, dalsi pipeline uz pak poustela jen testy IM.