### PR TITLE
Switch to table storage client where applicable in IM

### DIFF
--- a/libs/input-mapping/composer.json
+++ b/libs/input-mapping/composer.json
@@ -14,7 +14,7 @@
         "ext-json": "*",
         "keboola/php-file-storage-utils": "^0.2",
         "keboola/storage-api-client": "^14.5",
-        "keboola/storage-api-php-client-branch-wrapper": "dev-odin-SOX-138 as 3.1.0",
+        "keboola/storage-api-php-client-branch-wrapper": "^3.4",
         "symfony/config": "^5.4|^6.0",
         "symfony/finder": "^5.4|^6.0",
         "symfony/serializer": "^5.4|^6.0",

--- a/libs/input-mapping/composer.json
+++ b/libs/input-mapping/composer.json
@@ -14,7 +14,7 @@
         "ext-json": "*",
         "keboola/php-file-storage-utils": "^0.2",
         "keboola/storage-api-client": "^14.5",
-        "keboola/storage-api-php-client-branch-wrapper": "^3.1",
+        "keboola/storage-api-php-client-branch-wrapper": "dev-odin-SOX-138 as 3.1.0",
         "symfony/config": "^5.4|^6.0",
         "symfony/finder": "^5.4|^6.0",
         "symfony/serializer": "^5.4|^6.0",

--- a/libs/input-mapping/src/File/Strategy/AbstractStrategy.php
+++ b/libs/input-mapping/src/File/Strategy/AbstractStrategy.php
@@ -72,7 +72,7 @@ abstract class AbstractStrategy implements StrategyInterface
                 $outputStateConfiguration = [];
             }
             foreach ($files as $file) {
-                $fileInfo = $this->clientWrapper->getBasicClient()->getFile($file['id'], $fileOptions);
+                $fileInfo = $this->clientWrapper->getTableAndFileStorageClient()->getFile($file['id'], $fileOptions);
                 $fileDestinationPath = $this->getFileDestinationPath($destination, $fileInfo['id'], $fileInfo['name']);
                 $overwrite = $fileConfiguration['overwrite'];
 

--- a/libs/input-mapping/src/File/Strategy/Local.php
+++ b/libs/input-mapping/src/File/Strategy/Local.php
@@ -19,13 +19,13 @@ class Local extends AbstractStrategy implements StrategyInterface
         $fs = new Filesystem();
         if ($fileInfo['isSliced']) {
             $fs->mkdir($this->ensurePathDelimiter($this->dataStorage->getPath()) . $destinationPath);
-            $this->clientWrapper->getBasicClient()->downloadSlicedFile(
+            $this->clientWrapper->getTableAndFileStorageClient()->downloadSlicedFile(
                 $fileInfo['id'],
                 $this->ensurePathDelimiter($this->dataStorage->getPath()) . $destinationPath
             );
         } else {
             $fs->mkdir(dirname($this->ensurePathDelimiter($this->dataStorage->getPath()) . $destinationPath));
-            $this->clientWrapper->getBasicClient()->downloadFile(
+            $this->clientWrapper->getTableAndFileStorageClient()->downloadFile(
                 $fileInfo['id'],
                 $this->ensurePathDelimiter($this->dataStorage->getPath()) . $destinationPath
             );

--- a/libs/input-mapping/src/Helper/InputBucketValidator.php
+++ b/libs/input-mapping/src/Helper/InputBucketValidator.php
@@ -44,7 +44,7 @@ class InputBucketValidator
     private static function isDevBucket(string $bucketId, ClientWrapper $clientWrapper): bool
     {
         try {
-            $metadata = new Metadata($clientWrapper->getBasicClient());
+            $metadata = new Metadata($clientWrapper->getTableAndFileStorageClient());
             $metadata = $metadata->listBucketMetadata($bucketId);
             foreach ($metadata as $metadatum) {
                 if (($metadatum['key'] === 'KBC.lastUpdatedBy.branch.id') ||

--- a/libs/input-mapping/src/Helper/SourceRewriteHelper.php
+++ b/libs/input-mapping/src/Helper/SourceRewriteHelper.php
@@ -61,7 +61,9 @@ class SourceRewriteHelper
     {
         $newSource = self::getNewSource(
             $source,
-            $clientWrapper->getBranchClientIfAvailable()->webalizeDisplayName((string) $clientWrapper->getBranchId())['displayName']
+            $clientWrapper->getBranchClientIfAvailable()->webalizeDisplayName(
+                (string) $clientWrapper->getBranchId()
+            )['displayName']
         );
         if ($clientWrapper->getTableAndFileStorageClient()->tableExists($newSource)) {
             $logger->info(

--- a/libs/input-mapping/src/Helper/SourceRewriteHelper.php
+++ b/libs/input-mapping/src/Helper/SourceRewriteHelper.php
@@ -63,7 +63,7 @@ class SourceRewriteHelper
             $source,
             $clientWrapper->getBasicClient()->webalizeDisplayName((string) $clientWrapper->getBranchId())['displayName']
         );
-        if ($clientWrapper->getBasicClient()->tableExists($newSource)) {
+        if ($clientWrapper->getTableAndFileStorageClient()->tableExists($newSource)) {
             $logger->info(
                 sprintf('Using dev input "%s" instead of "%s".', $newSource, $source)
             );

--- a/libs/input-mapping/src/Helper/SourceRewriteHelper.php
+++ b/libs/input-mapping/src/Helper/SourceRewriteHelper.php
@@ -61,7 +61,7 @@ class SourceRewriteHelper
     {
         $newSource = self::getNewSource(
             $source,
-            $clientWrapper->getBasicClient()->webalizeDisplayName((string) $clientWrapper->getBranchId())['displayName']
+            $clientWrapper->getBranchClientIfAvailable()->webalizeDisplayName((string) $clientWrapper->getBranchId())['displayName']
         );
         if ($clientWrapper->getTableAndFileStorageClient()->tableExists($newSource)) {
             $logger->info(

--- a/libs/input-mapping/src/Helper/TagsRewriteHelper.php
+++ b/libs/input-mapping/src/Helper/TagsRewriteHelper.php
@@ -97,7 +97,7 @@ class TagsRewriteHelper
         $options->setTags($tags);
         $options->setLimit(1);
 
-        return count($clientWrapper->getBasicClient()->listFiles($options)) > 0;
+        return count($clientWrapper->getTableAndFileStorageClient()->listFiles($options)) > 0;
     }
 
     private static function overwriteSourceTags(string $prefix, array $tags): array
@@ -114,6 +114,6 @@ class TagsRewriteHelper
         $options->setQuery(BuildQueryFromConfigurationHelper::buildQueryForSourceTags($tags));
         $options->setLimit(1);
 
-        return count($clientWrapper->getBasicClient()->listFiles($options)) > 0;
+        return count($clientWrapper->getTableAndFileStorageClient()->listFiles($options)) > 0;
     }
 }

--- a/libs/input-mapping/src/Reader.php
+++ b/libs/input-mapping/src/Reader.php
@@ -29,6 +29,8 @@ class Reader
     private LoggerInterface $logger;
     private StrategyFactory $strategyFactory;
 
+    public const PROTECTED_DEFAULT_BRANCH_FEATURE = 'protected-default-branch';
+
     public function __construct(StrategyFactory $strategyFactory)
     {
         $this->logger = $strategyFactory->getLogger();
@@ -71,7 +73,8 @@ class Reader
         string $stagingType,
         ReaderOptions $readerOptions
     ): Result {
-        $tableResolver = new TableDefinitionResolver($this->clientWrapper->getBasicClient(), $this->logger);
+        // assuming yes on https://keboolaglobal.slack.com/archives/C05BK5V8N1Z/p1688578793224979
+        $tableResolver = new TableDefinitionResolver($this->clientWrapper->getTableAndFileStorageClient(), $this->logger);
         $tablesState = SourceRewriteHelper::rewriteTableStatesDestinations(
             $tablesState,
             $this->clientWrapper,
@@ -127,7 +130,7 @@ class Reader
             $clientWrapper,
             $logger
         );
-        $storageClient = $clientWrapper->getBasicClient();
+        $storageClient = $clientWrapper->getTableAndFileStorageClient();
 
         if (isset($fileConfigurationRewritten['query']) && $clientWrapper->hasBranch()) {
             throw new InvalidInputException(

--- a/libs/input-mapping/src/Reader.php
+++ b/libs/input-mapping/src/Reader.php
@@ -74,7 +74,10 @@ class Reader
         ReaderOptions $readerOptions
     ): Result {
         // assuming yes on https://keboolaglobal.slack.com/archives/C05BK5V8N1Z/p1688578793224979
-        $tableResolver = new TableDefinitionResolver($this->clientWrapper->getTableAndFileStorageClient(), $this->logger);
+        $tableResolver = new TableDefinitionResolver(
+            $this->clientWrapper->getTableAndFileStorageClient(),
+            $this->logger
+        );
         $tablesState = SourceRewriteHelper::rewriteTableStatesDestinations(
             $tablesState,
             $this->clientWrapper,

--- a/libs/input-mapping/src/Table/Strategy/ABS.php
+++ b/libs/input-mapping/src/Table/Strategy/ABS.php
@@ -15,7 +15,7 @@ class ABS extends AbstractStrategy
     {
         $exportOptions = $table->getStorageApiExportOptions($this->tablesState);
         $exportOptions['gzip'] = true;
-        $jobId = $this->clientWrapper->getBasicClient()->queueTableExport($table->getSource(), $exportOptions);
+        $jobId = $this->clientWrapper->getTableAndFileStorageClient()->queueTableExport($table->getSource(), $exportOptions);
         return [$jobId, $table];
     }
 
@@ -36,8 +36,8 @@ class ABS extends AbstractStrategy
             list ($jobId, $table) = $export;
             $manifestPath = $this->ensurePathDelimiter($this->metadataStorage->getPath()) .
                 $this->getDestinationFilePath($this->destination, $table) . '.manifest';
-            $tableInfo = $this->clientWrapper->getBasicClient()->getTable($table->getSource());
-            $fileInfo = $this->clientWrapper->getBasicClient()->getFile(
+            $tableInfo = $this->clientWrapper->getTableAndFileStorageClient()->getTable($table->getSource());
+            $fileInfo = $this->clientWrapper->getTableAndFileStorageClient()->getFile(
                 $keyedResults[$jobId]['results']['file']['id'],
                 (new GetFileOptions())->setFederationToken(true)
             )

--- a/libs/input-mapping/src/Table/Strategy/ABS.php
+++ b/libs/input-mapping/src/Table/Strategy/ABS.php
@@ -15,7 +15,10 @@ class ABS extends AbstractStrategy
     {
         $exportOptions = $table->getStorageApiExportOptions($this->tablesState);
         $exportOptions['gzip'] = true;
-        $jobId = $this->clientWrapper->getTableAndFileStorageClient()->queueTableExport($table->getSource(), $exportOptions);
+        $jobId = $this->clientWrapper->getTableAndFileStorageClient()->queueTableExport(
+            $table->getSource(),
+            $exportOptions
+        );
         return [$jobId, $table];
     }
 

--- a/libs/input-mapping/src/Table/Strategy/ABS.php
+++ b/libs/input-mapping/src/Table/Strategy/ABS.php
@@ -28,7 +28,7 @@ class ABS extends AbstractStrategy
         $jobIds = array_map(function ($export) {
             return $export[0];
         }, $exports);
-        $jobResults = $this->clientWrapper->getBasicClient()->handleAsyncTasks($jobIds);
+        $jobResults = $this->clientWrapper->getBranchClientIfAvailable()->handleAsyncTasks($jobIds);
         $keyedResults = [];
         foreach ($jobResults as $result) {
             $keyedResults[$result['id']] = $result;

--- a/libs/input-mapping/src/Table/Strategy/ABSWorkspace.php
+++ b/libs/input-mapping/src/Table/Strategy/ABSWorkspace.php
@@ -62,7 +62,7 @@ class ABSWorkspace extends AbstractStrategy
                 $manifestPath = $this->ensurePathDelimiter($this->metadataStorage->getPath()) .
                     $this->getDestinationFilePath($this->ensureNoPathDelimiter($this->destination), $table) .
                     '.manifest';
-                $tableInfo = $this->clientWrapper->getBasicClient()->getTable($table->getSource());
+                $tableInfo = $this->clientWrapper->getTableAndFileStorageClient()->getTable($table->getSource());
                 $this->manifestCreator->writeTableManifest(
                     $tableInfo,
                     $manifestPath,

--- a/libs/input-mapping/src/Table/Strategy/ABSWorkspace.php
+++ b/libs/input-mapping/src/Table/Strategy/ABSWorkspace.php
@@ -57,7 +57,7 @@ class ABSWorkspace extends AbstractStrategy
         $jobResults = [];
         if ($workspaceJobId) {
             $this->logger->info('Processing workspace export.');
-            $jobResults = $this->clientWrapper->getBasicClient()->handleAsyncTasks([$workspaceJobId]);
+            $jobResults = $this->clientWrapper->getBranchClientIfAvailable()->handleAsyncTasks([$workspaceJobId]);
             foreach ($workspaceTables as $table) {
                 $manifestPath = $this->ensurePathDelimiter($this->metadataStorage->getPath()) .
                     $this->getDestinationFilePath($this->ensureNoPathDelimiter($this->destination), $table) .

--- a/libs/input-mapping/src/Table/Strategy/AbstractDatabaseStrategy.php
+++ b/libs/input-mapping/src/Table/Strategy/AbstractDatabaseStrategy.php
@@ -88,7 +88,7 @@ abstract class AbstractDatabaseStrategy extends AbstractStrategy
                     'preserve' => $preserve ? 1 : 0,
                 ]
             );
-            $cloneJobResult = $this->clientWrapper->getBasicClient()->handleAsyncTasks([$jobId]);
+            $cloneJobResult = $this->clientWrapper->getBranchClientIfAvailable()->handleAsyncTasks([$jobId]);
             if (!$preserve) {
                 $hasBeenCleaned = true;
             }
@@ -105,7 +105,7 @@ abstract class AbstractDatabaseStrategy extends AbstractStrategy
                     'preserve' => !$hasBeenCleaned && !$preserve ? 0 : 1,
                 ]
             );
-            $copyJobResult = $this->clientWrapper->getBasicClient()->handleAsyncTasks([$jobId]);
+            $copyJobResult = $this->clientWrapper->getBranchClientIfAvailable()->handleAsyncTasks([$jobId]);
         }
         $jobResults = array_merge($cloneJobResult, $copyJobResult);
         $this->logger->info('Processed ' . count($jobResults) . ' workspace exports.');

--- a/libs/input-mapping/src/Table/Strategy/AbstractDatabaseStrategy.php
+++ b/libs/input-mapping/src/Table/Strategy/AbstractDatabaseStrategy.php
@@ -14,7 +14,7 @@ abstract class AbstractDatabaseStrategy extends AbstractStrategy
 
     public function downloadTable(InputTableOptions $table): array
     {
-        $tableInfo = $this->clientWrapper->getBasicClient()->getTable($table->getSource());
+        $tableInfo = $this->clientWrapper->getTableAndFileStorageClient()->getTable($table->getSource());
         $loadOptions = $table->getStorageApiLoadOptions($this->tablesState);
         if (LoadTypeDecider::canClone($tableInfo, $this->getWorkspaceType(), $loadOptions)) {
             $this->logger->info(sprintf('Table "%s" will be cloned.', $table->getSource()));
@@ -113,7 +113,7 @@ abstract class AbstractDatabaseStrategy extends AbstractStrategy
         foreach ($workspaceTables as $table) {
             $manifestPath = $this->ensurePathDelimiter($this->metadataStorage->getPath()) .
                 $this->getDestinationFilePath($this->destination, $table) . '.manifest';
-            $tableInfo = $this->clientWrapper->getBasicClient()->getTable($table->getSource());
+            $tableInfo = $this->clientWrapper->getTableAndFileStorageClient()->getTable($table->getSource());
             $this->manifestCreator->writeTableManifest(
                 $tableInfo,
                 $manifestPath,

--- a/libs/input-mapping/src/Table/Strategy/AbstractStrategy.php
+++ b/libs/input-mapping/src/Table/Strategy/AbstractStrategy.php
@@ -55,7 +55,7 @@ abstract class AbstractStrategy implements StrategyInterface
         $exports = [];
         $result = new Result();
         foreach ($tables as $table) {
-            $tableInfo = $this->clientWrapper->getBasicClient()->getTable($table->getSource());
+            $tableInfo = $this->clientWrapper->getTableAndFileStorageClient()->getTable($table->getSource());
             $outputStateConfiguration[] = [
                 'source' => $table->getSource(),
                 'lastImportDate' => $tableInfo['lastImportDate'],

--- a/libs/input-mapping/src/Table/Strategy/Local.php
+++ b/libs/input-mapping/src/Table/Strategy/Local.php
@@ -15,7 +15,7 @@ class Local extends AbstractStrategy
 
     public function downloadTable(InputTableOptions $table): array
     {
-        $tokenInfo = $this->clientWrapper->getBasicClient()->verifyToken();
+        $tokenInfo = $this->clientWrapper->getBranchClientIfAvailable()->verifyToken();
         $exportLimit = self::DEFAULT_MAX_EXPORT_SIZE_BYTES;
         if (!empty($tokenInfo['owner']['limits'][self::EXPORT_SIZE_LIMIT_NAME])) {
             $exportLimit = $tokenInfo['owner']['limits'][self::EXPORT_SIZE_LIMIT_NAME]['value'];
@@ -23,7 +23,7 @@ class Local extends AbstractStrategy
 
         $file = $this->ensurePathDelimiter($this->dataStorage->getPath()) .
             $this->getDestinationFilePath($this->destination, $table);
-        $tableInfo = $this->clientWrapper->getBasicClient()->getTable($table->getSource());
+        $tableInfo = $this->clientWrapper->getTableAndFileStorageClient()->getTable($table->getSource());
         if ($tableInfo['dataSizeBytes'] > $exportLimit) {
             throw new InvalidInputException(sprintf(
                 'Table "%s" with size %s bytes exceeds the input mapping limit of %s bytes. ' .
@@ -50,7 +50,7 @@ class Local extends AbstractStrategy
 
     public function handleExports(array $exports, bool $preserve): array
     {
-        $tableExporter = new TableExporter($this->clientWrapper->getBasicClient());
+        $tableExporter = new TableExporter($this->clientWrapper->getTableAndFileStorageClient());
         $this->logger->info('Processing ' . count($exports) . ' local table exports.');
         return $tableExporter->exportTables($exports);
     }

--- a/libs/input-mapping/src/Table/Strategy/S3.php
+++ b/libs/input-mapping/src/Table/Strategy/S3.php
@@ -27,7 +27,7 @@ class S3 extends AbstractStrategy
         $jobIds = array_map(function ($export) {
             return $export['jobId'];
         }, $exports);
-        $jobResults = $this->clientWrapper->getBasicClient()->handleAsyncTasks($jobIds);
+        $jobResults = $this->clientWrapper->getBranchClientIfAvailable()->handleAsyncTasks($jobIds);
         $keyedResults = [];
         foreach ($jobResults as $result) {
             $keyedResults[$result['id']] = $result;

--- a/libs/input-mapping/src/Table/Strategy/S3.php
+++ b/libs/input-mapping/src/Table/Strategy/S3.php
@@ -14,7 +14,10 @@ class S3 extends AbstractStrategy
     {
         $exportOptions = $table->getStorageApiExportOptions($this->tablesState);
         $exportOptions['gzip'] = true;
-        $jobId = $this->clientWrapper->getTableAndFileStorageClient()->queueTableExport($table->getSource(), $exportOptions);
+        $jobId = $this->clientWrapper->getTableAndFileStorageClient()->queueTableExport(
+            $table->getSource(),
+            $exportOptions
+        );
         return ['jobId' => $jobId, 'table' => $table];
     }
 

--- a/libs/input-mapping/src/Table/Strategy/S3.php
+++ b/libs/input-mapping/src/Table/Strategy/S3.php
@@ -14,7 +14,7 @@ class S3 extends AbstractStrategy
     {
         $exportOptions = $table->getStorageApiExportOptions($this->tablesState);
         $exportOptions['gzip'] = true;
-        $jobId = $this->clientWrapper->getBasicClient()->queueTableExport($table->getSource(), $exportOptions);
+        $jobId = $this->clientWrapper->getTableAndFileStorageClient()->queueTableExport($table->getSource(), $exportOptions);
         return ['jobId' => $jobId, 'table' => $table];
     }
 
@@ -34,8 +34,8 @@ class S3 extends AbstractStrategy
             $table = $export['table'];
             $manifestPath = $this->ensurePathDelimiter($this->metadataStorage->getPath()) .
                 $this->getDestinationFilePath($this->destination, $table) . '.manifest';
-            $tableInfo = $this->clientWrapper->getBasicClient()->getTable($table->getSource());
-            $fileInfo = $this->clientWrapper->getBasicClient()->getFile(
+            $tableInfo = $this->clientWrapper->getTableAndFileStorageClient()->getTable($table->getSource());
+            $fileInfo = $this->clientWrapper->getTableAndFileStorageClient()->getFile(
                 $keyedResults[$export['jobId']]['results']['file']['id'],
                 (new GetFileOptions())->setFederationToken(true)
             )

--- a/libs/input-mapping/src/Table/Strategy/Synapse.php
+++ b/libs/input-mapping/src/Table/Strategy/Synapse.php
@@ -61,7 +61,7 @@ class Synapse extends AbstractStrategy
         foreach ($workspaceTables as $table) {
             $manifestPath = $this->ensurePathDelimiter($this->metadataStorage->getPath()) .
                 $this->getDestinationFilePath($this->destination, $table) . '.manifest';
-            $tableInfo = $this->clientWrapper->getBasicClient()->getTable($table->getSource());
+            $tableInfo = $this->clientWrapper->getTableAndFileStorageClient()->getTable($table->getSource());
             $this->manifestCreator->writeTableManifest(
                 $tableInfo,
                 $manifestPath,

--- a/libs/input-mapping/src/Table/Strategy/Synapse.php
+++ b/libs/input-mapping/src/Table/Strategy/Synapse.php
@@ -57,7 +57,7 @@ class Synapse extends AbstractStrategy
         );
 
         $this->logger->info('Processing ' . count($workspaceJobs) . ' workspace exports.');
-        $jobResults = $this->clientWrapper->getBasicClient()->handleAsyncTasks($workspaceJobs);
+        $jobResults = $this->clientWrapper->getBranchClientIfAvailable()->handleAsyncTasks($workspaceJobs);
         foreach ($workspaceTables as $table) {
             $manifestPath = $this->ensurePathDelimiter($this->metadataStorage->getPath()) .
                 $this->getDestinationFilePath($this->destination, $table) . '.manifest';

--- a/libs/input-mapping/tests/AbstractTestCase.php
+++ b/libs/input-mapping/tests/AbstractTestCase.php
@@ -63,14 +63,14 @@ abstract class AbstractTestCase extends TestCase
         $this->clientWrapper = new ClientWrapper(
             new ClientOptions((string) getenv('STORAGE_API_URL'), (string) getenv('STORAGE_API_TOKEN')),
         );
-        $tokenInfo = $this->clientWrapper->getBasicClient()->verifyToken();
+        $tokenInfo = $this->clientWrapper->getBranchClientIfAvailable()->verifyToken();
         print(sprintf(
             'Authorized as "%s (%s)" to project "%s (%s)" at "%s" stack.',
             $tokenInfo['description'],
             $tokenInfo['id'],
             $tokenInfo['owner']['name'],
             $tokenInfo['owner']['id'],
-            $this->clientWrapper->getBasicClient()->getApiUrl()
+            $this->clientWrapper->getBranchClientIfAvailable()->getApiUrl()
         ));
     }
 

--- a/libs/input-mapping/tests/Functional/DownloadFilesAbsWorkspaceTest.php
+++ b/libs/input-mapping/tests/Functional/DownloadFilesAbsWorkspaceTest.php
@@ -137,11 +137,11 @@ class DownloadFilesAbsWorkspaceTest extends TestCase
         $root = $temp->getTmpFolder();
         file_put_contents($root . '/upload', 'test');
         $clientWrapper = $this->getClientWrapper(null);
-        $id1 = $clientWrapper->getBasicClient()->uploadFile(
+        $id1 = $clientWrapper->getTableAndFileStorageClient()->uploadFile(
             $root . '/upload',
             (new FileUploadOptions())->setTags(['download-files-test'])
         );
-        $id2 = $clientWrapper->getBasicClient()->uploadFile(
+        $id2 = $clientWrapper->getTableAndFileStorageClient()->uploadFile(
             $root . '/upload',
             (new FileUploadOptions())->setTags(['download-files-test'])
         );
@@ -207,7 +207,7 @@ class DownloadFilesAbsWorkspaceTest extends TestCase
         file_put_contents($root . '/upload', 'test');
 
         $clientWrapper = $this->getClientWrapper(null);
-        $id1 = $clientWrapper->getBasicClient()->uploadFile(
+        $id1 = $clientWrapper->getTableAndFileStorageClient()->uploadFile(
             $root . '/upload',
             (new FileUploadOptions())->setTags(['download-files-test'])
         );
@@ -271,15 +271,15 @@ class DownloadFilesAbsWorkspaceTest extends TestCase
         $fo = new FileUploadOptions();
         $fo->setTags(['download-files-test']);
 
-        $clientWrapper->getBasicClient()->setRunId('xyz');
-        $id1 = $clientWrapper->getBasicClient()->uploadFile($root . '/upload', $fo);
-        $id2 = $clientWrapper->getBasicClient()->uploadFile($root . '/upload', $fo);
-        $clientWrapper->getBasicClient()->setRunId('1234567');
-        $id3 = $clientWrapper->getBasicClient()->uploadFile($root . '/upload', $fo);
-        $id4 = $clientWrapper->getBasicClient()->uploadFile($root . '/upload', $fo);
-        $clientWrapper->getBasicClient()->setRunId('1234567.8901234');
-        $id5 = $clientWrapper->getBasicClient()->uploadFile($root . '/upload', $fo);
-        $id6 = $clientWrapper->getBasicClient()->uploadFile($root . '/upload', $fo);
+        $clientWrapper->getTableAndFileStorageClient()->setRunId('xyz');
+        $id1 = $clientWrapper->getTableAndFileStorageClient()->uploadFile($root . '/upload', $fo);
+        $id2 = $clientWrapper->getTableAndFileStorageClient()->uploadFile($root . '/upload', $fo);
+        $clientWrapper->getTableAndFileStorageClient()->setRunId('1234567');
+        $id3 = $clientWrapper->getTableAndFileStorageClient()->uploadFile($root . '/upload', $fo);
+        $id4 = $clientWrapper->getTableAndFileStorageClient()->uploadFile($root . '/upload', $fo);
+        $clientWrapper->getTableAndFileStorageClient()->setRunId('1234567.8901234');
+        $id5 = $clientWrapper->getTableAndFileStorageClient()->uploadFile($root . '/upload', $fo);
+        $id6 = $clientWrapper->getTableAndFileStorageClient()->uploadFile($root . '/upload', $fo);
         sleep(5);
         $configuration = [
             [
@@ -368,15 +368,15 @@ class DownloadFilesAbsWorkspaceTest extends TestCase
         $fo = new FileUploadOptions();
         $fo->setTags(['download-files-test']);
 
-        $clientWrapper->getBasicClient()->setRunId('xyz');
-        $id1 = $clientWrapper->getBasicClient()->uploadFile($root . '/upload', $fo);
-        $id2 = $clientWrapper->getBasicClient()->uploadFile($root . '/upload', $fo);
-        $clientWrapper->getBasicClient()->setRunId('1234567');
-        $id3 = $clientWrapper->getBasicClient()->uploadFile($root . '/upload', $fo);
-        $id4 = $clientWrapper->getBasicClient()->uploadFile($root . '/upload', $fo);
-        $clientWrapper->getBasicClient()->setRunId('1234567.8901234');
-        $id5 = $clientWrapper->getBasicClient()->uploadFile($root . '/upload', $fo);
-        $id6 = $clientWrapper->getBasicClient()->uploadFile($root . '/upload', $fo);
+        $clientWrapper->getTableAndFileStorageClient()->setRunId('xyz');
+        $id1 = $clientWrapper->getTableAndFileStorageClient()->uploadFile($root . '/upload', $fo);
+        $id2 = $clientWrapper->getTableAndFileStorageClient()->uploadFile($root . '/upload', $fo);
+        $clientWrapper->getTableAndFileStorageClient()->setRunId('1234567');
+        $id3 = $clientWrapper->getTableAndFileStorageClient()->uploadFile($root . '/upload', $fo);
+        $id4 = $clientWrapper->getTableAndFileStorageClient()->uploadFile($root . '/upload', $fo);
+        $clientWrapper->getTableAndFileStorageClient()->setRunId('1234567.8901234');
+        $id5 = $clientWrapper->getTableAndFileStorageClient()->uploadFile($root . '/upload', $fo);
+        $id6 = $clientWrapper->getTableAndFileStorageClient()->uploadFile($root . '/upload', $fo);
         sleep(5);
         $configuration = [
             [
@@ -463,8 +463,8 @@ class DownloadFilesAbsWorkspaceTest extends TestCase
         $fo = new FileUploadOptions();
         $fo->setTags(['download-files-test']);
 
-        $id1 = $clientWrapper->getBasicClient()->uploadFile($root . '/upload', $fo);
-        $id2 = $clientWrapper->getBasicClient()->uploadFile($root . '/upload', $fo);
+        $id1 = $clientWrapper->getTableAndFileStorageClient()->uploadFile($root . '/upload', $fo);
+        $id2 = $clientWrapper->getTableAndFileStorageClient()->uploadFile($root . '/upload', $fo);
         sleep(2);
         $configuration = [[
             'tags' => ['download-files-test'],
@@ -498,8 +498,8 @@ class DownloadFilesAbsWorkspaceTest extends TestCase
             'download/upload/' . $id2 . '.manifest'
         );
 
-        $id3 = $clientWrapper->getBasicClient()->uploadFile($root . '/upload', $fo);
-        $id4 = $clientWrapper->getBasicClient()->uploadFile($root . '/upload', $fo);
+        $id3 = $clientWrapper->getTableAndFileStorageClient()->uploadFile($root . '/upload', $fo);
+        $id4 = $clientWrapper->getTableAndFileStorageClient()->uploadFile($root . '/upload', $fo);
         sleep(2);
 
         $newOutputFileStateList = $reader->downloadFiles(

--- a/libs/input-mapping/tests/Functional/DownloadFilesAdaptiveBranchTest.php
+++ b/libs/input-mapping/tests/Functional/DownloadFilesAdaptiveBranchTest.php
@@ -46,11 +46,11 @@ class DownloadFilesAdaptiveBranchTest extends DownloadFilesTestAbstract
 
         $branchTag = sprintf('%s-%s', $branchId, self::TEST_FILE_TAG_FOR_BRANCH);
 
-        $file1Id = $clientWrapper->getBasicClient()->uploadFile(
+        $file1Id = $clientWrapper->getTableAndFileStorageClient()->uploadFile(
             $root . '/upload',
             (new FileUploadOptions())->setTags([$branchTag])
         );
-        $file2Id = $clientWrapper->getBasicClient()->uploadFile(
+        $file2Id = $clientWrapper->getTableAndFileStorageClient()->uploadFile(
             $root . '/upload',
             (new FileUploadOptions())->setTags([self::TEST_FILE_TAG_FOR_BRANCH])
         );
@@ -103,7 +103,7 @@ class DownloadFilesAdaptiveBranchTest extends DownloadFilesTestAbstract
             )
         ));
         // add another valid file and assert that it gets downloaded and the previous doesn't
-        $file3Id = $clientWrapper->getBasicClient()->uploadFile(
+        $file3Id = $clientWrapper->getTableAndFileStorageClient()->uploadFile(
             $root . '/upload',
             (new FileUploadOptions())->setTags([$branchTag, sprintf('%s-adaptive', $branchId)])
         );

--- a/libs/input-mapping/tests/Functional/DownloadFilesAdaptiveTest.php
+++ b/libs/input-mapping/tests/Functional/DownloadFilesAdaptiveTest.php
@@ -16,11 +16,11 @@ class DownloadFilesAdaptiveTest extends DownloadFilesTestAbstract
         $root = $this->temp->getTmpFolder();
         file_put_contents($root . '/upload', 'test');
 
-        $id1 = $this->clientWrapper->getBasicClient()->uploadFile(
+        $id1 = $this->clientWrapper->getTableAndFileStorageClient()->uploadFile(
             $root . '/upload',
             (new FileUploadOptions())->setTags([self::DEFAULT_TEST_FILE_TAG, 'adaptive'])
         );
-        $id2 = $this->clientWrapper->getBasicClient()->uploadFile(
+        $id2 = $this->clientWrapper->getTableAndFileStorageClient()->uploadFile(
             $root . '/upload',
             (new FileUploadOptions())->setTags([self::DEFAULT_TEST_FILE_TAG, 'adaptive', 'test 2'])
         );
@@ -57,11 +57,11 @@ class DownloadFilesAdaptiveTest extends DownloadFilesTestAbstract
         self::assertFileExists($root . '/download/' . $id2 . '_upload.manifest');
 
         // now load some new files and make sure we just grab the latest since the last run
-        $id3 = $this->clientWrapper->getBasicClient()->uploadFile(
+        $id3 = $this->clientWrapper->getTableAndFileStorageClient()->uploadFile(
             $root . '/upload',
             (new FileUploadOptions())->setTags([self::DEFAULT_TEST_FILE_TAG, 'adaptive', 'test 3'])
         );
-        $id4 = $this->clientWrapper->getBasicClient()->uploadFile(
+        $id4 = $this->clientWrapper->getTableAndFileStorageClient()->uploadFile(
             $root . '/upload',
             (new FileUploadOptions())->setTags([self::DEFAULT_TEST_FILE_TAG, 'adaptive', 'test 4'])
         );
@@ -93,15 +93,15 @@ class DownloadFilesAdaptiveTest extends DownloadFilesTestAbstract
         $root = $this->temp->getTmpFolder();
         file_put_contents($root . '/upload', 'test');
 
-        $id1 = $this->clientWrapper->getBasicClient()->uploadFile(
+        $id1 = $this->clientWrapper->getTableAndFileStorageClient()->uploadFile(
             $root . '/upload',
             (new FileUploadOptions())->setTags([self::DEFAULT_TEST_FILE_TAG, 'adaptive'])
         );
-        $id2 = $this->clientWrapper->getBasicClient()->uploadFile(
+        $id2 = $this->clientWrapper->getTableAndFileStorageClient()->uploadFile(
             $root . '/upload',
             (new FileUploadOptions())->setTags([self::DEFAULT_TEST_FILE_TAG, 'adaptive', 'test 2'])
         );
-        $idExclude = $this->clientWrapper->getBasicClient()->uploadFile(
+        $idExclude = $this->clientWrapper->getTableAndFileStorageClient()->uploadFile(
             $root . '/upload',
             (new FileUploadOptions())->setTags([self::DEFAULT_TEST_FILE_TAG, 'adaptive', 'exclude'])
         );
@@ -146,11 +146,11 @@ class DownloadFilesAdaptiveTest extends DownloadFilesTestAbstract
         self::assertFileDoesNotExist($root . '/download/' . $idExclude . '_upload');
 
         // now load some new files and make sure we just grab the latest since the last run
-        $id3 = $this->clientWrapper->getBasicClient()->uploadFile(
+        $id3 = $this->clientWrapper->getTableAndFileStorageClient()->uploadFile(
             $root . '/upload',
             (new FileUploadOptions())->setTags([self::DEFAULT_TEST_FILE_TAG, 'adaptive', 'test 3'])
         );
-        $id4 = $this->clientWrapper->getBasicClient()->uploadFile(
+        $id4 = $this->clientWrapper->getTableAndFileStorageClient()->uploadFile(
             $root . '/upload',
             (new FileUploadOptions())->setTags([self::DEFAULT_TEST_FILE_TAG, 'adaptive', 'test 4'])
         );
@@ -203,11 +203,11 @@ class DownloadFilesAdaptiveTest extends DownloadFilesTestAbstract
         $root = $this->temp->getTmpFolder();
         file_put_contents($root . '/upload', 'test');
 
-        $id1 = $this->clientWrapper->getBasicClient()->uploadFile(
+        $id1 = $this->clientWrapper->getTableAndFileStorageClient()->uploadFile(
             $root . '/upload',
             (new FileUploadOptions())->setTags([self::DEFAULT_TEST_FILE_TAG, 'adaptive'])
         );
-        $id2 = $this->clientWrapper->getBasicClient()->uploadFile(
+        $id2 = $this->clientWrapper->getTableAndFileStorageClient()->uploadFile(
             $root . '/upload',
             (new FileUploadOptions())->setTags([self::DEFAULT_TEST_FILE_TAG, 'adaptive', 'test 2'])
         );
@@ -259,11 +259,11 @@ class DownloadFilesAdaptiveTest extends DownloadFilesTestAbstract
         $root = $this->temp->getTmpFolder();
         file_put_contents($root . '/upload', 'test');
 
-        $id1 = $this->clientWrapper->getBasicClient()->uploadFile(
+        $id1 = $this->clientWrapper->getTableAndFileStorageClient()->uploadFile(
             $root . '/upload',
             (new FileUploadOptions())->setTags([self::DEFAULT_TEST_FILE_TAG, 'adaptive'])
         );
-        $id2 = $this->clientWrapper->getBasicClient()->uploadFile(
+        $id2 = $this->clientWrapper->getTableAndFileStorageClient()->uploadFile(
             $root . '/upload',
             (new FileUploadOptions())->setTags([self::DEFAULT_TEST_FILE_TAG, 'adaptive', 'test 2'])
         );

--- a/libs/input-mapping/tests/Functional/DownloadFilesBranchTest.php
+++ b/libs/input-mapping/tests/Functional/DownloadFilesBranchTest.php
@@ -53,9 +53,9 @@ class DownloadFilesBranchTest extends DownloadFilesTestAbstract
         $file3 = new FileUploadOptions();
         $file3->setTags(['tag-1', sprintf('%s-tag-2', $branchId)]);
 
-        $id1 = $clientWrapper->getBasicClient()->uploadFile($root . '/upload', $file1);
-        $id2 = $clientWrapper->getBasicClient()->uploadFile($root . '/upload', $file2);
-        $id3 = $clientWrapper->getBasicClient()->uploadFile($root . '/upload', $file3);
+        $id1 = $clientWrapper->getTableAndFileStorageClient()->uploadFile($root . '/upload', $file1);
+        $id2 = $clientWrapper->getTableAndFileStorageClient()->uploadFile($root . '/upload', $file2);
+        $id3 = $clientWrapper->getTableAndFileStorageClient()->uploadFile($root . '/upload', $file3);
 
         sleep(5);
 
@@ -157,11 +157,11 @@ class DownloadFilesBranchTest extends DownloadFilesTestAbstract
 
         $branchTag = sprintf('%s-%s', $branchId, self::TEST_FILE_TAG_FOR_BRANCH);
 
-        $file1Id = $clientWrapper->getBasicClient()->uploadFile(
+        $file1Id = $clientWrapper->getTableAndFileStorageClient()->uploadFile(
             $root . '/upload',
             (new FileUploadOptions())->setTags([$branchTag])
         );
-        $file2Id = $clientWrapper->getBasicClient()->uploadFile(
+        $file2Id = $clientWrapper->getTableAndFileStorageClient()->uploadFile(
             $root . '/upload',
             (new FileUploadOptions())->setTags([self::TEST_FILE_TAG_FOR_BRANCH])
         );
@@ -217,23 +217,23 @@ class DownloadFilesBranchTest extends DownloadFilesTestAbstract
         $branchProcessedTag = sprintf('%s-processed-%s', $branchId, self::TEST_FILE_TAG_FOR_BRANCH);
         $excludeTag = sprintf('exclude-%s', self::TEST_FILE_TAG_FOR_BRANCH);
 
-        $file1Id = $clientWrapper->getBasicClient()->uploadFile(
+        $file1Id = $clientWrapper->getTableAndFileStorageClient()->uploadFile(
             $root . '/upload',
             (new FileUploadOptions())->setTags([$branchTag])
         );
-        $file2Id = $clientWrapper->getBasicClient()->uploadFile(
+        $file2Id = $clientWrapper->getTableAndFileStorageClient()->uploadFile(
             $root . '/upload',
             (new FileUploadOptions())->setTags([self::TEST_FILE_TAG_FOR_BRANCH])
         );
-        $processedFileId = $clientWrapper->getBasicClient()->uploadFile(
+        $processedFileId = $clientWrapper->getTableAndFileStorageClient()->uploadFile(
             $root . '/upload',
             (new FileUploadOptions())->setTags([$branchTag, $processedTag])
         );
-        $branchProcessedFileId = $clientWrapper->getBasicClient()->uploadFile(
+        $branchProcessedFileId = $clientWrapper->getTableAndFileStorageClient()->uploadFile(
             $root . '/upload',
             (new FileUploadOptions())->setTags([$branchTag, $branchProcessedTag])
         );
-        $excludeFileId = $clientWrapper->getBasicClient()->uploadFile(
+        $excludeFileId = $clientWrapper->getTableAndFileStorageClient()->uploadFile(
             $root . '/upload',
             (new FileUploadOptions())->setTags([$branchTag, $excludeTag])
         );
@@ -285,10 +285,10 @@ class DownloadFilesBranchTest extends DownloadFilesTestAbstract
             [$branchTag, $processedTag]
         );
 
-        $clientWrapper->getBasicClient()->deleteFile($file1Id);
-        $clientWrapper->getBasicClient()->deleteFile($excludeFileId);
-        $clientWrapper->getBasicClient()->deleteFile($processedFileId);
-        $clientWrapper->getBasicClient()->deleteFile($branchProcessedFileId);
+        $clientWrapper->getTableAndFileStorageClient()->deleteFile($file1Id);
+        $clientWrapper->getTableAndFileStorageClient()->deleteFile($excludeFileId);
+        $clientWrapper->getTableAndFileStorageClient()->deleteFile($processedFileId);
+        $clientWrapper->getTableAndFileStorageClient()->deleteFile($branchProcessedFileId);
     }
 
     private function assertManifestTags(string $manifestPath, array $tags): void

--- a/libs/input-mapping/tests/Functional/DownloadFilesRedshiftTest.php
+++ b/libs/input-mapping/tests/Functional/DownloadFilesRedshiftTest.php
@@ -69,8 +69,8 @@ class DownloadFilesRedshiftTest extends AbstractTestCase
         $csv = new CsvFile($root . '/upload.csv');
         $csv->writeRow(['Id', 'Name']);
         $csv->writeRow(['test', 'test']);
-        $tableId = $clientWrapper->getBasicClient()->createTableAsync($this->redshiftBucketId, 'test_file', $csv);
-        $table = $clientWrapper->getBasicClient()->exportTableAsync($tableId);
+        $tableId = $clientWrapper->getTableAndFileStorageClient()->createTableAsync($this->redshiftBucketId, 'test_file', $csv);
+        $table = $clientWrapper->getTableAndFileStorageClient()->exportTableAsync($tableId);
         $fileId = $table['file']['id'];
 
         $reader = new Reader($this->getStagingFactory($clientWrapper, $root));

--- a/libs/input-mapping/tests/Functional/DownloadFilesRedshiftTest.php
+++ b/libs/input-mapping/tests/Functional/DownloadFilesRedshiftTest.php
@@ -69,7 +69,11 @@ class DownloadFilesRedshiftTest extends AbstractTestCase
         $csv = new CsvFile($root . '/upload.csv');
         $csv->writeRow(['Id', 'Name']);
         $csv->writeRow(['test', 'test']);
-        $tableId = $clientWrapper->getTableAndFileStorageClient()->createTableAsync($this->redshiftBucketId, 'test_file', $csv);
+        $tableId = $clientWrapper->getTableAndFileStorageClient()->createTableAsync(
+            $this->redshiftBucketId,
+            'test_file',
+            $csv
+        );
         $table = $clientWrapper->getTableAndFileStorageClient()->exportTableAsync($tableId);
         $fileId = $table['file']['id'];
 

--- a/libs/input-mapping/tests/Functional/DownloadFilesTest.php
+++ b/libs/input-mapping/tests/Functional/DownloadFilesTest.php
@@ -26,11 +26,11 @@ class DownloadFilesTest extends DownloadFilesTestAbstract
         file_put_contents($root . '/upload', 'test');
         file_put_contents($root . '/upload_second', 'test');
 
-        $id1 = $this->clientWrapper->getBasicClient()->uploadFile(
+        $id1 = $this->clientWrapper->getTableAndFileStorageClient()->uploadFile(
             $root . '/upload',
             (new FileUploadOptions())->setTags([self::DEFAULT_TEST_FILE_TAG])
         );
-        $id2 = $this->clientWrapper->getBasicClient()->uploadFile(
+        $id2 = $this->clientWrapper->getTableAndFileStorageClient()->uploadFile(
             $root . '/upload_second',
             (new FileUploadOptions())->setTags([self::DEFAULT_TEST_FILE_TAG])
         );
@@ -73,7 +73,7 @@ class DownloadFilesTest extends DownloadFilesTestAbstract
         $root = $this->temp->getTmpFolder();
         file_put_contents($root . '/upload', 'test');
 
-        $id1 = $this->clientWrapper->getBasicClient()->uploadFile(
+        $id1 = $this->clientWrapper->getTableAndFileStorageClient()->uploadFile(
             $root . '/upload',
             (new FileUploadOptions())->setTags([self::DEFAULT_TEST_FILE_TAG])
         );
@@ -120,15 +120,15 @@ class DownloadFilesTest extends DownloadFilesTestAbstract
         $fo = new FileUploadOptions();
         $fo->setTags([self::DEFAULT_TEST_FILE_TAG]);
 
-        $this->clientWrapper->getBasicClient()->setRunId('xyz');
-        $id1 = $this->clientWrapper->getBasicClient()->uploadFile($root . '/upload', $fo);
-        $id2 = $this->clientWrapper->getBasicClient()->uploadFile($root . '/upload', $fo);
-        $this->clientWrapper->getBasicClient()->setRunId('1234567');
-        $id3 = $this->clientWrapper->getBasicClient()->uploadFile($root . '/upload', $fo);
-        $id4 = $this->clientWrapper->getBasicClient()->uploadFile($root . '/upload', $fo);
-        $this->clientWrapper->getBasicClient()->setRunId('1234567.8901234');
-        $id5 = $this->clientWrapper->getBasicClient()->uploadFile($root . '/upload', $fo);
-        $id6 = $this->clientWrapper->getBasicClient()->uploadFile($root . '/upload', $fo);
+        $this->clientWrapper->getTableAndFileStorageClient()->setRunId('xyz');
+        $id1 = $this->clientWrapper->getTableAndFileStorageClient()->uploadFile($root . '/upload', $fo);
+        $id2 = $this->clientWrapper->getTableAndFileStorageClient()->uploadFile($root . '/upload', $fo);
+        $this->clientWrapper->getTableAndFileStorageClient()->setRunId('1234567');
+        $id3 = $this->clientWrapper->getTableAndFileStorageClient()->uploadFile($root . '/upload', $fo);
+        $id4 = $this->clientWrapper->getTableAndFileStorageClient()->uploadFile($root . '/upload', $fo);
+        $this->clientWrapper->getTableAndFileStorageClient()->setRunId('1234567.8901234');
+        $id5 = $this->clientWrapper->getTableAndFileStorageClient()->uploadFile($root . '/upload', $fo);
+        $id6 = $this->clientWrapper->getTableAndFileStorageClient()->uploadFile($root . '/upload', $fo);
         sleep(5);
 
         $configuration = [
@@ -168,9 +168,9 @@ class DownloadFilesTest extends DownloadFilesTestAbstract
         $file3 = new FileUploadOptions();
         $file3->setTags(['tag-1', 'tag-2', 'tag-3']);
 
-        $id1 = $this->clientWrapper->getBasicClient()->uploadFile($root . '/upload', $file1);
-        $id2 = $this->clientWrapper->getBasicClient()->uploadFile($root . '/upload', $file2);
-        $id3 = $this->clientWrapper->getBasicClient()->uploadFile($root . '/upload', $file3);
+        $id1 = $this->clientWrapper->getTableAndFileStorageClient()->uploadFile($root . '/upload', $file1);
+        $id2 = $this->clientWrapper->getTableAndFileStorageClient()->uploadFile($root . '/upload', $file2);
+        $id3 = $this->clientWrapper->getTableAndFileStorageClient()->uploadFile($root . '/upload', $file3);
 
         sleep(5);
 
@@ -218,9 +218,9 @@ class DownloadFilesTest extends DownloadFilesTestAbstract
         $file3 = new FileUploadOptions();
         $file3->setTags(['tag-1', 'tag-2', 'tag-3']);
 
-        $id1 = $this->clientWrapper->getBasicClient()->uploadFile($root . '/upload', $file1);
-        $id2 = $this->clientWrapper->getBasicClient()->uploadFile($root . '/upload', $file2);
-        $id3 = $this->clientWrapper->getBasicClient()->uploadFile($root . '/upload', $file3);
+        $id1 = $this->clientWrapper->getTableAndFileStorageClient()->uploadFile($root . '/upload', $file1);
+        $id2 = $this->clientWrapper->getTableAndFileStorageClient()->uploadFile($root . '/upload', $file2);
+        $id3 = $this->clientWrapper->getTableAndFileStorageClient()->uploadFile($root . '/upload', $file3);
 
         sleep(5);
 
@@ -269,8 +269,8 @@ class DownloadFilesTest extends DownloadFilesTestAbstract
         $file2 = new FileUploadOptions();
         $file2->setTags(['tag-1', 'tag-2']);
 
-        $id1 = $this->clientWrapper->getBasicClient()->uploadFile($root . '/upload', $file1);
-        $id2 = $this->clientWrapper->getBasicClient()->uploadFile($root . '/upload', $file2);
+        $id1 = $this->clientWrapper->getTableAndFileStorageClient()->uploadFile($root . '/upload', $file1);
+        $id2 = $this->clientWrapper->getTableAndFileStorageClient()->uploadFile($root . '/upload', $file2);
 
         sleep(5);
 
@@ -310,15 +310,15 @@ class DownloadFilesTest extends DownloadFilesTestAbstract
         $fo = new FileUploadOptions();
         $fo->setTags([self::DEFAULT_TEST_FILE_TAG]);
 
-        $this->clientWrapper->getBasicClient()->setRunId('xyz');
-        $id1 = $this->clientWrapper->getBasicClient()->uploadFile($root . '/upload', $fo);
-        $id2 = $this->clientWrapper->getBasicClient()->uploadFile($root . '/upload', $fo);
-        $this->clientWrapper->getBasicClient()->setRunId('1234567');
-        $id3 = $this->clientWrapper->getBasicClient()->uploadFile($root . '/upload', $fo);
-        $id4 = $this->clientWrapper->getBasicClient()->uploadFile($root . '/upload', $fo);
-        $this->clientWrapper->getBasicClient()->setRunId('1234567.8901234');
-        $id5 = $this->clientWrapper->getBasicClient()->uploadFile($root . '/upload', $fo);
-        $id6 = $this->clientWrapper->getBasicClient()->uploadFile($root . '/upload', $fo);
+        $this->clientWrapper->getTableAndFileStorageClient()->setRunId('xyz');
+        $id1 = $this->clientWrapper->getTableAndFileStorageClient()->uploadFile($root . '/upload', $fo);
+        $id2 = $this->clientWrapper->getTableAndFileStorageClient()->uploadFile($root . '/upload', $fo);
+        $this->clientWrapper->getTableAndFileStorageClient()->setRunId('1234567');
+        $id3 = $this->clientWrapper->getTableAndFileStorageClient()->uploadFile($root . '/upload', $fo);
+        $id4 = $this->clientWrapper->getTableAndFileStorageClient()->uploadFile($root . '/upload', $fo);
+        $this->clientWrapper->getTableAndFileStorageClient()->setRunId('1234567.8901234');
+        $id5 = $this->clientWrapper->getTableAndFileStorageClient()->uploadFile($root . '/upload', $fo);
+        $id6 = $this->clientWrapper->getTableAndFileStorageClient()->uploadFile($root . '/upload', $fo);
         sleep(5);
 
         $configuration = [
@@ -351,7 +351,7 @@ class DownloadFilesTest extends DownloadFilesTestAbstract
 
         // make at least 100 files in the project
         for ($i = 0; $i < 102; $i++) {
-            $this->clientWrapper->getBasicClient()->uploadFile(
+            $this->clientWrapper->getTableAndFileStorageClient()->uploadFile(
                 $root . '/upload',
                 (new FileUploadOptions())->setTags([self::DEFAULT_TEST_FILE_TAG])
             );
@@ -412,7 +412,7 @@ class DownloadFilesTest extends DownloadFilesTestAbstract
     public function testReadSlicedFileSnowflake(): void
     {
         // Create table and export it to produce a sliced file
-        $table = $this->clientWrapper->getBasicClient()->exportTableAsync($this->firstTableId);
+        $table = $this->clientWrapper->getTableAndFileStorageClient()->exportTableAsync($this->firstTableId);
         sleep(2);
         $fileId = $table['file']['id'];
 
@@ -458,7 +458,7 @@ class DownloadFilesTest extends DownloadFilesTestAbstract
         $fileUploadOptions
             ->setIsSliced(true)
             ->setFileName('empty_file');
-        $uploadFileId = $this->clientWrapper->getBasicClient()->uploadSlicedFile([], $fileUploadOptions);
+        $uploadFileId = $this->clientWrapper->getTableAndFileStorageClient()->uploadSlicedFile([], $fileUploadOptions);
         sleep(5);
 
         $reader = new Reader($this->getLocalStagingFactory($this->clientWrapper));
@@ -488,7 +488,7 @@ class DownloadFilesTest extends DownloadFilesTestAbstract
         $root = $this->temp->getTmpFolder();
         file_put_contents($root . '/upload', 'test');
 
-        $id = $this->clientWrapper->getBasicClient()->uploadFile(
+        $id = $this->clientWrapper->getTableAndFileStorageClient()->uploadFile(
             $root . '/upload',
             (new FileUploadOptions())->setTags([self::DEFAULT_TEST_FILE_TAG])
         );

--- a/libs/input-mapping/tests/Functional/DownloadFilesTestAbstract.php
+++ b/libs/input-mapping/tests/Functional/DownloadFilesTestAbstract.php
@@ -22,9 +22,9 @@ class DownloadFilesTestAbstract extends AbstractTestCase
         $options = new ListFilesOptions();
         $options->setTags([self::DEFAULT_TEST_FILE_TAG, self::TEST_FILE_TAG_FOR_BRANCH]);
         $options->setLimit(1000);
-        $files = $this->clientWrapper->getBasicClient()->listFiles($options);
+        $files = $this->clientWrapper->getTableAndFileStorageClient()->listFiles($options);
         foreach ($files as $file) {
-            $this->clientWrapper->getBasicClient()->deleteFile($file['id']);
+            $this->clientWrapper->getTableAndFileStorageClient()->deleteFile($file['id']);
         }
         sleep(2);
     }

--- a/libs/input-mapping/tests/Functional/DownloadTablesAdaptiveTest.php
+++ b/libs/input-mapping/tests/Functional/DownloadTablesAdaptiveTest.php
@@ -28,7 +28,7 @@ class DownloadTablesAdaptiveTest extends AbstractTestCase
                 'changed_since' => InputTableOptions::ADAPTIVE_INPUT_MAPPING_VALUE,
             ],
         ]);
-        $testTableInfo = $this->clientWrapper->getBasicClient()->getTable($this->firstTableId);
+        $testTableInfo = $this->clientWrapper->getTableAndFileStorageClient()->getTable($this->firstTableId);
         $inputTablesState = new InputTableStateList([
             [
                 'source' => $this->firstTableId,
@@ -77,13 +77,13 @@ class DownloadTablesAdaptiveTest extends AbstractTestCase
         $csv = new CsvFile($this->temp->getTmpFolder() . DIRECTORY_SEPARATOR . 'upload.csv');
         $csv->writeRow(['Id', 'Name', 'foo', 'bar']);
         $csv->writeRow(['id4', 'name4', 'foo4', 'bar4']);
-        $this->clientWrapper->getBasicClient()->writeTableAsync(
+        $this->clientWrapper->getTableAndFileStorageClient()->writeTableAsync(
             $this->firstTableId,
             $csv,
             ['incremental' => true]
         );
 
-        $updatedTestTableInfo = $this->clientWrapper->getBasicClient()->getTable($this->firstTableId);
+        $updatedTestTableInfo = $this->clientWrapper->getTableAndFileStorageClient()->getTable($this->firstTableId);
         $secondTablesResult = $reader->downloadTables(
             $configuration,
             $firstTablesResult->getInputTableStateList(),

--- a/libs/input-mapping/tests/Functional/DownloadTablesDefaultTest.php
+++ b/libs/input-mapping/tests/Functional/DownloadTablesDefaultTest.php
@@ -140,7 +140,7 @@ class DownloadTablesDefaultTest extends AbstractTestCase
                 ],
             ],
         ];
-        $metadata = new Metadata($this->clientWrapper->getBasicClient());
+        $metadata = new Metadata($this->clientWrapper->getTableAndFileStorageClient());
         $metadata->postTableMetadataWithColumns(
             new TableMetadataUpdateOptions(
                 $this->firstTableId,
@@ -208,7 +208,7 @@ class DownloadTablesDefaultTest extends AbstractTestCase
                 'value' => 'testReadTablesWithSourceSearch',
             ],
         ];
-        $metadata = new Metadata($this->clientWrapper->getBasicClient());
+        $metadata = new Metadata($this->clientWrapper->getTableAndFileStorageClient());
         $metadata->postTableMetadataWithColumns(
             new TableMetadataUpdateOptions($this->firstTableId, 'dataLoaderTest', $tableMetadata)
         );
@@ -274,7 +274,7 @@ class DownloadTablesDefaultTest extends AbstractTestCase
             ],
         ];
 
-        $metadata = new Metadata($this->clientWrapper->getBasicClient());
+        $metadata = new Metadata($this->clientWrapper->getTableAndFileStorageClient());
         $metadata->postTableMetadataWithColumns(
             new TableMetadataUpdateOptions(
                 $this->firstTableId,
@@ -394,7 +394,7 @@ class DownloadTablesDefaultTest extends AbstractTestCase
     #[NeedsTestTables]
     public function testReadTableLimitTest(): void
     {
-        $tokenInfo = $this->clientWrapper->getBasicClient()->verifyToken();
+        $tokenInfo = $this->clientWrapper->getBranchClientIfAvailable()->verifyToken();
         $tokenInfo['owner']['limits'][Local::EXPORT_SIZE_LIMIT_NAME] = [
             'name' => Local::EXPORT_SIZE_LIMIT_NAME,
             'value' => 10,
@@ -408,7 +408,8 @@ class DownloadTablesDefaultTest extends AbstractTestCase
         $client->method('verifyToken')->willReturn($tokenInfo);
         /** @var Client $client */
         $clientWrapper = self::createMock(ClientWrapper::class);
-        $clientWrapper->method('getBasicClient')->willReturn($client);
+        $clientWrapper->method('getBranchClientIfAvailable')->willReturn($client);
+        $clientWrapper->method('getTableAndFileStorageClient')->willReturn($client);
 
         $reader = new Reader($this->getLocalStagingFactory($clientWrapper));
         $configuration = new InputTableOptionsList([
@@ -450,7 +451,7 @@ class DownloadTablesDefaultTest extends AbstractTestCase
                 'destination' => 'test2.csv',
             ],
         ]);
-        $metadata = new Metadata($this->clientWrapper->getBasicClient());
+        $metadata = new Metadata($this->clientWrapper->getTableAndFileStorageClient());
         $metadata->postBucketMetadata(
             $this->testBucketId,
             'test',

--- a/libs/input-mapping/tests/Functional/DownloadTablesOutputTest.php
+++ b/libs/input-mapping/tests/Functional/DownloadTablesOutputTest.php
@@ -22,7 +22,7 @@ class DownloadTablesOutputTest extends AbstractTestCase
     #[NeedsTestTables(2)]
     public function testDownloadTablesResult(): void
     {
-        $metadataApi = new Metadata($this->clientWrapper->getBasicClient());
+        $metadataApi = new Metadata($this->clientWrapper->getTableAndFileStorageClient());
         $metadataApi->postTableMetadataWithColumns(
             new TableMetadataUpdateOptions(
                 $this->firstTableId,
@@ -59,8 +59,8 @@ class DownloadTablesOutputTest extends AbstractTestCase
             AbstractStrategyFactory::LOCAL,
             new ReaderOptions(true)
         );
-        $test1TableInfo = $this->clientWrapper->getBasicClient()->getTable($this->firstTableId);
-        $test2TableInfo = $this->clientWrapper->getBasicClient()->getTable($this->secondTableId);
+        $test1TableInfo = $this->clientWrapper->getTableAndFileStorageClient()->getTable($this->firstTableId);
+        $test2TableInfo = $this->clientWrapper->getTableAndFileStorageClient()->getTable($this->secondTableId);
         self::assertEquals(
             $test1TableInfo['lastImportDate'],
             $tablesResult->getInputTableStateList()->getTable($this->firstTableId)->getLastImportDate()

--- a/libs/input-mapping/tests/Functional/DownloadTablesRedshiftTest.php
+++ b/libs/input-mapping/tests/Functional/DownloadTablesRedshiftTest.php
@@ -93,7 +93,10 @@ class DownloadTablesRedshiftTest extends AbstractTestCase
 
         $options['columns'] = $columns;
         $options['dataFileId'] = $uploadFileId;
-        $this->clientWrapper->getTableAndFileStorageClient()->writeTableAsyncDirect($this->redshiftBucketId . '.empty', $options);
+        $this->clientWrapper->getTableAndFileStorageClient()->writeTableAsyncDirect(
+            $this->redshiftBucketId . '.empty',
+            $options
+        );
 
         $reader = new Reader($this->getLocalStagingFactory());
         $configuration = new InputTableOptionsList([

--- a/libs/input-mapping/tests/Functional/DownloadTablesRedshiftTest.php
+++ b/libs/input-mapping/tests/Functional/DownloadTablesRedshiftTest.php
@@ -80,11 +80,11 @@ class DownloadTablesRedshiftTest extends AbstractTestCase
         $fileUploadOptions
             ->setIsSliced(true)
             ->setFileName('emptyfile');
-        $uploadFileId = $this->clientWrapper->getBasicClient()->uploadSlicedFile([], $fileUploadOptions);
+        $uploadFileId = $this->clientWrapper->getTableAndFileStorageClient()->uploadSlicedFile([], $fileUploadOptions);
         $columns = ['Id', 'Name'];
         $headerCsvFile = new CsvFile($this->temp->getTmpFolder() . 'header.csv');
         $headerCsvFile->writeRow($columns);
-        $this->clientWrapper->getBasicClient()->createTableAsync(
+        $this->clientWrapper->getTableAndFileStorageClient()->createTableAsync(
             $this->redshiftBucketId,
             'empty',
             $headerCsvFile,
@@ -93,7 +93,7 @@ class DownloadTablesRedshiftTest extends AbstractTestCase
 
         $options['columns'] = $columns;
         $options['dataFileId'] = $uploadFileId;
-        $this->clientWrapper->getBasicClient()->writeTableAsyncDirect($this->redshiftBucketId . '.empty', $options);
+        $this->clientWrapper->getTableAndFileStorageClient()->writeTableAsyncDirect($this->redshiftBucketId . '.empty', $options);
 
         $reader = new Reader($this->getLocalStagingFactory());
         $configuration = new InputTableOptionsList([

--- a/libs/input-mapping/tests/Functional/DownloadTablesSynapseTest.php
+++ b/libs/input-mapping/tests/Functional/DownloadTablesSynapseTest.php
@@ -53,7 +53,11 @@ class DownloadTablesSynapseTest extends AbstractTestCase
         $csv = new CsvFile($this->temp->getTmpFolder() . DIRECTORY_SEPARATOR . 'upload.csv');
         $csv->writeRow(['Id', 'Name']);
         $csv->writeRow(['test', 'test']);
-        $this->clientWrapper->getTableAndFileStorageClient()->createTableAsync('in.c-docker-test-synapse', 'test', $csv);
+        $this->clientWrapper->getTableAndFileStorageClient()->createTableAsync(
+            'in.c-docker-test-synapse',
+            'test',
+            $csv
+        );
     }
 
     protected function initClient(): void
@@ -157,7 +161,10 @@ class DownloadTablesSynapseTest extends AbstractTestCase
 
         $options['columns'] = $columns;
         $options['dataFileId'] = $uploadFileId;
-        $this->clientWrapper->getTableAndFileStorageClient()->writeTableAsyncDirect('in.c-docker-test-synapse.empty', $options);
+        $this->clientWrapper->getTableAndFileStorageClient()->writeTableAsyncDirect(
+            'in.c-docker-test-synapse.empty',
+            $options
+        );
 
         $reader = new Reader($this->getLocalStagingFactory());
         $configuration = new InputTableOptionsList([

--- a/libs/input-mapping/tests/Functional/DownloadTablesSynapseTest.php
+++ b/libs/input-mapping/tests/Functional/DownloadTablesSynapseTest.php
@@ -30,7 +30,7 @@ class DownloadTablesSynapseTest extends AbstractTestCase
             return;
         }
         try {
-            $this->clientWrapper->getBasicClient()->dropBucket(
+            $this->clientWrapper->getTableAndFileStorageClient()->dropBucket(
                 'in.c-docker-test-synapse',
                 [
                     'force' => true,
@@ -42,7 +42,7 @@ class DownloadTablesSynapseTest extends AbstractTestCase
                 throw $e;
             }
         }
-        $this->clientWrapper->getBasicClient()->createBucket(
+        $this->clientWrapper->getTableAndFileStorageClient()->createBucket(
             'docker-test-synapse',
             Client::STAGE_IN,
             'Docker Testsuite',
@@ -53,7 +53,7 @@ class DownloadTablesSynapseTest extends AbstractTestCase
         $csv = new CsvFile($this->temp->getTmpFolder() . DIRECTORY_SEPARATOR . 'upload.csv');
         $csv->writeRow(['Id', 'Name']);
         $csv->writeRow(['test', 'test']);
-        $this->clientWrapper->getBasicClient()->createTableAsync('in.c-docker-test-synapse', 'test', $csv);
+        $this->clientWrapper->getTableAndFileStorageClient()->createTableAsync('in.c-docker-test-synapse', 'test', $csv);
     }
 
     protected function initClient(): void
@@ -65,14 +65,14 @@ class DownloadTablesSynapseTest extends AbstractTestCase
             ),
         );
 
-        $tokenInfo = $this->clientWrapper->getBasicClient()->verifyToken();
+        $tokenInfo = $this->clientWrapper->getBranchClientIfAvailable()->verifyToken();
         print(sprintf(
             'Authorized as "%s (%s)" to project "%s (%s)" at "%s" stack.',
             $tokenInfo['description'],
             $tokenInfo['id'],
             $tokenInfo['owner']['name'],
             $tokenInfo['owner']['id'],
-            $this->clientWrapper->getBasicClient()->getApiUrl()
+            $this->clientWrapper->getBranchClientIfAvailable()->getApiUrl()
         ));
     }
 
@@ -144,11 +144,11 @@ class DownloadTablesSynapseTest extends AbstractTestCase
         $fileUploadOptions
             ->setIsSliced(true)
             ->setFileName('emptyfile');
-        $uploadFileId = $this->clientWrapper->getBasicClient()->uploadSlicedFile([], $fileUploadOptions);
+        $uploadFileId = $this->clientWrapper->getTableAndFileStorageClient()->uploadSlicedFile([], $fileUploadOptions);
         $columns = ['Id', 'Name'];
         $headerCsvFile = new CsvFile($this->temp->getTmpFolder() . 'header.csv');
         $headerCsvFile->writeRow($columns);
-        $this->clientWrapper->getBasicClient()->createTableAsync(
+        $this->clientWrapper->getTableAndFileStorageClient()->createTableAsync(
             'in.c-docker-test-synapse',
             'empty',
             $headerCsvFile,
@@ -157,7 +157,7 @@ class DownloadTablesSynapseTest extends AbstractTestCase
 
         $options['columns'] = $columns;
         $options['dataFileId'] = $uploadFileId;
-        $this->clientWrapper->getBasicClient()->writeTableAsyncDirect('in.c-docker-test-synapse.empty', $options);
+        $this->clientWrapper->getTableAndFileStorageClient()->writeTableAsyncDirect('in.c-docker-test-synapse.empty', $options);
 
         $reader = new Reader($this->getLocalStagingFactory());
         $configuration = new InputTableOptionsList([

--- a/libs/input-mapping/tests/Functional/DownloadTablesWorkspaceAbsTest.php
+++ b/libs/input-mapping/tests/Functional/DownloadTablesWorkspaceAbsTest.php
@@ -41,14 +41,14 @@ class DownloadTablesWorkspaceAbsTest extends AbstractTestCase
                 (string) getenv('SYNAPSE_STORAGE_API_TOKEN')
             ),
         );
-        $tokenInfo = $this->clientWrapper->getBasicClient()->verifyToken();
+        $tokenInfo = $this->clientWrapper->getBranchClientIfAvailable()->verifyToken();
         print(sprintf(
             'Authorized as "%s (%s)" to project "%s (%s)" at "%s" stack.',
             $tokenInfo['description'],
             $tokenInfo['id'],
             $tokenInfo['owner']['name'],
             $tokenInfo['owner']['id'],
-            $this->clientWrapper->getBasicClient()->getApiUrl()
+            $this->clientWrapper->getBranchClientIfAvailable()->getApiUrl()
         ));
     }
 

--- a/libs/input-mapping/tests/Functional/DownloadTablesWorkspaceRedshiftTest.php
+++ b/libs/input-mapping/tests/Functional/DownloadTablesWorkspaceRedshiftTest.php
@@ -68,7 +68,10 @@ class DownloadTablesWorkspaceRedshiftTest extends AbstractTestCase
             Client::STAGE_OUT
         );
         if ($bucketId !== null) {
-            $this->clientWrapper->getTableAndFileStorageClient()->dropBucket($bucketId, ['force' => true, 'async' => true]);
+            $this->clientWrapper->getTableAndFileStorageClient()->dropBucket(
+                $bucketId,
+                ['force' => true, 'async' => true]
+            );
         }
 
         $this->emptyOutputBucketId = $this->clientWrapper->getTableAndFileStorageClient()->createBucket(

--- a/libs/input-mapping/tests/Functional/DownloadTablesWorkspaceRedshiftTest.php
+++ b/libs/input-mapping/tests/Functional/DownloadTablesWorkspaceRedshiftTest.php
@@ -68,10 +68,10 @@ class DownloadTablesWorkspaceRedshiftTest extends AbstractTestCase
             Client::STAGE_OUT
         );
         if ($bucketId !== null) {
-            $this->clientWrapper->getBasicClient()->dropBucket($bucketId, ['force' => true, 'async' => true]);
+            $this->clientWrapper->getTableAndFileStorageClient()->dropBucket($bucketId, ['force' => true, 'async' => true]);
         }
 
-        $this->emptyOutputBucketId = $this->clientWrapper->getBasicClient()->createBucket(
+        $this->emptyOutputBucketId = $this->clientWrapper->getTableAndFileStorageClient()->createBucket(
             'input-mapping-test-rs',
             Client::STAGE_OUT,
             'Docker Testsuite',
@@ -82,17 +82,17 @@ class DownloadTablesWorkspaceRedshiftTest extends AbstractTestCase
         $manifest = $adapter->readFromFile($this->temp->getTmpFolder() . '/download/test1.manifest');
         self::assertEquals($this->firstTableId, $manifest['id']);
         // test that the table exists in the workspace
-        $tableId = $this->clientWrapper->getBasicClient()->createTableAsyncDirect(
+        $tableId = $this->clientWrapper->getTableAndFileStorageClient()->createTableAsyncDirect(
             $bucketId,
             ['dataWorkspaceId' => $this->workspaceId, 'dataTableName' => 'test1', 'name' => 'test1']
         );
         self::assertEquals($bucketId . '.test1', $tableId);
-        $table = $this->clientWrapper->getBasicClient()->getTable($tableId);
+        $table = $this->clientWrapper->getTableAndFileStorageClient()->getTable($tableId);
         self::assertEquals(['id'], $table['columns']);
 
         $manifest = $adapter->readFromFile($this->temp->getTmpFolder() . '/download/test2.manifest');
         self::assertEquals($this->secondTableId, $manifest['id']);
-        $tableId = $this->clientWrapper->getBasicClient()->createTableAsyncDirect(
+        $tableId = $this->clientWrapper->getTableAndFileStorageClient()->createTableAsyncDirect(
             $bucketId,
             ['dataWorkspaceId' => $this->workspaceId, 'dataTableName' => 'test2', 'name' => 'test2']
         );

--- a/libs/input-mapping/tests/Functional/DownloadTablesWorkspaceSnowflakeTest.php
+++ b/libs/input-mapping/tests/Functional/DownloadTablesWorkspaceSnowflakeTest.php
@@ -63,7 +63,7 @@ class DownloadTablesWorkspaceSnowflakeTest extends AbstractTestCase
         /* we want to check that the table exists in the workspace, so we try to load it, which fails, because of
             the _timestamp columns, but that's okay. It means that the table is indeed in the workspace. */
         try {
-            $this->clientWrapper->getBasicClient()->createTableAsyncDirect(
+            $this->clientWrapper->getTableAndFileStorageClient()->createTableAsyncDirect(
                 $this->firstTableId,
                 ['dataWorkspaceId' => $this->workspaceId, 'dataTableName' => 'test1', 'name' => 'test1']
             );
@@ -75,21 +75,21 @@ class DownloadTablesWorkspaceSnowflakeTest extends AbstractTestCase
         // this is copy, so it doesn't contain the _timestamp column
         $manifest = $adapter->readFromFile($this->temp->getTmpFolder() . '/download/test2.manifest');
         self::assertEquals($this->secondTableId, $manifest['id']);
-        $this->clientWrapper->getBasicClient()->createTableAsyncDirect(
+        $this->clientWrapper->getTableAndFileStorageClient()->createTableAsyncDirect(
             $this->emptyOutputBucketId,
             ['dataWorkspaceId' => $this->workspaceId, 'dataTableName' => 'test2', 'name' => 'test2']
         );
-        self::assertTrue($this->clientWrapper->getBasicClient()->tableExists($this->emptyOutputBucketId . '.test2'));
+        self::assertTrue($this->clientWrapper->getTableAndFileStorageClient()->tableExists($this->emptyOutputBucketId . '.test2'));
 
         $manifest = $adapter->readFromFile($this->temp->getTmpFolder() . '/download/test3.manifest');
         self::assertEquals($this->thirdTableId, $manifest['id']);
         /* we want to check that the table exists in the workspace, so we try to load it. This time it
             doesn't fail because keep_internal_timestamp_column=false was provided */
-        $this->clientWrapper->getBasicClient()->createTableAsyncDirect(
+        $this->clientWrapper->getTableAndFileStorageClient()->createTableAsyncDirect(
             $this->emptyOutputBucketId,
             ['dataWorkspaceId' => $this->workspaceId, 'dataTableName' => 'test3', 'name' => 'test3']
         );
-        self::assertTrue($this->clientWrapper->getBasicClient()->tableExists($this->emptyOutputBucketId . '.test3'));
+        self::assertTrue($this->clientWrapper->getTableAndFileStorageClient()->tableExists($this->emptyOutputBucketId . '.test3'));
         self::assertTrue($logger->hasInfoThatContains('Using "workspace-snowflake" table input staging.'));
         self::assertTrue($logger->hasInfoThatContains(sprintf('Table "%s" will be cloned.', $this->firstTableId)));
         self::assertTrue($logger->hasInfoThatContains(sprintf('Table "%s" will be copied.', $this->secondTableId)));
@@ -99,7 +99,7 @@ class DownloadTablesWorkspaceSnowflakeTest extends AbstractTestCase
         self::assertTrue($logger->hasInfoThatContains('Processed 2 workspace exports.'));
         // test that the clone jobs are merged into a single one
         sleep(2);
-        $jobs = $this->clientWrapper->getBasicClient()->listJobs(['limit' => 20]);
+        $jobs = $this->clientWrapper->getTableAndFileStorageClient()->listJobs(['limit' => 20]);
         $params = null;
         foreach ($jobs as $job) {
             if ($job['operationName'] === 'workspaceLoadClone') {
@@ -179,7 +179,7 @@ class DownloadTablesWorkspaceSnowflakeTest extends AbstractTestCase
             $manifest['columns']
         );
         // check that the table exists in the workspace
-        $this->clientWrapper->getBasicClient()->createTableAsyncDirect(
+        $this->clientWrapper->getTableAndFileStorageClient()->createTableAsyncDirect(
             $this->emptyOutputBucketId,
             ['dataWorkspaceId' => $this->workspaceId, 'dataTableName' => 'test2', 'name' => 'test2']
         );
@@ -268,7 +268,7 @@ class DownloadTablesWorkspaceSnowflakeTest extends AbstractTestCase
             $manifest['columns']
         );
         // check that the table exists in the workspace
-        $this->clientWrapper->getBasicClient()->createTableAsyncDirect(
+        $this->clientWrapper->getTableAndFileStorageClient()->createTableAsyncDirect(
             $this->emptyOutputBucketId,
             ['dataWorkspaceId' => $this->workspaceId, 'dataTableName' => 'test2', 'name' => 'test2']
         );
@@ -304,7 +304,7 @@ class DownloadTablesWorkspaceSnowflakeTest extends AbstractTestCase
         /* we want to check that the table exists in the workspace, so we try to load it, which fails, because of
             the _timestamp columns, but that's okay. It means that the table is indeed in the workspace. */
         try {
-            $this->clientWrapper->getBasicClient()->createTableAsyncDirect(
+            $this->clientWrapper->getTableAndFileStorageClient()->createTableAsyncDirect(
                 $this->emptyOutputBucketId,
                 ['dataWorkspaceId' => $this->workspaceId, 'dataTableName' => 'test2', 'name' => 'test2', 'columns']
             );
@@ -396,7 +396,7 @@ class DownloadTablesWorkspaceSnowflakeTest extends AbstractTestCase
         );
         // the initial_table should not be present in the workspace anymore
         try {
-            $this->clientWrapper->getBasicClient()->createTableAsyncDirect(
+            $this->clientWrapper->getTableAndFileStorageClient()->createTableAsyncDirect(
                 $this->emptyOutputBucketId,
                 [
                     'dataWorkspaceId' => $this->workspaceId,
@@ -414,7 +414,7 @@ class DownloadTablesWorkspaceSnowflakeTest extends AbstractTestCase
 
         // check that the tables exist in the workspace. the cloned table will throw the _timestamp col error
         try {
-            $this->clientWrapper->getBasicClient()->createTableAsyncDirect(
+            $this->clientWrapper->getTableAndFileStorageClient()->createTableAsyncDirect(
                 $this->emptyOutputBucketId,
                 [
                     'dataWorkspaceId' => $this->workspaceId,
@@ -426,7 +426,7 @@ class DownloadTablesWorkspaceSnowflakeTest extends AbstractTestCase
             self::assertStringContainsString('Invalid columns: _timestamp:', $exception->getMessage());
         }
 
-        $this->clientWrapper->getBasicClient()->createTableAsyncDirect(
+        $this->clientWrapper->getTableAndFileStorageClient()->createTableAsyncDirect(
             $this->emptyOutputBucketId,
             ['dataWorkspaceId' => $this->workspaceId, 'dataTableName' => 'new_copy_table', 'name' => 'new_clopy_table']
         );

--- a/libs/input-mapping/tests/Functional/DownloadTablesWorkspaceSnowflakeTest.php
+++ b/libs/input-mapping/tests/Functional/DownloadTablesWorkspaceSnowflakeTest.php
@@ -79,7 +79,9 @@ class DownloadTablesWorkspaceSnowflakeTest extends AbstractTestCase
             $this->emptyOutputBucketId,
             ['dataWorkspaceId' => $this->workspaceId, 'dataTableName' => 'test2', 'name' => 'test2']
         );
-        self::assertTrue($this->clientWrapper->getTableAndFileStorageClient()->tableExists($this->emptyOutputBucketId . '.test2'));
+        self::assertTrue($this->clientWrapper->getTableAndFileStorageClient()->tableExists(
+            $this->emptyOutputBucketId . '.test2'
+        ));
 
         $manifest = $adapter->readFromFile($this->temp->getTmpFolder() . '/download/test3.manifest');
         self::assertEquals($this->thirdTableId, $manifest['id']);
@@ -89,7 +91,9 @@ class DownloadTablesWorkspaceSnowflakeTest extends AbstractTestCase
             $this->emptyOutputBucketId,
             ['dataWorkspaceId' => $this->workspaceId, 'dataTableName' => 'test3', 'name' => 'test3']
         );
-        self::assertTrue($this->clientWrapper->getTableAndFileStorageClient()->tableExists($this->emptyOutputBucketId . '.test3'));
+        self::assertTrue($this->clientWrapper->getTableAndFileStorageClient()->tableExists(
+            $this->emptyOutputBucketId . '.test3'
+        ));
         self::assertTrue($logger->hasInfoThatContains('Using "workspace-snowflake" table input staging.'));
         self::assertTrue($logger->hasInfoThatContains(sprintf('Table "%s" will be cloned.', $this->firstTableId)));
         self::assertTrue($logger->hasInfoThatContains(sprintf('Table "%s" will be copied.', $this->secondTableId)));

--- a/libs/input-mapping/tests/Functional/DownloadTablesWorkspaceSynapseTest.php
+++ b/libs/input-mapping/tests/Functional/DownloadTablesWorkspaceSynapseTest.php
@@ -40,14 +40,14 @@ class DownloadTablesWorkspaceSynapseTest extends AbstractTestCase
                 (string) getenv('SYNAPSE_STORAGE_API_TOKEN')
             ),
         );
-        $tokenInfo = $this->clientWrapper->getBasicClient()->verifyToken();
+        $tokenInfo = $this->clientWrapper->getBranchClientIfAvailable()->verifyToken();
         print(sprintf(
             'Authorized as "%s (%s)" to project "%s (%s)" at "%s" stack.',
             $tokenInfo['description'],
             $tokenInfo['id'],
             $tokenInfo['owner']['name'],
             $tokenInfo['owner']['id'],
-            $this->clientWrapper->getBasicClient()->getApiUrl()
+            $this->clientWrapper->getBranchClientIfAvailable()->getApiUrl()
         ));
     }
 
@@ -108,17 +108,17 @@ class DownloadTablesWorkspaceSynapseTest extends AbstractTestCase
 
         self::assertEquals($this->firstTableId, $manifest['id']);
         // test that the table exists in the workspace
-        $tableId = $this->clientWrapper->getBasicClient()->createTableAsyncDirect(
+        $tableId = $this->clientWrapper->getTableAndFileStorageClient()->createTableAsyncDirect(
             $this->emptyOutputBucketId,
             ['dataWorkspaceId' => $this->workspaceId, 'dataTableName' => 'test1', 'name' => 'test1']
         );
         self::assertEquals($this->emptyOutputBucketId . '.test1', $tableId);
-        $table = $this->clientWrapper->getBasicClient()->getTable($tableId);
+        $table = $this->clientWrapper->getTableAndFileStorageClient()->getTable($tableId);
         self::assertEquals(['Id'], $table['columns']);
 
         $manifest = $adapter->readFromFile($this->temp->getTmpFolder() . '/download/test2.manifest');
         self::assertEquals($this->secondTableId, $manifest['id']);
-        $tableId = $this->clientWrapper->getBasicClient()->createTableAsyncDirect(
+        $tableId = $this->clientWrapper->getTableAndFileStorageClient()->createTableAsyncDirect(
             $this->emptyOutputBucketId,
             ['dataWorkspaceId' => $this->workspaceId, 'dataTableName' => 'test2', 'name' => 'test2']
         );
@@ -129,7 +129,7 @@ class DownloadTablesWorkspaceSynapseTest extends AbstractTestCase
         self::assertEquals($this->firstTableId, $manifest['id']);
 
         try {
-            $this->clientWrapper->getBasicClient()->createTableAsyncDirect(
+            $this->clientWrapper->getTableAndFileStorageClient()->createTableAsyncDirect(
                 $this->emptyOutputBucketId,
                 ['dataWorkspaceId' => $this->workspaceId, 'dataTableName' => 'test3', 'name' => 'test3']
             );
@@ -162,7 +162,7 @@ class DownloadTablesWorkspaceSynapseTest extends AbstractTestCase
         );
         // the initially loaded tables should not be present in the workspace anymore
         try {
-            $this->clientWrapper->getBasicClient()->createTableAsyncDirect(
+            $this->clientWrapper->getTableAndFileStorageClient()->createTableAsyncDirect(
                 $this->emptyOutputBucketId,
                 ['dataWorkspaceId' => $this->workspaceId, 'dataTableName' => 'test2', 'name' => 'test2']
             );
@@ -171,7 +171,7 @@ class DownloadTablesWorkspaceSynapseTest extends AbstractTestCase
             self::assertStringContainsString('Table "test2" not found in schema', $exception->getMessage());
         }
         try {
-            $this->clientWrapper->getBasicClient()->createTableAsyncDirect(
+            $this->clientWrapper->getTableAndFileStorageClient()->createTableAsyncDirect(
                 $this->emptyOutputBucketId,
                 ['dataWorkspaceId' => $this->workspaceId, 'dataTableName' => 'test3', 'name' => 'test3']
             );

--- a/libs/input-mapping/tests/Helper/InputBucketValidatorTest.php
+++ b/libs/input-mapping/tests/Helper/InputBucketValidatorTest.php
@@ -17,7 +17,7 @@ class InputBucketValidatorTest extends AbstractTestCase
     private function initBuckets(bool $hasMetadata): void
     {
         if ($hasMetadata) {
-            $metadataApi = new Metadata($this->clientWrapper->getBasicClient());
+            $metadataApi = new Metadata($this->clientWrapper->getTableAndFileStorageClient());
             $metadataApi->postBucketMetadata(
                 $this->emptyOutputBucketId,
                 'test',

--- a/libs/input-mapping/tests/Helper/SourceRewriteHelperTest.php
+++ b/libs/input-mapping/tests/Helper/SourceRewriteHelperTest.php
@@ -386,7 +386,7 @@ class SourceRewriteHelperTest extends TestCase
             fn ($argument) => ['displayName' => $argument]
         );
         $clientWrapper = self::createMock(ClientWrapper::class);
-        $clientWrapper->method('getBasicClient')->willReturn($basicClientMock);
+        $clientWrapper->method('getBranchClientIfAvailable')->willReturn($basicClientMock);
         $clientWrapper->method('getTableAndFileStorageClient')->willReturn($storageClientMock);
         $clientWrapper->expects(self::once())->method('hasBranch')->willReturn(true);
         $clientWrapper->method('getBranchId')->willReturn('123456');
@@ -433,7 +433,7 @@ class SourceRewriteHelperTest extends TestCase
             fn ($argument) => ['displayName' => $argument]
         );
         $clientWrapper = self::createMock(ClientWrapper::class);
-        $clientWrapper->method('getBasicClient')->willReturn($basicClientMock);
+        $clientWrapper->method('getBranchClientIfAvailable')->willReturn($basicClientMock);
         $clientWrapper->method('getTableAndFileStorageClient')->willReturn($storageClientMock);
         $clientWrapper->expects(self::once())->method('hasBranch')->willReturn($hasBranch);
         $clientWrapper->method('getBranchId')->willReturn('123456');

--- a/libs/input-mapping/tests/Helper/SourceRewriteHelperTest.php
+++ b/libs/input-mapping/tests/Helper/SourceRewriteHelperTest.php
@@ -55,7 +55,10 @@ class SourceRewriteHelperTest extends TestCase
 
         $outBucketId = TestSatisfyer::getBucketIdByDisplayName($clientWrapper, 'main', Client::STAGE_OUT);
         if ($outBucketId) {
-            $clientWrapper->getTableAndFileStorageClient()->dropBucket((string) $outBucketId, ['force' => true, 'async' => true]);
+            $clientWrapper->getTableAndFileStorageClient()->dropBucket(
+                (string) $outBucketId,
+                ['force' => true, 'async' => true]
+            );
         }
 
         $outDevBucketId = TestSatisfyer::getBucketIdByDisplayName(
@@ -64,12 +67,18 @@ class SourceRewriteHelperTest extends TestCase
             Client::STAGE_OUT
         );
         if ($outDevBucketId) {
-            $clientWrapper->getTableAndFileStorageClient()->dropBucket((string) $outDevBucketId, ['force' => true, 'async' => true]);
+            $clientWrapper->getTableAndFileStorageClient()->dropBucket(
+                (string) $outDevBucketId,
+                ['force' => true, 'async' => true]
+            );
         }
 
         foreach ($clientWrapper->getTableAndFileStorageClient()->listBuckets() as $bucket) {
             if (preg_match('/^(c-)?[0-9]+-output-mapping-test$/ui', $bucket['name'])) {
-                $clientWrapper->getTableAndFileStorageClient()->dropBucket($bucket['id'], ['force' => true, 'async' => true]);
+                $clientWrapper->getTableAndFileStorageClient()->dropBucket(
+                    $bucket['id'],
+                    ['force' => true, 'async' => true]
+                );
             }
         }
 
@@ -237,8 +246,16 @@ class SourceRewriteHelperTest extends TestCase
         file_put_contents($temp->getTmpFolder() . 'data.csv', "foo,bar\n1,2");
         $csvFile = new CsvFile($temp->getTmpFolder() . 'data.csv');
 
-        $clientWrapper->getTableAndFileStorageClient()->createTableAsync($this->outBranchBucketId, 'my-table', $csvFile);
-        $clientWrapper->getTableAndFileStorageClient()->createTableAsync($this->outBranchBucketId, 'my-table-2', $csvFile);
+        $clientWrapper->getTableAndFileStorageClient()->createTableAsync(
+            $this->outBranchBucketId,
+            'my-table',
+            $csvFile
+        );
+        $clientWrapper->getTableAndFileStorageClient()->createTableAsync(
+            $this->outBranchBucketId,
+            'my-table-2',
+            $csvFile
+        );
         $testLogger = new TestLogger();
         $inputTablesOptions = new InputTableOptionsList([
             [
@@ -311,8 +328,16 @@ class SourceRewriteHelperTest extends TestCase
         $temp = new Temp(uniqid('input-mapping'));
         file_put_contents($temp->getTmpFolder() . 'data.csv', "foo,bar\n1,2");
         $csvFile = new CsvFile($temp->getTmpFolder() . 'data.csv');
-        $clientWrapper->getTableAndFileStorageClient()->createTableAsync($this->outBranchBucketId, 'my-table', $csvFile);
-        $clientWrapper->getTableAndFileStorageClient()->createTableAsync($this->outBranchBucketId, 'my-table-2', $csvFile);
+        $clientWrapper->getTableAndFileStorageClient()->createTableAsync(
+            $this->outBranchBucketId,
+            'my-table',
+            $csvFile
+        );
+        $clientWrapper->getTableAndFileStorageClient()->createTableAsync(
+            $this->outBranchBucketId,
+            'my-table-2',
+            $csvFile
+        );
         $testLogger = new TestLogger();
         $inputTablesStates = new InputTableStateList([
             [

--- a/libs/input-mapping/tests/Helper/SourceRewriteHelperTest.php
+++ b/libs/input-mapping/tests/Helper/SourceRewriteHelperTest.php
@@ -55,7 +55,7 @@ class SourceRewriteHelperTest extends TestCase
 
         $outBucketId = TestSatisfyer::getBucketIdByDisplayName($clientWrapper, 'main', Client::STAGE_OUT);
         if ($outBucketId) {
-            $clientWrapper->getBasicClient()->dropBucket((string) $outBucketId, ['force' => true, 'async' => true]);
+            $clientWrapper->getTableAndFileStorageClient()->dropBucket((string) $outBucketId, ['force' => true, 'async' => true]);
         }
 
         $outDevBucketId = TestSatisfyer::getBucketIdByDisplayName(
@@ -64,17 +64,17 @@ class SourceRewriteHelperTest extends TestCase
             Client::STAGE_OUT
         );
         if ($outDevBucketId) {
-            $clientWrapper->getBasicClient()->dropBucket((string) $outDevBucketId, ['force' => true, 'async' => true]);
+            $clientWrapper->getTableAndFileStorageClient()->dropBucket((string) $outDevBucketId, ['force' => true, 'async' => true]);
         }
 
-        foreach ($clientWrapper->getBasicClient()->listBuckets() as $bucket) {
+        foreach ($clientWrapper->getTableAndFileStorageClient()->listBuckets() as $bucket) {
             if (preg_match('/^(c-)?[0-9]+-output-mapping-test$/ui', $bucket['name'])) {
-                $clientWrapper->getBasicClient()->dropBucket($bucket['id'], ['force' => true, 'async' => true]);
+                $clientWrapper->getTableAndFileStorageClient()->dropBucket($bucket['id'], ['force' => true, 'async' => true]);
             }
         }
 
-        $this->outBucketId = $clientWrapper->getBasicClient()->createBucket('main', Client::STAGE_OUT);
-        $this->outBranchBucketId = $clientWrapper->getBasicClient()->createBucket(
+        $this->outBucketId = $clientWrapper->getTableAndFileStorageClient()->createBucket('main', Client::STAGE_OUT);
+        $this->outBranchBucketId = $clientWrapper->getTableAndFileStorageClient()->createBucket(
             $this->branchId . '-main',
             Client::STAGE_OUT
         );
@@ -237,8 +237,8 @@ class SourceRewriteHelperTest extends TestCase
         file_put_contents($temp->getTmpFolder() . 'data.csv', "foo,bar\n1,2");
         $csvFile = new CsvFile($temp->getTmpFolder() . 'data.csv');
 
-        $clientWrapper->getBasicClient()->createTableAsync($this->outBranchBucketId, 'my-table', $csvFile);
-        $clientWrapper->getBasicClient()->createTableAsync($this->outBranchBucketId, 'my-table-2', $csvFile);
+        $clientWrapper->getTableAndFileStorageClient()->createTableAsync($this->outBranchBucketId, 'my-table', $csvFile);
+        $clientWrapper->getTableAndFileStorageClient()->createTableAsync($this->outBranchBucketId, 'my-table-2', $csvFile);
         $testLogger = new TestLogger();
         $inputTablesOptions = new InputTableOptionsList([
             [
@@ -311,8 +311,8 @@ class SourceRewriteHelperTest extends TestCase
         $temp = new Temp(uniqid('input-mapping'));
         file_put_contents($temp->getTmpFolder() . 'data.csv', "foo,bar\n1,2");
         $csvFile = new CsvFile($temp->getTmpFolder() . 'data.csv');
-        $clientWrapper->getBasicClient()->createTableAsync($this->outBranchBucketId, 'my-table', $csvFile);
-        $clientWrapper->getBasicClient()->createTableAsync($this->outBranchBucketId, 'my-table-2', $csvFile);
+        $clientWrapper->getTableAndFileStorageClient()->createTableAsync($this->outBranchBucketId, 'my-table', $csvFile);
+        $clientWrapper->getTableAndFileStorageClient()->createTableAsync($this->outBranchBucketId, 'my-table-2', $csvFile);
         $testLogger = new TestLogger();
         $inputTablesStates = new InputTableStateList([
             [
@@ -353,14 +353,16 @@ class SourceRewriteHelperTest extends TestCase
 
     public function testHasBranchRewriteWithPrefix(): void
     {
-        $clientMock = self::createMock(Client::class);
-        $clientMock->expects(self::once())->method('tableExists')
+        $storageClientMock = self::createMock(Client::class);
+        $storageClientMock->expects(self::once())->method('tableExists')
             ->with('out.c-123456-main.my-table')->willReturn(true);
-        $clientMock->expects(self::once())->method('webalizeDisplayName')->willReturnCallback(
+        $basicClientMock = self::createMock(Client::class);
+        $basicClientMock->expects(self::once())->method('webalizeDisplayName')->willReturnCallback(
             fn ($argument) => ['displayName' => $argument]
         );
         $clientWrapper = self::createMock(ClientWrapper::class);
-        $clientWrapper->method('getBasicClient')->willReturn($clientMock);
+        $clientWrapper->method('getBasicClient')->willReturn($basicClientMock);
+        $clientWrapper->method('getTableAndFileStorageClient')->willReturn($storageClientMock);
         $clientWrapper->expects(self::once())->method('hasBranch')->willReturn(true);
         $clientWrapper->method('getBranchId')->willReturn('123456');
         $inputTablesOptions = new InputTableOptionsList([
@@ -398,14 +400,16 @@ class SourceRewriteHelperTest extends TestCase
         int $checkCount,
         bool $hasBranch,
     ): void {
-        $clientMock = self::createMock(Client::class);
-        $clientMock->expects(self::exactly($checkCount))->method('tableExists')
+        $storageClientMock = self::createMock(Client::class);
+        $storageClientMock->expects(self::exactly($checkCount))->method('tableExists')
             ->with($destinationTable)->willReturn(true);
-        $clientMock->expects(self::exactly($checkCount))->method('webalizeDisplayName')->willReturnCallback(
+        $basicClientMock = self::createMock(Client::class);
+        $basicClientMock->expects(self::exactly($checkCount))->method('webalizeDisplayName')->willReturnCallback(
             fn ($argument) => ['displayName' => $argument]
         );
         $clientWrapper = self::createMock(ClientWrapper::class);
-        $clientWrapper->method('getBasicClient')->willReturn($clientMock);
+        $clientWrapper->method('getBasicClient')->willReturn($basicClientMock);
+        $clientWrapper->method('getTableAndFileStorageClient')->willReturn($storageClientMock);
         $clientWrapper->expects(self::once())->method('hasBranch')->willReturn($hasBranch);
         $clientWrapper->method('getBranchId')->willReturn('123456');
         $inputTablesOptions = new InputTableOptionsList([

--- a/libs/input-mapping/tests/Helper/TagsRewriteHelperTest.php
+++ b/libs/input-mapping/tests/Helper/TagsRewriteHelperTest.php
@@ -31,11 +31,11 @@ class TagsRewriteHelperTest extends TestCase
         $this->tmpDir = $temp->getTmpFolder();
         sleep(2);
         $clientWrapper = self::getClientWrapper(null);
-        $files = $clientWrapper->getBasicClient()->listFiles(
+        $files = $clientWrapper->getTableAndFileStorageClient()->listFiles(
             (new ListFilesOptions())->setTags([self::TEST_REWRITE_BASE_TAG, self::$branchTag])
         );
         foreach ($files as $file) {
-            $clientWrapper->getBasicClient()->deleteFile($file['id']);
+            $clientWrapper->getTableAndFileStorageClient()->deleteFile($file['id']);
         }
     }
 
@@ -84,7 +84,7 @@ class TagsRewriteHelperTest extends TestCase
         $root = $this->tmpDir;
         file_put_contents($root . '/upload', 'test');
         $clientWrapper = self::getClientWrapper(self::$branchId);
-        $clientWrapper->getBasicClient()->uploadFile(
+        $clientWrapper->getTableAndFileStorageClient()->uploadFile(
             $root . '/upload',
             (new FileUploadOptions())->setTags([self::$branchTag])
         );
@@ -109,7 +109,7 @@ class TagsRewriteHelperTest extends TestCase
 
         $clientWrapper = self::getClientWrapper(self::$branchId);
         $clientWrapper
-            ->getBasicClient()
+            ->getTableAndFileStorageClient()
             ->uploadFile($root . '/upload', (new FileUploadOptions())->setTags([self::$branchTag]));
         sleep(2);
 
@@ -201,7 +201,7 @@ class TagsRewriteHelperTest extends TestCase
         file_put_contents($this->tmpDir . '/upload', 'test');
         $clientWrapper = self::getClientWrapper(self::$branchId);
         $clientWrapper
-            ->getBasicClient()
+            ->getTableAndFileStorageClient()
             ->uploadFile(
                 $this->tmpDir . '/upload',
                 (new FileUploadOptions())->setTags([self::$branchTag, $branchProcessedTag])
@@ -244,7 +244,7 @@ class TagsRewriteHelperTest extends TestCase
         file_put_contents($this->tmpDir . '/upload', 'test');
         $clientWrapper = self::getClientWrapper(self::$branchId);
         $clientWrapper
-            ->getBasicClient()
+            ->getTableAndFileStorageClient()
             ->uploadFile(
                 $this->tmpDir . '/upload',
                 (new FileUploadOptions())->setTags([self::TEST_REWRITE_BASE_TAG, 'processed'])

--- a/libs/input-mapping/tests/Needs/TestSatisfyer.php
+++ b/libs/input-mapping/tests/Needs/TestSatisfyer.php
@@ -36,7 +36,7 @@ class TestSatisfyer
     ): ?string {
         // the client has method getBucketId, but it does not work with display name, and actually it is not
         // useful at all https://keboola.slack.com/archives/CFVRE56UA/p1680696020855349
-        $buckets = $clientWrapper->getBasicClient()->listBuckets();
+        $buckets = $clientWrapper->getTableAndFileStorageClient()->listBuckets();
         foreach ($buckets as $bucket) {
             if ($bucket['displayName'] === $bucketDisplayName && $bucket['stage'] === $stage) {
                 return $bucket['id'];
@@ -53,13 +53,13 @@ class TestSatisfyer
     ): string {
         $bucketId = self::getBucketIdByDisplayName($clientWrapper, $bucketName, $stage);
         if ($bucketId !== null) {
-            $tables = $clientWrapper->getBasicClient()->listTables($bucketId, ['include' => '']);
+            $tables = $clientWrapper->getTableAndFileStorageClient()->listTables($bucketId, ['include' => '']);
             foreach ($tables as $table) {
-                $clientWrapper->getBasicClient()->dropTable($table['id']);
+                $clientWrapper->getTableAndFileStorageClient()->dropTable($table['id']);
             }
             return $bucketId;
         }
-        return $clientWrapper->getBasicClient()->createBucket(name: $bucketName, stage: $stage, backend: $backend);
+        return $clientWrapper->getTableAndFileStorageClient()->createBucket(name: $bucketName, stage: $stage, backend: $backend);
     }
 
     /**
@@ -124,7 +124,7 @@ class TestSatisfyer
             // Create table
             $propNames = ['firstTableId', 'secondTableId', 'thirdTableId'];
             for ($i = 0; $i < max($tableCount, count($propNames)); $i++) {
-                $tableIds[$i] = $clientWrapper->getBasicClient()->createTableAsync(
+                $tableIds[$i] = $clientWrapper->getTableAndFileStorageClient()->createTableAsync(
                     $testBucketId,
                     'test' . ($i + 1),
                     $csv
@@ -146,7 +146,7 @@ class TestSatisfyer
             $csv->writeRow(['id2', 'name2', 'foo2', 'bar2']);
             $csv->writeRow(['id3', 'name3', 'foo3', 'bar3']);
 
-            $redshiftTableId = $clientWrapper->getBasicClient()->createTableAsync(
+            $redshiftTableId = $clientWrapper->getTableAndFileStorageClient()->createTableAsync(
                 $testRedshiftBucketId,
                 'test',
                 $csv

--- a/libs/input-mapping/tests/Needs/TestSatisfyer.php
+++ b/libs/input-mapping/tests/Needs/TestSatisfyer.php
@@ -59,7 +59,11 @@ class TestSatisfyer
             }
             return $bucketId;
         }
-        return $clientWrapper->getTableAndFileStorageClient()->createBucket(name: $bucketName, stage: $stage, backend: $backend);
+        return $clientWrapper->getTableAndFileStorageClient()->createBucket(
+            name: $bucketName,
+            stage: $stage,
+            backend: $backend
+        );
     }
 
     /**

--- a/libs/input-mapping/tests/ReaderTest.php
+++ b/libs/input-mapping/tests/ReaderTest.php
@@ -227,7 +227,10 @@ class ReaderTest extends TestCase
             Client::STAGE_IN
         );
         if ($branchBucketId) {
-            $clientWrapper->getTableAndFileStorageClient()->dropBucket((string) $branchBucketId, ['force' => true, 'async' => true]);
+            $clientWrapper->getTableAndFileStorageClient()->dropBucket(
+                (string) $branchBucketId,
+                ['force' => true, 'async' => true]
+            );
         }
         $inBucketId = TestSatisfyer::getBucketIdByDisplayName(
             $clientWrapper,
@@ -235,11 +238,17 @@ class ReaderTest extends TestCase
             Client::STAGE_IN
         );
         if ($inBucketId) {
-            $clientWrapper->getTableAndFileStorageClient()->dropBucket((string) $inBucketId, ['force' => true, 'async' => true]);
+            $clientWrapper->getTableAndFileStorageClient()->dropBucket(
+                (string) $inBucketId,
+                ['force' => true, 'async' => true]
+            );
         }
         foreach ($clientWrapper->getTableAndFileStorageClient()->listBuckets() as $bucket) {
             if (preg_match('/^(c-)?[0-9]+-input-mapping-test/ui', $bucket['name'])) {
-                $clientWrapper->getTableAndFileStorageClient()->dropBucket($bucket['id'], ['force' => true, 'async' => true]);
+                $clientWrapper->getTableAndFileStorageClient()->dropBucket(
+                    $bucket['id'],
+                    ['force' => true, 'async' => true]
+                );
             }
         }
 
@@ -251,7 +260,10 @@ class ReaderTest extends TestCase
         }
         $branchId = (string) $branchesApi->createBranch('my-branch')['id'];
 
-        $inBucketId = $clientWrapper->getTableAndFileStorageClient()->createBucket('input-mapping-test', Client::STAGE_IN);
+        $inBucketId = $clientWrapper->getTableAndFileStorageClient()->createBucket(
+            'input-mapping-test',
+            Client::STAGE_IN
+        );
         // we need to know the $inBucketId, which is known only after creation, but we need the bucket not to exist
         // hence - create the bucket, get it id, and drop it
         $clientWrapper->getTableAndFileStorageClient()->dropBucket($inBucketId, ['force' => true, 'async' => true]);

--- a/libs/input-mapping/tests/ReaderTest.php
+++ b/libs/input-mapping/tests/ReaderTest.php
@@ -39,14 +39,14 @@ class ReaderTest extends TestCase
         $fs = new Filesystem();
         $fs->mkdir($this->temp->getTmpFolder() . '/download');
         $clientWrapper = $this->getClientWrapper(null);
-        $tokenInfo = $clientWrapper->getBasicClient()->verifyToken();
+        $tokenInfo = $clientWrapper->getBranchClientIfAvailable()->verifyToken();
         print(sprintf(
             'Authorized as "%s (%s)" to project "%s (%s)" at "%s" stack.',
             $tokenInfo['description'],
             $tokenInfo['id'],
             $tokenInfo['owner']['name'],
             $tokenInfo['owner']['id'],
-            $clientWrapper->getBasicClient()->getApiUrl()
+            $clientWrapper->getBranchClientIfAvailable()->getApiUrl()
         ));
     }
 
@@ -94,25 +94,25 @@ class ReaderTest extends TestCase
     public function testParentId(): void
     {
         $clientWrapper = $this->getClientWrapper(null);
-        $clientWrapper->getBasicClient()->setRunId('123456789');
+        $clientWrapper->getTableAndFileStorageClient()->setRunId('123456789');
         self::assertEquals(
             '123456789',
-            Reader::getParentRunId((string) $clientWrapper->getBasicClient()->getRunId())
+            Reader::getParentRunId((string) $clientWrapper->getTableAndFileStorageClient()->getRunId())
         );
-        $clientWrapper->getBasicClient()->setRunId('123456789.98765432');
+        $clientWrapper->getTableAndFileStorageClient()->setRunId('123456789.98765432');
         self::assertEquals(
             '123456789',
-            Reader::getParentRunId((string) $clientWrapper->getBasicClient()->getRunId())
+            Reader::getParentRunId((string) $clientWrapper->getTableAndFileStorageClient()->getRunId())
         );
-        $clientWrapper->getBasicClient()->setRunId('123456789.98765432.4563456');
+        $clientWrapper->getTableAndFileStorageClient()->setRunId('123456789.98765432.4563456');
         self::assertEquals(
             '123456789.98765432',
-            Reader::getParentRunId((string) $clientWrapper->getBasicClient()->getRunId())
+            Reader::getParentRunId((string) $clientWrapper->getTableAndFileStorageClient()->getRunId())
         );
-        $clientWrapper->getBasicClient()->setRunId(null);
+        $clientWrapper->getTableAndFileStorageClient()->setRunId(null);
         self::assertEquals(
             '',
-            Reader::getParentRunId((string) $clientWrapper->getBasicClient()->getRunId())
+            Reader::getParentRunId((string) $clientWrapper->getTableAndFileStorageClient()->getRunId())
         );
     }
 
@@ -227,7 +227,7 @@ class ReaderTest extends TestCase
             Client::STAGE_IN
         );
         if ($branchBucketId) {
-            $clientWrapper->getBasicClient()->dropBucket((string) $branchBucketId, ['force' => true, 'async' => true]);
+            $clientWrapper->getTableAndFileStorageClient()->dropBucket((string) $branchBucketId, ['force' => true, 'async' => true]);
         }
         $inBucketId = TestSatisfyer::getBucketIdByDisplayName(
             $clientWrapper,
@@ -235,11 +235,11 @@ class ReaderTest extends TestCase
             Client::STAGE_IN
         );
         if ($inBucketId) {
-            $clientWrapper->getBasicClient()->dropBucket((string) $inBucketId, ['force' => true, 'async' => true]);
+            $clientWrapper->getTableAndFileStorageClient()->dropBucket((string) $inBucketId, ['force' => true, 'async' => true]);
         }
-        foreach ($clientWrapper->getBasicClient()->listBuckets() as $bucket) {
+        foreach ($clientWrapper->getTableAndFileStorageClient()->listBuckets() as $bucket) {
             if (preg_match('/^(c-)?[0-9]+-input-mapping-test/ui', $bucket['name'])) {
-                $clientWrapper->getBasicClient()->dropBucket($bucket['id'], ['force' => true, 'async' => true]);
+                $clientWrapper->getTableAndFileStorageClient()->dropBucket($bucket['id'], ['force' => true, 'async' => true]);
             }
         }
 
@@ -251,15 +251,15 @@ class ReaderTest extends TestCase
         }
         $branchId = (string) $branchesApi->createBranch('my-branch')['id'];
 
-        $inBucketId = $clientWrapper->getBasicClient()->createBucket('input-mapping-test', Client::STAGE_IN);
+        $inBucketId = $clientWrapper->getTableAndFileStorageClient()->createBucket('input-mapping-test', Client::STAGE_IN);
         // we need to know the $inBucketId, which is known only after creation, but we need the bucket not to exist
         // hence - create the bucket, get it id, and drop it
-        $clientWrapper->getBasicClient()->dropBucket($inBucketId, ['force' => true, 'async' => true]);
-        $branchBucketId = $clientWrapper->getBasicClient()->createBucket(
+        $clientWrapper->getTableAndFileStorageClient()->dropBucket($inBucketId, ['force' => true, 'async' => true]);
+        $branchBucketId = $clientWrapper->getTableAndFileStorageClient()->createBucket(
             sprintf('%s-input-mapping-test', $branchId),
             Client::STAGE_IN
         );
-        $clientWrapper->getBasicClient()->createTableAsync($branchBucketId, 'test', $csvFile);
+        $clientWrapper->getTableAndFileStorageClient()->createTableAsync($branchBucketId, 'test', $csvFile);
         $reader = new Reader($this->getStagingFactory($this->getClientWrapper($branchId)));
         $configuration = new InputTableOptionsList([
             [

--- a/libs/input-mapping/tests/Table/Strategy/S3StrategyTest.php
+++ b/libs/input-mapping/tests/Table/Strategy/S3StrategyTest.php
@@ -35,7 +35,7 @@ class S3StrategyTest extends AbstractTestCase
         $result = $strategy->downloadTable($tableOptions);
         self::assertArrayHasKey('jobId', $result);
         self::assertArrayHasKey('table', $result);
-        $job = $this->clientWrapper->getBasicClient()->getJob($result['jobId']);
+        $job = $this->clientWrapper->getBranchClientIfAvailable()->getJob($result['jobId']);
         self::assertEquals(
             'tableExport',
             $job['operationName']

--- a/libs/input-mapping/tests/Table/Strategy/S3StrategyTest.php
+++ b/libs/input-mapping/tests/Table/Strategy/S3StrategyTest.php
@@ -78,7 +78,7 @@ class S3StrategyTest extends AbstractTestCase
         $result = $strategy->downloadTable($tableOptions);
         self::assertArrayHasKey('jobId', $result);
         self::assertArrayHasKey('table', $result);
-        $job = $this->clientWrapper->getBasicClient()->getJob($result['jobId']);
+        $job = $this->clientWrapper->getBranchClientIfAvailable()->getJob($result['jobId']);
         self::assertEquals(
             'tableExport',
             $job['operationName']


### PR DESCRIPTION
https://keboola.atlassian.net/browse/SOX-138

Pointa změny je v tom, že basicClient se nadále používá jen u věcí, který nejsou nikdy branchovaný, což je tohle:

![image](https://github.com/keboola/platform-libraries/assets/4319320/ec587a36-cfa3-4dbc-9804-93efd3635cea)

Pro ostatní výskyty getBasicClient je použitý getTableAndFileStorageClient, který je branchovaný podle flagu v ClientOptions a ultimátně podle feature projektu.

Depends on https://github.com/keboola/storage-api-php-client-branch-wrapper/pull/17