### PR TITLE
[api-bundle] composer: allow permission checker 1.0

### DIFF
--- a/libs/api-bundle/composer.json
+++ b/libs/api-bundle/composer.json
@@ -4,7 +4,7 @@
     "type": "symfony-bundle",
     "require": {
         "php": ">=8.1",
-        "keboola/permission-checker": "^0.1.0",
+        "keboola/permission-checker": "^1.0",
         "monolog/monolog": "^2.0",
         "symfony/dependency-injection": "^6.0",
         "symfony/monolog-bundle": "^3.8"


### PR DESCRIPTION
Včera jsem udělal bc break do permission checkeru pro schedules, tak jsem ho releasnul jako 1.0