### PR TITLE
Switch to table storage client where applicable in OM

### DIFF
--- a/libs/output-mapping/composer.json
+++ b/libs/output-mapping/composer.json
@@ -33,7 +33,7 @@
         "keboola/php-file-storage-utils": "^0.2",
         "keboola/sanitizer": "^0.1",
         "keboola/storage-api-client": "^14.5",
-        "keboola/storage-api-php-client-branch-wrapper": "dev-odin-SOX-138-b as 3.1.0",
+        "keboola/storage-api-php-client-branch-wrapper": "^3.4",
         "microsoft/azure-storage-blob": "^1.5",
         "monolog/monolog": "^1.25.5|^2.0",
         "symfony/config": "^5.4|^6.0",

--- a/libs/output-mapping/composer.json
+++ b/libs/output-mapping/composer.json
@@ -33,7 +33,7 @@
         "keboola/php-file-storage-utils": "^0.2",
         "keboola/sanitizer": "^0.1",
         "keboola/storage-api-client": "^14.5",
-        "keboola/storage-api-php-client-branch-wrapper": "dev-odin-SOX-138 as 3.1.0",
+        "keboola/storage-api-php-client-branch-wrapper": "dev-odin-SOX-138-b as 3.1.0",
         "microsoft/azure-storage-blob": "^1.5",
         "monolog/monolog": "^1.25.5|^2.0",
         "symfony/config": "^5.4|^6.0",

--- a/libs/output-mapping/composer.json
+++ b/libs/output-mapping/composer.json
@@ -33,7 +33,7 @@
         "keboola/php-file-storage-utils": "^0.2",
         "keboola/sanitizer": "^0.1",
         "keboola/storage-api-client": "^14.5",
-        "keboola/storage-api-php-client-branch-wrapper": "^3.1",
+        "keboola/storage-api-php-client-branch-wrapper": "dev-odin-SOX-138 as 3.1.0",
         "microsoft/azure-storage-blob": "^1.5",
         "monolog/monolog": "^1.25.5|^2.0",
         "symfony/config": "^5.4|^6.0",

--- a/libs/output-mapping/src/DeferredTasks/FailedLoadTableDecider.php
+++ b/libs/output-mapping/src/DeferredTasks/FailedLoadTableDecider.php
@@ -4,19 +4,19 @@ declare(strict_types=1);
 
 namespace Keboola\OutputMapping\DeferredTasks;
 
-use Keboola\StorageApi\Client;
 use Keboola\StorageApi\ClientException;
+use Keboola\StorageApiBranch\ClientWrapper;
 use Psr\Log\LoggerInterface;
 
 class FailedLoadTableDecider
 {
     public static function decideTableDelete(
         LoggerInterface $logger,
-        Client $client,
+        ClientWrapper $clientWrapper,
         LoadTableTaskInterface $task
     ): bool {
         try {
-            $tableInfo = $client->getTable($task->getDestinationTableName());
+            $tableInfo = $clientWrapper->getTableAndFileStorageClient()->getTable($task->getDestinationTableName());
         } catch (ClientException $e) {
             // likely the table doesn't exist, but any other error really prevents us from positive decision
             return false;

--- a/libs/output-mapping/src/DeferredTasks/LoadTableQueue.php
+++ b/libs/output-mapping/src/DeferredTasks/LoadTableQueue.php
@@ -63,7 +63,7 @@ class LoadTableQueue
             $jobId = $task->getStorageJobId();
             $jobIds[] = $jobId;
             /** @var array $jobResult */
-            $jobResult = $this->clientWrapper->getBasicClient()->waitForJob($jobId);
+            $jobResult = $this->clientWrapper->getBranchClientIfAvailable()->waitForJob($jobId);
 
             if ($jobResult['status'] === 'error') {
                 $errors[] = sprintf(

--- a/libs/output-mapping/src/Writer/File/Strategy/ABSWorkspace.php
+++ b/libs/output-mapping/src/Writer/File/Strategy/ABSWorkspace.php
@@ -146,7 +146,7 @@ class ABSWorkspace extends AbstractFileStrategy implements StrategyInterface
             ->setIsEncrypted($storageConfig['is_encrypted'])
             ->setIsPublic($storageConfig['is_public'])
             ->setNotify($storageConfig['notify']);
-        return (string) $this->clientWrapper->getBasicClient()->uploadFile($tmpFileName, $options);
+        return (string) $this->clientWrapper->getTableAndFileStorageClient()->uploadFile($tmpFileName, $options);
     }
 
     public function readFileManifest(string $manifestFile): array

--- a/libs/output-mapping/src/Writer/File/Strategy/Local.php
+++ b/libs/output-mapping/src/Writer/File/Strategy/Local.php
@@ -73,7 +73,7 @@ class Local extends AbstractFileStrategy implements StrategyInterface
             ->setIsEncrypted($storageConfig['is_encrypted'])
             ->setIsPublic($storageConfig['is_public'])
             ->setNotify($storageConfig['notify']);
-        return (string) $this->clientWrapper->getBasicClient()
+        return (string) $this->clientWrapper->getTableAndFileStorageClient()
             ->uploadFile($this->dataStorage->getPath() . '/' . $file, $options);
     }
 

--- a/libs/output-mapping/src/Writer/FileWriter.php
+++ b/libs/output-mapping/src/Writer/FileWriter.php
@@ -145,7 +145,7 @@ class FileWriter extends AbstractWriter
     {
         $prefix = null;
         if ($this->clientWrapper->hasBranch()) {
-            $prefix = $this->clientWrapper->getBasicClient()->webalizeDisplayName(
+            $prefix = $this->clientWrapper->getBranchClientIfAvailable()->webalizeDisplayName(
                 (string) $this->clientWrapper->getBranchId()
             )['displayName'];
         }
@@ -159,7 +159,7 @@ class FileWriter extends AbstractWriter
                 );
                 foreach ($files as $file) {
                     foreach ($fileConfiguration['processed_tags'] as $tag) {
-                        $this->clientWrapper->getBasicClient()->addFileTag(
+                        $this->clientWrapper->getTableAndFileStorageClient()->addFileTag(
                             $file['id'],
                             $prefix ? $prefix . '-' . $tag : $tag
                         );

--- a/libs/output-mapping/src/Writer/Helper/DestinationRewriter.php
+++ b/libs/output-mapping/src/Writer/Helper/DestinationRewriter.php
@@ -29,7 +29,7 @@ class DestinationRewriter
         }
 
         try {
-            $webalizeResult = $clientWrapper->getBasicClient()->webalizeDisplayName(
+            $webalizeResult = $clientWrapper->getBranchClientIfAvailable()->webalizeDisplayName(
                 (string) $clientWrapper->getBranchId()
             );
         } catch (ClientException $e) {

--- a/libs/output-mapping/src/Writer/Helper/TagsHelper.php
+++ b/libs/output-mapping/src/Writer/Helper/TagsHelper.php
@@ -13,7 +13,7 @@ class TagsHelper
     public static function rewriteTags(array $storageConfig, ClientWrapper $clientWrapper): array
     {
         if (!empty($storageConfig['tags']) && $clientWrapper->hasBranch()) {
-            $prefix = $clientWrapper->getBasicClient()->webalizeDisplayName(
+            $prefix = $clientWrapper->getBranchClientIfAvailable()->webalizeDisplayName(
                 (string) $clientWrapper->getBranchId()
             )['displayName'];
             $storageConfig['tags'] = array_map(function ($tag) use ($prefix) {

--- a/libs/output-mapping/src/Writer/Table/Strategy/LocalTableStrategy.php
+++ b/libs/output-mapping/src/Writer/Table/Strategy/LocalTableStrategy.php
@@ -92,7 +92,10 @@ class LocalTableStrategy extends AbstractTableStrategy
             ->setTags($tags)
         ;
 
-        return (string) $this->clientWrapper->getBasicClient()->uploadSlicedFile($sliceFiles, $fileUploadOptions);
+        return (string) $this->clientWrapper->getTableAndFileStorageClient()->uploadSlicedFile(
+            $sliceFiles,
+            $fileUploadOptions
+        );
     }
 
     private function uploadRegularFile(SplFileInfo $source, array $tags): string
@@ -102,6 +105,9 @@ class LocalTableStrategy extends AbstractTableStrategy
             ->setTags($tags)
         ;
 
-        return (string) $this->clientWrapper->getBasicClient()->uploadFile($source->getPathname(), $fileUploadOptions);
+        return (string) $this->clientWrapper->getTableAndFileStorageClient()->uploadFile(
+            $source->getPathname(),
+            $fileUploadOptions
+        );
     }
 }

--- a/libs/output-mapping/src/Writer/Table/TableConfigurationResolver.php
+++ b/libs/output-mapping/src/Writer/Table/TableConfigurationResolver.php
@@ -88,7 +88,7 @@ class TableConfigurationResolver
 
         $config = $this->normalizeConfig($config, $mappingSource);
 
-        $tokenInfo = $this->clientWrapper->getBasicClient()->verifyToken();
+        $tokenInfo = $this->clientWrapper->getBranchClientIfAvailable()->verifyToken();
         if (in_array(TableWriter::TAG_STAGING_FILES_FEATURE, $tokenInfo['owner']['features'], true)) {
             $config = TagsHelper::addSystemTags($config, $systemMetadata, $this->logger);
         }

--- a/libs/output-mapping/tests/AbstractTestCase.php
+++ b/libs/output-mapping/tests/AbstractTestCase.php
@@ -264,7 +264,7 @@ abstract class AbstractTestCase extends TestCase
 
     protected function assertJobParamsMatches(array $expectedParams, string $jobId): void
     {
-        $job = $this->clientWrapper->getBasicClient()->getJob($jobId);
+        $job = $this->clientWrapper->getBranchClientIfAvailable()->getJob($jobId);
         foreach ($expectedParams as $expectedParam) {
             self::assertContains($expectedParam, $job['operationParams']['params']);
         }

--- a/libs/output-mapping/tests/DeferredTasks/FailedLoadTableDeciderTest.php
+++ b/libs/output-mapping/tests/DeferredTasks/FailedLoadTableDeciderTest.php
@@ -10,6 +10,7 @@ use Keboola\OutputMapping\DeferredTasks\TableWriter\LoadTableTask;
 use Keboola\OutputMapping\Writer\Table\MappingDestination;
 use Keboola\StorageApi\Client;
 use Keboola\StorageApi\ClientException;
+use Keboola\StorageApiBranch\ClientWrapper;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\Test\TestLogger;
 
@@ -67,8 +68,11 @@ class FailedLoadTableDeciderTest extends TestCase
         $client->expects(self::once())->method('getTable')
             ->with('in.c-test.table')
             ->willReturn($tableInfo);
+        $clientWrapperMock = self::createMock(ClientWrapper::class);
+        $clientWrapperMock->method('getTableAndFileStorageClient')
+            ->willReturn($client);
         $task = new LoadTableTask(new MappingDestination('in.c-test.table'), [], $freshlyCreated);
-        $result = FailedLoadTableDecider::decideTableDelete($logger, $client, $task);
+        $result = FailedLoadTableDecider::decideTableDelete($logger, $clientWrapperMock, $task);
         self::assertSame($expectedResult, $result);
     }
 
@@ -79,8 +83,11 @@ class FailedLoadTableDeciderTest extends TestCase
         $client->expects(self::once())->method('getTable')
             ->with('in.c-test.table')
             ->willThrowException(new ClientException('Table not foundd', 404));
+        $clientWrapperMock = self::createMock(ClientWrapper::class);
+        $clientWrapperMock->method('getTableAndFileStorageClient')
+            ->willReturn($client);
         $task = new LoadTableTask(new MappingDestination('in.c-test.table'), [], true);
-        $result = FailedLoadTableDecider::decideTableDelete($logger, $client, $task);
+        $result = FailedLoadTableDecider::decideTableDelete($logger, $clientWrapperMock, $task);
         self::assertSame(false, $result);
     }
 }

--- a/libs/output-mapping/tests/DeferredTasks/LoadTableQueueTest.php
+++ b/libs/output-mapping/tests/DeferredTasks/LoadTableQueueTest.php
@@ -26,6 +26,7 @@ class LoadTableQueueTest extends TestCase
         $clientWrapperMock = $this->createMock(ClientWrapper::class);
         $clientWrapperMock->method('getTableAndFileStorageClient')
             ->willReturn($this->createMock(Client::class));
+
         $loadQueue = new LoadTableQueue(
             $clientWrapperMock,
             new NullLogger(),
@@ -146,6 +147,8 @@ class LoadTableQueueTest extends TestCase
         $clientWrapperMock = $this->createMock(ClientWrapper::class);
         $clientWrapperMock->method('getTableAndFileStorageClient')
             ->willReturn($clientMock);
+        $clientWrapperMock->method('getBranchClientIfAvailable')
+            ->willReturn($clientMock);
 
         $loadQueue = new LoadTableQueue($clientWrapperMock, new NullLogger(), [$loadTask]);
 
@@ -223,6 +226,8 @@ class LoadTableQueueTest extends TestCase
 
         $clientWrapperMock = $this->createMock(ClientWrapper::class);
         $clientWrapperMock->method('getTableAndFileStorageClient')
+            ->willReturn($clientMock);
+        $clientWrapperMock->method('getBranchClientIfAvailable')
             ->willReturn($clientMock);
 
         $loadQueue = new LoadTableQueue($clientWrapperMock, new NullLogger(), [$loadTask]);
@@ -305,6 +310,8 @@ class LoadTableQueueTest extends TestCase
         $clientWrapperMock = $this->createMock(ClientWrapper::class);
         $clientWrapperMock->method('getTableAndFileStorageClient')
             ->willReturn($clientMock);
+        $clientWrapperMock->method('getBranchClientIfAvailable')
+            ->willReturn($clientMock);
 
         $loadQueue = new LoadTableQueue($clientWrapperMock, new NullLogger(), [$loadTask]);
         $loadQueue->waitForAll();
@@ -363,6 +370,8 @@ class LoadTableQueueTest extends TestCase
 
         $clientWrapperMock = $this->createMock(ClientWrapper::class);
         $clientWrapperMock->method('getTableAndFileStorageClient')
+            ->willReturn($clientMock);
+        $clientWrapperMock->method('getBranchClientIfAvailable')
             ->willReturn($clientMock);
 
         $loadQueue = new LoadTableQueue($clientWrapperMock, new NullLogger(), [$loadTask]);
@@ -433,6 +442,8 @@ class LoadTableQueueTest extends TestCase
 
         $clientWrapperMock = $this->createMock(ClientWrapper::class);
         $clientWrapperMock->method('getTableAndFileStorageClient')
+            ->willReturn($clientMock);
+        $clientWrapperMock->method('getBranchClientIfAvailable')
             ->willReturn($clientMock);
 
         $loadQueue = new LoadTableQueue($clientWrapperMock, new NullLogger(), [$loadTask]);

--- a/libs/output-mapping/tests/InitSynapseStorageClientTrait.php
+++ b/libs/output-mapping/tests/InitSynapseStorageClientTrait.php
@@ -34,14 +34,14 @@ trait InitSynapseStorageClientTrait
                 return 1;
             });
         $clientWrapper = new ClientWrapper($clientOptions);
-        $tokenInfo = $clientWrapper->getBasicClient()->verifyToken();
+        $tokenInfo = $clientWrapper->getBranchClientIfAvailable()->verifyToken();
         print(sprintf(
             'Authorized as "%s (%s)" to project "%s (%s)" at "%s" stack.',
             $tokenInfo['description'],
             $tokenInfo['id'],
             $tokenInfo['owner']['name'],
             $tokenInfo['owner']['id'],
-            $clientWrapper->getBasicClient()->getApiUrl()
+            $clientWrapper->getBranchClientIfAvailable()->getApiUrl()
         ));
         return $clientWrapper;
     }

--- a/libs/output-mapping/tests/Needs/TestSatisfyer.php
+++ b/libs/output-mapping/tests/Needs/TestSatisfyer.php
@@ -36,7 +36,7 @@ class TestSatisfyer
     ): ?string {
         // the client has method getBucketId, but it does not work with display name, and actually it is not
         // useful at all https://keboola.slack.com/archives/CFVRE56UA/p1680696020855349
-        $buckets = $clientWrapper->getBasicClient()->listBuckets();
+        $buckets = $clientWrapper->getTableAndFileStorageClient()->listBuckets();
         foreach ($buckets as $bucket) {
             if ($bucket['displayName'] === $bucketDisplayName && $bucket['stage'] === $stage) {
                 return $bucket['id'];
@@ -53,13 +53,17 @@ class TestSatisfyer
     ): string {
         $bucketId = self::getBucketIdByDisplayName($clientWrapper, $bucketName, $stage);
         if ($bucketId !== null) {
-            $tables = $clientWrapper->getBasicClient()->listTables($bucketId, ['include' => '']);
+            $tables = $clientWrapper->getTableAndFileStorageClient()->listTables($bucketId, ['include' => '']);
             foreach ($tables as $table) {
-                $clientWrapper->getBasicClient()->dropTable($table['id']);
+                $clientWrapper->getTableAndFileStorageClient()->dropTable($table['id']);
             }
             return $bucketId;
         }
-        return $clientWrapper->getBasicClient()->createBucket(name: $bucketName, stage: $stage, backend: $backend);
+        return $clientWrapper->getTableAndFileStorageClient()->createBucket(
+            name: $bucketName,
+            stage: $stage,
+            backend: $backend
+        );
     }
 
     /**
@@ -147,7 +151,7 @@ class TestSatisfyer
             // Create table
             $propNames = ['firstTableId', 'secondTableId', 'thirdTableId'];
             for ($i = 0; $i < max($tableCount, count($propNames)); $i++) {
-                $tableIds[$i] = $clientWrapper->getBasicClient()->createTableAsync(
+                $tableIds[$i] = $clientWrapper->getTableAndFileStorageClient()->createTableAsync(
                     $testBucketId,
                     'test' . ($i + 1),
                     $csv

--- a/libs/output-mapping/tests/Writer/BaseWriterMetadataTest.php
+++ b/libs/output-mapping/tests/Writer/BaseWriterMetadataTest.php
@@ -35,7 +35,7 @@ abstract class BaseWriterMetadataTest extends AbstractTestCase
         $csv->writeRow(['Id', 'Name']);
         $csv->writeRow(['test', 'test']);
         $csv->writeRow(['aabb', 'ccdd']);
-        $this->clientWrapper->getBasicClient()->createTableAsync($inputBucket, 'table88', $csv);
+        $this->clientWrapper->getTableAndFileStorageClient()->createTableAsync($inputBucket, 'table88', $csv);
 
         $csv = new CsvFile($root . '/upload/table88b.csv');
         $csv->writeRow(['Id', 'Name', 'Foo']);
@@ -74,7 +74,7 @@ abstract class BaseWriterMetadataTest extends AbstractTestCase
         ];
 
         $runId = $this->clientWrapper->getBasicClient()->generateRunId();
-        $this->clientWrapper->getBasicClient()->setRunId($runId);
+        $this->clientWrapper->getTableAndFileStorageClient()->setRunId($runId);
 
         $writer = new TableWriter($this->getLocalStagingFactory());
         $tableQueue =  $writer->uploadTables(
@@ -89,7 +89,7 @@ abstract class BaseWriterMetadataTest extends AbstractTestCase
         self::assertCount(1, $jobIds);
 
         $writerJobs = array_filter(
-            $this->clientWrapper->getBasicClient()->listJobs(),
+            $this->clientWrapper->getTableAndFileStorageClient()->listJobs(),
             function (array $job) use ($runId) {
                 return $runId === $job['runId'];
             }
@@ -100,7 +100,7 @@ abstract class BaseWriterMetadataTest extends AbstractTestCase
         self::assertTableColumnAddJob(array_pop($writerJobs), 'Foo');
         self::assertTableImportJob(array_pop($writerJobs), $incrementalFlag);
 
-        $metadataApi = new Metadata($this->clientWrapper->getBasicClient());
+        $metadataApi = new Metadata($this->clientWrapper->getTableAndFileStorageClient());
         $idColMetadata = $metadataApi->listColumnMetadata($inputBucket . '.table88.Id');
         $expectedColumnMetadata = [
             'testComponent' => [
@@ -131,7 +131,7 @@ abstract class BaseWriterMetadataTest extends AbstractTestCase
         $csv->writeRow(['Id with special chars', 'Name']);
         $csv->writeRow(['test', 'test']);
         $csv->writeRow(['aabb', 'ccdd']);
-        $this->clientWrapper->getBasicClient()->createTableAsync($inputBucket, 'table88', $csv);
+        $this->clientWrapper->getTableAndFileStorageClient()->createTableAsync($inputBucket, 'table88', $csv);
 
         $csv = new CsvFile($root . '/upload/table88b.csv', ';', '\'');
         $csv->writeRow(['Id with special chars', 'Name', 'Foo']);
@@ -175,7 +175,7 @@ abstract class BaseWriterMetadataTest extends AbstractTestCase
         $jobIds = $tableQueue->waitForAll();
         self::assertCount(1, $jobIds);
 
-        $metadataApi = new Metadata($this->clientWrapper->getBasicClient());
+        $metadataApi = new Metadata($this->clientWrapper->getTableAndFileStorageClient());
         $nameColMetadata = $metadataApi->listColumnMetadata($inputBucket . '.table88.Name');
         $expectedColumnMetadata = [
             'testComponent' => [
@@ -199,7 +199,7 @@ abstract class BaseWriterMetadataTest extends AbstractTestCase
         $csv->writeRow(['Id with special chars', 'Name']);
         $csv->writeRow(['test', 'test']);
         $csv->writeRow(['aabb', 'ccdd']);
-        $this->clientWrapper->getBasicClient()->createTableAsync($inputBucket, 'table88', $csv);
+        $this->clientWrapper->getTableAndFileStorageClient()->createTableAsync($inputBucket, 'table88', $csv);
 
         $csv = new CsvFile($root . '/upload/table88b.csv');
         $csv->writeRow(['Id with special chars', 'Name', 'Foo']);
@@ -247,7 +247,7 @@ abstract class BaseWriterMetadataTest extends AbstractTestCase
         $jobIds = $tableQueue->waitForAll();
         self::assertCount(1, $jobIds);
 
-        $metadataApi = new Metadata($this->clientWrapper->getBasicClient());
+        $metadataApi = new Metadata($this->clientWrapper->getTableAndFileStorageClient());
         $idColMetadata = $metadataApi->listColumnMetadata(
             $inputBucket . '.table88.Id_with_special_chars'
         );
@@ -280,7 +280,7 @@ abstract class BaseWriterMetadataTest extends AbstractTestCase
         $csv->writeRow(['Id', 'Name']);
         $csv->writeRow(['test', 'test']);
         $csv->writeRow(['aabb', 'ccdd']);
-        $this->clientWrapper->getBasicClient()->createTableAsync($inputBucket, 'table99', $csv);
+        $this->clientWrapper->getTableAndFileStorageClient()->createTableAsync($inputBucket, 'table99', $csv);
 
         mkdir($root . '/upload/table99b', 0777, true);
         $csv = new CsvFile($root . '/upload/table99b/slice1.csv');
@@ -330,7 +330,7 @@ abstract class BaseWriterMetadataTest extends AbstractTestCase
         $jobIds = $tableQueue->waitForAll();
         self::assertCount(1, $jobIds);
 
-        $metadataApi = new Metadata($this->clientWrapper->getBasicClient());
+        $metadataApi = new Metadata($this->clientWrapper->getTableAndFileStorageClient());
         $idColMetadata = $metadataApi->listColumnMetadata($inputBucket . '.table99.Id');
         $expectedColumnMetadata = [
             'testComponent' => [

--- a/libs/output-mapping/tests/Writer/File/Strategy/ABSWorkspaceTest.php
+++ b/libs/output-mapping/tests/Writer/File/Strategy/ABSWorkspaceTest.php
@@ -42,7 +42,7 @@ class ABSWorkspaceTest extends AbstractTestCase
         $mock->method('getWorkspaceId')->willReturnCallback(
             function () use ($data): string {
                 if (!$this->workspaceId) {
-                    $workspaces = new Workspaces($this->clientWrapper->getBasicClient());
+                    $workspaces = new Workspaces($this->clientWrapper->getBranchClientIfAvailable());
                     $workspace = $workspaces->createWorkspace(['backend' => 'abs'], true);
                     $this->workspaceId = (string) $workspace['id'];
                     $this->workspace = $data ?: $workspace;
@@ -53,7 +53,7 @@ class ABSWorkspaceTest extends AbstractTestCase
         $mock->method('getCredentials')->willReturnCallback(
             function () use ($data): array {
                 if (!$this->workspaceId) {
-                    $workspaces = new Workspaces($this->clientWrapper->getBasicClient());
+                    $workspaces = new Workspaces($this->clientWrapper->getBranchClientIfAvailable());
                     $workspace = $workspaces->createWorkspace(['backend' => 'abs'], true);
                     $this->workspaceId = (string) $workspace['id'];
                     $this->workspace = $data ?: $workspace;
@@ -100,7 +100,7 @@ class ABSWorkspaceTest extends AbstractTestCase
             $this->getProvider(),
             'json'
         );
-        $workspaces = new Workspaces($this->clientWrapper->getBasicClient());
+        $workspaces = new Workspaces($this->clientWrapper->getBranchClientIfAvailable());
         $workspaces->deleteWorkspace($this->workspace['id'], [], true);
         self::expectException(InvalidOutputException::class);
         self::expectExceptionMessage('Failed to list files: "The specified container does not exist.".');
@@ -177,7 +177,7 @@ class ABSWorkspaceTest extends AbstractTestCase
             $this->getProvider(),
             'json'
         );
-        $workspaces = new Workspaces($this->clientWrapper->getBasicClient());
+        $workspaces = new Workspaces($this->clientWrapper->getBranchClientIfAvailable());
         $workspaces->deleteWorkspace($this->workspace['id'], [], true);
         self::expectException(InvalidOutputException::class);
         self::expectExceptionMessage('Failed to list files: "The specified container does not exist.".');
@@ -251,13 +251,13 @@ class ABSWorkspaceTest extends AbstractTestCase
             'manifest'
         );
         $fileId = $strategy->loadFileToStorage('data/out/files/my-file_one', []);
-        $this->clientWrapper->getBasicClient()->getFile($fileId);
+        $this->clientWrapper->getTableAndFileStorageClient()->getFile($fileId);
         $destination = $this->temp->getTmpFolder() . 'destination';
-        $this->clientWrapper->getBasicClient()->downloadFile($fileId, $destination);
+        $this->clientWrapper->getTableAndFileStorageClient()->downloadFile($fileId, $destination);
         $contents = (string) file_get_contents($destination);
         self::assertEquals('my-data', $contents);
 
-        $file = $this->clientWrapper->getBasicClient()->getFile($fileId);
+        $file = $this->clientWrapper->getTableAndFileStorageClient()->getFile($fileId);
         self::assertEquals($fileId, $file['id']);
         self::assertEquals('my_file_one', $file['name']);
         self::assertEquals([], $file['tags']);
@@ -298,13 +298,13 @@ class ABSWorkspaceTest extends AbstractTestCase
                 'is_encrypted' => true,
             ]
         );
-        $this->clientWrapper->getBasicClient()->getFile($fileId);
+        $this->clientWrapper->getTableAndFileStorageClient()->getFile($fileId);
         $destination = $this->temp->getTmpFolder() . 'destination';
-        $this->clientWrapper->getBasicClient()->downloadFile($fileId, $destination);
+        $this->clientWrapper->getTableAndFileStorageClient()->downloadFile($fileId, $destination);
         $contents = (string) file_get_contents($destination);
         self::assertEquals('my-data', $contents);
 
-        $file = $this->clientWrapper->getBasicClient()->getFile($fileId);
+        $file = $this->clientWrapper->getTableAndFileStorageClient()->getFile($fileId);
         self::assertEquals($fileId, $file['id']);
         self::assertEquals('my_file_one', $file['name']);
         self::assertEquals(['first-tag', 'second-tag'], $file['tags']);

--- a/libs/output-mapping/tests/Writer/File/Strategy/LocalTest.php
+++ b/libs/output-mapping/tests/Writer/File/Strategy/LocalTest.php
@@ -189,13 +189,13 @@ class LocalTest extends AbstractTestCase
             'manifest data'
         );
         $fileId = $strategy->loadFileToStorage('/data/out/files/my-file_one', []);
-        $this->clientWrapper->getBasicClient()->getFile($fileId);
+        $this->clientWrapper->getTableAndFileStorageClient()->getFile($fileId);
         $destination = $this->temp->getTmpFolder() . 'destination';
-        $this->clientWrapper->getBasicClient()->downloadFile($fileId, $destination);
+        $this->clientWrapper->getTableAndFileStorageClient()->downloadFile($fileId, $destination);
         $contents = (string) file_get_contents($destination);
         self::assertEquals('my-data', $contents);
 
-        $file = $this->clientWrapper->getBasicClient()->getFile($fileId);
+        $file = $this->clientWrapper->getTableAndFileStorageClient()->getFile($fileId);
         self::assertEquals($fileId, $file['id']);
         self::assertEquals('my_file_one', $file['name']);
         self::assertEquals([], $file['tags']);
@@ -233,13 +233,13 @@ class LocalTest extends AbstractTestCase
                 'is_encrypted' => true,
             ]
         );
-        $this->clientWrapper->getBasicClient()->getFile($fileId);
+        $this->clientWrapper->getTableAndFileStorageClient()->getFile($fileId);
         $destination = $this->temp->getTmpFolder() . 'destination';
-        $this->clientWrapper->getBasicClient()->downloadFile($fileId, $destination);
+        $this->clientWrapper->getTableAndFileStorageClient()->downloadFile($fileId, $destination);
         $contents = (string) file_get_contents($destination);
         self::assertEquals('my-data', $contents);
 
-        $file = $this->clientWrapper->getBasicClient()->getFile($fileId);
+        $file = $this->clientWrapper->getTableAndFileStorageClient()->getFile($fileId);
         self::assertEquals($fileId, $file['id']);
         self::assertEquals('my_file_one', $file['name']);
         self::assertEquals(['first-tag', 'second-tag'], $file['tags']);

--- a/libs/output-mapping/tests/Writer/Helper/DestinationRewriterTest.php
+++ b/libs/output-mapping/tests/Writer/Helper/DestinationRewriterTest.php
@@ -97,7 +97,7 @@ class DestinationRewriterTest extends TestCase
             }
         );
         $clientWrapper = self::createMock(ClientWrapper::class);
-        $clientWrapper->method('getBasicClient')->willReturn($clientMock);
+        $clientWrapper->method('getBranchClientIfAvailable')->willReturn($clientMock);
         $clientWrapper->method('getBranchId')->willReturn($branchId);
         $clientWrapper->method('hasBranch')->willReturn($branchId !== null);
 

--- a/libs/output-mapping/tests/Writer/Helper/PrimaryKeyHelperTest.php
+++ b/libs/output-mapping/tests/Writer/Helper/PrimaryKeyHelperTest.php
@@ -17,7 +17,7 @@ class PrimaryKeyHelperTest extends AbstractTestCase
     {
         $csv = new CsvFile($this->temp->getTmpFolder() . '/import.csv');
         $csv->writeRow($columns);
-        return $this->clientWrapper->getBasicClient()->createTableAsync(
+        return $this->clientWrapper->getTableAndFileStorageClient()->createTableAsync(
             $this->emptyOutputBucketId,
             'test-table',
             $csv,
@@ -136,12 +136,12 @@ class PrimaryKeyHelperTest extends AbstractTestCase
     {
         $logger = new TestLogger();
         $tableId = $this->createTable(['id', 'name', 'foo'], 'id,name');
-        $tableInfo = $this->clientWrapper->getBasicClient()->getTable($tableId);
+        $tableInfo = $this->clientWrapper->getTableAndFileStorageClient()->getTable($tableId);
         self::assertEquals(['id', 'name'], $tableInfo['primaryKey']);
 
         PrimaryKeyHelper::modifyPrimaryKey(
             $logger,
-            $this->clientWrapper->getBasicClient(),
+            $this->clientWrapper->getTableAndFileStorageClient(),
             $tableId,
             ['id', 'name'],
             ['id', 'foo']
@@ -149,7 +149,7 @@ class PrimaryKeyHelperTest extends AbstractTestCase
         self::assertTrue($logger->hasWarningThatContains(
             sprintf('Modifying primary key of table "%s" from "id, name" to "id, foo".', $tableId)
         ));
-        $tableInfo = $this->clientWrapper->getBasicClient()->getTable($tableId);
+        $tableInfo = $this->clientWrapper->getTableAndFileStorageClient()->getTable($tableId);
         self::assertEquals(['id', 'foo'], $tableInfo['primaryKey']);
     }
 
@@ -158,12 +158,12 @@ class PrimaryKeyHelperTest extends AbstractTestCase
     {
         $logger = new TestLogger();
         $tableId = $this->createTable(['id', 'name', 'foo'], '');
-        $tableInfo = $this->clientWrapper->getBasicClient()->getTable($tableId);
+        $tableInfo = $this->clientWrapper->getTableAndFileStorageClient()->getTable($tableId);
         self::assertEquals([], $tableInfo['primaryKey']);
 
         PrimaryKeyHelper::modifyPrimaryKey(
             $logger,
-            $this->clientWrapper->getBasicClient(),
+            $this->clientWrapper->getTableAndFileStorageClient(),
             $tableId,
             [ ],
             ['id', 'foo']
@@ -171,7 +171,7 @@ class PrimaryKeyHelperTest extends AbstractTestCase
         self::assertTrue($logger->hasWarningThatContains(
             sprintf('Modifying primary key of table "%s" from "" to "id, foo".', $tableId)
         ));
-        $tableInfo = $this->clientWrapper->getBasicClient()->getTable($tableId);
+        $tableInfo = $this->clientWrapper->getTableAndFileStorageClient()->getTable($tableId);
         self::assertEquals(['id', 'foo'], $tableInfo['primaryKey']);
     }
 
@@ -180,12 +180,12 @@ class PrimaryKeyHelperTest extends AbstractTestCase
     {
         $logger = new TestLogger();
         $tableId = $this->createTable(['id', 'name', 'foo'], 'id,foo');
-        $tableInfo = $this->clientWrapper->getBasicClient()->getTable($tableId);
+        $tableInfo = $this->clientWrapper->getTableAndFileStorageClient()->getTable($tableId);
         self::assertEquals(['id', 'foo'], $tableInfo['primaryKey']);
 
         PrimaryKeyHelper::modifyPrimaryKey(
             $logger,
-            $this->clientWrapper->getBasicClient(),
+            $this->clientWrapper->getTableAndFileStorageClient(),
             $tableId,
             $tableInfo['primaryKey'],
             []
@@ -193,7 +193,7 @@ class PrimaryKeyHelperTest extends AbstractTestCase
         self::assertTrue($logger->hasWarningThatContains(
             sprintf('Modifying primary key of table "%s" from "id, foo" to "".', $tableId)
         ));
-        $tableInfo = $this->clientWrapper->getBasicClient()->getTable($tableId);
+        $tableInfo = $this->clientWrapper->getTableAndFileStorageClient()->getTable($tableId);
         self::assertEquals([], $tableInfo['primaryKey']);
     }
 
@@ -202,13 +202,13 @@ class PrimaryKeyHelperTest extends AbstractTestCase
     {
         $logger = new TestLogger();
         $tableId = $this->createTable(['id', 'name', 'foo'], 'id,name');
-        $tableInfo = $this->clientWrapper->getBasicClient()->getTable($tableId);
+        $tableInfo = $this->clientWrapper->getTableAndFileStorageClient()->getTable($tableId);
         self::assertEquals(['id', 'name'], $tableInfo['primaryKey']);
         $invalidTableId = $tableId . '-non-existent';
 
         PrimaryKeyHelper::modifyPrimaryKey(
             $logger,
-            $this->clientWrapper->getBasicClient(),
+            $this->clientWrapper->getTableAndFileStorageClient(),
             $invalidTableId,
             ['id', 'name'],
             ['id', 'foo']
@@ -224,7 +224,7 @@ class PrimaryKeyHelperTest extends AbstractTestCase
                 $this->emptyOutputBucketId
             )
         ));
-        $tableInfo = $this->clientWrapper->getBasicClient()->getTable($tableId);
+        $tableInfo = $this->clientWrapper->getTableAndFileStorageClient()->getTable($tableId);
         self::assertEquals(['id', 'name'], $tableInfo['primaryKey']);
     }
 
@@ -233,12 +233,12 @@ class PrimaryKeyHelperTest extends AbstractTestCase
     {
         $logger = new TestLogger();
         $tableId = $this->createTable(['id', 'name', 'foo'], 'id,name');
-        $tableInfo = $this->clientWrapper->getBasicClient()->getTable($tableId);
+        $tableInfo = $this->clientWrapper->getTableAndFileStorageClient()->getTable($tableId);
         self::assertEquals(['id', 'name'], $tableInfo['primaryKey']);
 
         PrimaryKeyHelper::modifyPrimaryKey(
             $logger,
-            $this->clientWrapper->getBasicClient(),
+            $this->clientWrapper->getTableAndFileStorageClient(),
             $tableId,
             ['id', 'name'],
             ['id', 'bar']
@@ -252,7 +252,7 @@ class PrimaryKeyHelperTest extends AbstractTestCase
                 $tableId
             )
         ));
-        $tableInfo = $this->clientWrapper->getBasicClient()->getTable($tableId);
+        $tableInfo = $this->clientWrapper->getTableAndFileStorageClient()->getTable($tableId);
         self::assertEquals(['id', 'name'], $tableInfo['primaryKey']);
     }
 }

--- a/libs/output-mapping/tests/Writer/Redshift/RedshiftWriterWorkspaceTest.php
+++ b/libs/output-mapping/tests/Writer/Redshift/RedshiftWriterWorkspaceTest.php
@@ -33,7 +33,7 @@ class RedshiftWriterWorkspaceTest extends AbstractTestCase
         $tableIds = [];
         // Create table
         for ($i = 0; $i < 2; $i++) {
-            $tableIds[$i] = $this->clientWrapper->getBasicClient()->createTableAsync(
+            $tableIds[$i] = $this->clientWrapper->getTableAndFileStorageClient()->createTableAsync(
                 $this->emptyRedshiftInputBucketId,
                 'test' . ($i + 1),
                 $csv

--- a/libs/output-mapping/tests/Writer/Redshift/StorageApiLocalTableWriterRedshiftTest.php
+++ b/libs/output-mapping/tests/Writer/Redshift/StorageApiLocalTableWriterRedshiftTest.php
@@ -37,13 +37,15 @@ class StorageApiLocalTableWriterRedshiftTest extends AbstractTestCase
         $jobIds = $tableQueue->waitForAll();
         self::assertCount(1, $jobIds);
 
-        $tables = $this->clientWrapper->getBasicClient()->listTables($this->emptyRedshiftOutputBucketId);
+        $tables = $this->clientWrapper->getTableAndFileStorageClient()->listTables($this->emptyRedshiftOutputBucketId);
         self::assertCount(1, $tables);
         self::assertEquals($this->emptyRedshiftOutputBucketId . '.table3d', $tables[0]['id']);
-        $exporter = new TableExporter($this->clientWrapper->getBasicClient());
+        $exporter = new TableExporter($this->clientWrapper->getTableAndFileStorageClient());
         $downloadedFile = $root . DIRECTORY_SEPARATOR . 'download.csv';
         $exporter->exportTable($this->emptyRedshiftOutputBucketId . '.table3d', $downloadedFile, []);
-        $table = $this->clientWrapper->getBasicClient()->parseCsv((string) file_get_contents($downloadedFile));
+        $table = $this->clientWrapper->getTableAndFileStorageClient()->parseCsv(
+            (string) file_get_contents($downloadedFile)
+        );
         self::assertCount(1, $table);
         self::assertCount(2, $table[0]);
         self::assertArrayHasKey('Id', $table[0]);
@@ -97,13 +99,13 @@ class StorageApiLocalTableWriterRedshiftTest extends AbstractTestCase
         $jobIds = $tableQueue->waitForAll();
         self::assertCount(1, $jobIds);
 
-        $exporter = new TableExporter($this->clientWrapper->getBasicClient());
+        $exporter = new TableExporter($this->clientWrapper->getTableAndFileStorageClient());
         $exporter->exportTable(
             $this->emptyRedshiftOutputBucketId . '.table61',
             $root . DIRECTORY_SEPARATOR . 'download.csv',
             []
         );
-        $table = $this->clientWrapper->getBasicClient()->parseCsv(
+        $table = $this->clientWrapper->getTableAndFileStorageClient()->parseCsv(
             (string) file_get_contents($root . DIRECTORY_SEPARATOR . 'download.csv')
         );
         usort($table, function ($a, $b) {

--- a/libs/output-mapping/tests/Writer/Redshift/StorageApiSlicedWriterRedshiftTest.php
+++ b/libs/output-mapping/tests/Writer/Redshift/StorageApiSlicedWriterRedshiftTest.php
@@ -71,7 +71,7 @@ class StorageApiSlicedWriterRedshiftTest extends AbstractTestCase
         self::assertContains(['Id' => 'test', 'Name' => 'test'], $table);
         self::assertContains(['Id' => 'aabb', 'Name' => 'ccdd'], $table);
 
-        $job = $this->clientWrapper->getBasicClient()->getJob($jobIds[0]);
+        $job = $this->clientWrapper->getBranchClientIfAvailable()->getJob($jobIds[0]);
         $fileId = $job['operationParams']['source']['fileId'];
         $file = $this->clientWrapper->getTableAndFileStorageClient()->getFile($fileId);
         self::assertEquals([], $file['tags']);
@@ -105,6 +105,7 @@ class StorageApiSlicedWriterRedshiftTest extends AbstractTestCase
         $client->method('verifyToken')->willReturn($tokenInfo);
         $clientWrapper = $this->createMock(ClientWrapper::class);
         $clientWrapper->method('getBranchClientIfAvailable')->willReturn($client);
+        $clientWrapper->method('getTableAndFileStorageClient')->willReturn($client);
         $writer = new TableWriter($this->getLocalStagingFactory($clientWrapper));
 
         $tableQueue = $writer->uploadTables(
@@ -135,7 +136,7 @@ class StorageApiSlicedWriterRedshiftTest extends AbstractTestCase
         self::assertContains(['Id' => 'test', 'Name' => 'test'], $table);
         self::assertContains(['Id' => 'aabb', 'Name' => 'ccdd'], $table);
 
-        $job = $this->clientWrapper->getBasicClient()->getJob($jobIds[0]);
+        $job = $this->clientWrapper->getBranchClientIfAvailable()->getJob($jobIds[0]);
         $fileId = $job['operationParams']['source']['fileId'];
         $file = $this->clientWrapper->getTableAndFileStorageClient()->getFile($fileId);
         self::assertEquals(

--- a/libs/output-mapping/tests/Writer/SnowflakeWriterMetadataTest.php
+++ b/libs/output-mapping/tests/Writer/SnowflakeWriterMetadataTest.php
@@ -81,7 +81,7 @@ class SnowflakeWriterMetadataTest extends BaseWriterMetadataTest
         );
         $jobIds = $tableQueue->waitForAll();
         self::assertCount(1, $jobIds);
-        $metadataApi = new Metadata($this->clientWrapper->getBasicClient());
+        $metadataApi = new Metadata($this->clientWrapper->getTableAndFileStorageClient());
 
         $tableMetadata = $metadataApi->listTableMetadata($this->emptyOutputBucketId . '.table55');
         $expectedTableMetadata = [
@@ -234,7 +234,7 @@ class SnowflakeWriterMetadataTest extends BaseWriterMetadataTest
         $jobIds = $tableQueue->waitForAll();
         self::assertCount(1, $jobIds);
 
-        $metadataApi = new Metadata($this->clientWrapper->getBasicClient());
+        $metadataApi = new Metadata($this->clientWrapper->getTableAndFileStorageClient());
 
         $tableMetadata = $metadataApi->listTableMetadata($this->emptyOutputBucketId . '.table66');
         $expectedTableMetadata = [

--- a/libs/output-mapping/tests/Writer/StorageApiFileWriterTest.php
+++ b/libs/output-mapping/tests/Writer/StorageApiFileWriterTest.php
@@ -463,6 +463,16 @@ class StorageApiFileWriterTest extends AbstractTestCase
 
     public function testTagBranchProcessedFiles(): void
     {
+        $clientWrapper = new ClientWrapper(
+            new ClientOptions(
+                (string) getenv('STORAGE_API_URL'),
+                (string) getenv('STORAGE_API_TOKEN_MASTER'),
+                null
+            )
+        );
+        $branchName = self::class;
+        $branchId = $this->createBranch($clientWrapper, $branchName);
+
         $root = $this->temp->getTmpFolder();
         file_put_contents($root . '/upload/test', 'test');
 
@@ -472,11 +482,11 @@ class StorageApiFileWriterTest extends AbstractTestCase
         );
         $id2 = $this->clientWrapper->getTableAndFileStorageClient()->uploadFile(
             $root . '/upload/test',
-            (new FileUploadOptions())->setTags(['12345-' . self::FILE_TAG])
+            (new FileUploadOptions())->setTags([$branchId . '-' . self::FILE_TAG])
         );
         sleep(1);
         // set it to use a branch
-        $this->initClient('12345');
+        $this->initClient($branchId);
 
         $writer = new FileWriter($this->getLocalStagingFactory());
         $configuration = [['tags' => [self::FILE_TAG], 'processed_tags' => ['downloaded']]];
@@ -484,10 +494,10 @@ class StorageApiFileWriterTest extends AbstractTestCase
 
         // first file shouldn't be marked as processed because a branch file exists
         $file1 = $this->clientWrapper->getTableAndFileStorageClient()->getFile($id1);
-        self::assertTrue(!in_array('12345-downloaded', $file1['tags']));
+        self::assertTrue(!in_array($branchId . '-downloaded', $file1['tags']));
         $file2 = $this->clientWrapper->getTableAndFileStorageClient()->getFile($id2);
-        self::assertTrue(in_array('12345-downloaded', $file2['tags']));
-        self::assertTrue(in_array('12345-' . self::FILE_TAG, $file2['tags']));
+        self::assertTrue(in_array($branchId . '-downloaded', $file2['tags']));
+        self::assertTrue(in_array($branchId . '-' . self::FILE_TAG, $file2['tags']));
     }
 
     public function testTableFiles(): void

--- a/libs/output-mapping/tests/Writer/StorageApiFileWriterTest.php
+++ b/libs/output-mapping/tests/Writer/StorageApiFileWriterTest.php
@@ -75,7 +75,7 @@ class StorageApiFileWriterTest extends AbstractTestCase
 
         $options = new ListFilesOptions();
         $options->setTags([self::FILE_TAG]);
-        $files = $this->clientWrapper->getBasicClient()->listFiles($options);
+        $files = $this->clientWrapper->getTableAndFileStorageClient()->listFiles($options);
         self::assertCount(3, $files);
 
         $file1 = $file2 = $file3 = null;
@@ -147,7 +147,7 @@ class StorageApiFileWriterTest extends AbstractTestCase
 
         $options = new ListFilesOptions();
         $options->setTags([self::FILE_TAG]);
-        $files = $this->clientWrapper->getBasicClient()->listFiles($options);
+        $files = $this->clientWrapper->getTableAndFileStorageClient()->listFiles($options);
         // no files should be uploaded since, isFailedJob was true and write_always is not implemented for files
         self::assertCount(0, $files);
     }
@@ -178,7 +178,7 @@ class StorageApiFileWriterTest extends AbstractTestCase
 
         $options = new ListFilesOptions();
         $options->setTags([self::FILE_TAG]);
-        $files = $this->clientWrapper->getBasicClient()->listFiles($options);
+        $files = $this->clientWrapper->getTableAndFileStorageClient()->listFiles($options);
         self::assertCount(1, $files);
 
         $file1 = null;
@@ -245,7 +245,7 @@ class StorageApiFileWriterTest extends AbstractTestCase
 
         $options = new ListFilesOptions();
         $options->setTags([sprintf('%s-' . self::FILE_TAG, $branchId)]);
-        $files = $this->clientWrapper->getBasicClient()->listFiles($options);
+        $files = $this->clientWrapper->getTableAndFileStorageClient()->listFiles($options);
         self::assertCount(1, $files);
 
         $file1 = null;
@@ -299,7 +299,7 @@ class StorageApiFileWriterTest extends AbstractTestCase
 
         $options = new ListFilesOptions();
         $options->setTags([self::FILE_TAG]);
-        $files = $this->clientWrapper->getBasicClient()->listFiles($options);
+        $files = $this->clientWrapper->getTableAndFileStorageClient()->listFiles($options);
         self::assertCount(1, $files);
 
         $file1 = null;
@@ -441,11 +441,11 @@ class StorageApiFileWriterTest extends AbstractTestCase
         $root = $this->temp->getTmpFolder();
         file_put_contents($root . '/upload/test', 'test');
 
-        $id1 = $this->clientWrapper->getBasicClient()->uploadFile(
+        $id1 = $this->clientWrapper->getTableAndFileStorageClient()->uploadFile(
             $root . '/upload/test',
             (new FileUploadOptions())->setTags([self::FILE_TAG])
         );
-        $id2 = $this->clientWrapper->getBasicClient()->uploadFile(
+        $id2 = $this->clientWrapper->getTableAndFileStorageClient()->uploadFile(
             $root . '/upload/test',
             (new FileUploadOptions())->setTags([self::FILE_TAG])
         );
@@ -455,9 +455,9 @@ class StorageApiFileWriterTest extends AbstractTestCase
         $configuration = [['tags' => [self::FILE_TAG], 'processed_tags' => ['downloaded']]];
         $writer->tagFiles($configuration);
 
-        $file = $this->clientWrapper->getBasicClient()->getFile($id1);
+        $file = $this->clientWrapper->getTableAndFileStorageClient()->getFile($id1);
         self::assertTrue(in_array('downloaded', $file['tags']));
-        $file = $this->clientWrapper->getBasicClient()->getFile($id2);
+        $file = $this->clientWrapper->getTableAndFileStorageClient()->getFile($id2);
         self::assertTrue(in_array('downloaded', $file['tags']));
     }
 
@@ -466,11 +466,11 @@ class StorageApiFileWriterTest extends AbstractTestCase
         $root = $this->temp->getTmpFolder();
         file_put_contents($root . '/upload/test', 'test');
 
-        $id1 = $this->clientWrapper->getBasicClient()->uploadFile(
+        $id1 = $this->clientWrapper->getTableAndFileStorageClient()->uploadFile(
             $root . '/upload/test',
             (new FileUploadOptions())->setTags([self::FILE_TAG])
         );
-        $id2 = $this->clientWrapper->getBasicClient()->uploadFile(
+        $id2 = $this->clientWrapper->getTableAndFileStorageClient()->uploadFile(
             $root . '/upload/test',
             (new FileUploadOptions())->setTags(['12345-' . self::FILE_TAG])
         );
@@ -483,9 +483,9 @@ class StorageApiFileWriterTest extends AbstractTestCase
         $writer->tagFiles($configuration);
 
         // first file shouldn't be marked as processed because a branch file exists
-        $file1 = $this->clientWrapper->getBasicClient()->getFile($id1);
+        $file1 = $this->clientWrapper->getTableAndFileStorageClient()->getFile($id1);
         self::assertTrue(!in_array('12345-downloaded', $file1['tags']));
-        $file2 = $this->clientWrapper->getBasicClient()->getFile($id2);
+        $file2 = $this->clientWrapper->getTableAndFileStorageClient()->getFile($id2);
         self::assertTrue(in_array('12345-downloaded', $file2['tags']));
         self::assertTrue(in_array('12345-' . self::FILE_TAG, $file2['tags']));
     }
@@ -525,7 +525,7 @@ class StorageApiFileWriterTest extends AbstractTestCase
 
         $options = new ListFilesOptions();
         $options->setTags([self::FILE_TAG]);
-        $files = $this->clientWrapper->getBasicClient()->listFiles($options);
+        $files = $this->clientWrapper->getTableAndFileStorageClient()->listFiles($options);
         self::assertCount(1, $files);
 
         $expectedTags = [

--- a/libs/output-mapping/tests/Writer/StorageApiHeadlessWriterTest.php
+++ b/libs/output-mapping/tests/Writer/StorageApiHeadlessWriterTest.php
@@ -40,15 +40,17 @@ class StorageApiHeadlessWriterTest extends AbstractTestCase
         self::assertCount(1, $jobIds);
         self::assertEquals(1, $tableQueue->getTaskCount());
 
-        $tables = $this->clientWrapper->getBasicClient()->listTables($this->emptyOutputBucketId);
+        $tables = $this->clientWrapper->getTableAndFileStorageClient()->listTables($this->emptyOutputBucketId);
         self::assertCount(1, $tables);
-        $table = $this->clientWrapper->getBasicClient()->getTable($this->emptyOutputBucketId . '.table');
+        $table = $this->clientWrapper->getTableAndFileStorageClient()->getTable($this->emptyOutputBucketId . '.table');
         self::assertEquals(['Id', 'Name'], $table['columns']);
 
-        $exporter = new TableExporter($this->clientWrapper->getBasicClient());
+        $exporter = new TableExporter($this->clientWrapper->getTableAndFileStorageClient());
         $downloadedFile = $root . DIRECTORY_SEPARATOR . 'download.csv';
         $exporter->exportTable($this->emptyOutputBucketId . '.table', $downloadedFile, []);
-        $table = $this->clientWrapper->getBasicClient()->parseCsv((string) file_get_contents($downloadedFile));
+        $table = $this->clientWrapper->getTableAndFileStorageClient()->parseCsv(
+            (string) file_get_contents($downloadedFile)
+        );
         self::assertCount(2, $table);
         self::assertContains(['Id' => 'test', 'Name' => 'test'], $table);
         self::assertContains(['Id' => 'aabb', 'Name' => 'ccdd'], $table);
@@ -80,13 +82,15 @@ class StorageApiHeadlessWriterTest extends AbstractTestCase
         $jobIds = $tableQueue->waitForAll();
         self::assertCount(1, $jobIds);
 
-        $table = $this->clientWrapper->getBasicClient()->getTable($this->emptyOutputBucketId . '.table');
+        $table = $this->clientWrapper->getTableAndFileStorageClient()->getTable($this->emptyOutputBucketId . '.table');
         self::assertEquals(['Id', 'Name'], $table['columns']);
 
-        $exporter = new TableExporter($this->clientWrapper->getBasicClient());
+        $exporter = new TableExporter($this->clientWrapper->getTableAndFileStorageClient());
         $downloadedFile = $this->temp->getTmpFolder() . DIRECTORY_SEPARATOR . 'download.csv';
         $exporter->exportTable($this->emptyOutputBucketId . '.table', $downloadedFile, []);
-        $table = $this->clientWrapper->getBasicClient()->parseCsv((string) file_get_contents($downloadedFile));
+        $table = $this->clientWrapper->getTableAndFileStorageClient()->parseCsv(
+            (string) file_get_contents($downloadedFile)
+        );
         self::assertCount(0, $table);
     }
 
@@ -123,16 +127,18 @@ class StorageApiHeadlessWriterTest extends AbstractTestCase
         $jobIds = $tableQueue->waitForAll();
         self::assertCount(1, $jobIds);
 
-        $tables = $this->clientWrapper->getBasicClient()->listTables($this->emptyOutputBucketId);
+        $tables = $this->clientWrapper->getTableAndFileStorageClient()->listTables($this->emptyOutputBucketId);
         self::assertCount(1, $tables);
         self::assertEquals($this->emptyOutputBucketId . '.table', $tables[0]['id']);
-        $table = $this->clientWrapper->getBasicClient()->getTable($this->emptyOutputBucketId . '.table');
+        $table = $this->clientWrapper->getTableAndFileStorageClient()->getTable($this->emptyOutputBucketId . '.table');
         self::assertEquals(['Id', 'Name'], $table['columns']);
 
-        $exporter = new TableExporter($this->clientWrapper->getBasicClient());
+        $exporter = new TableExporter($this->clientWrapper->getTableAndFileStorageClient());
         $downloadedFile = $this->temp->getTmpFolder() . DIRECTORY_SEPARATOR . 'download.csv';
         $exporter->exportTable($this->emptyOutputBucketId . '.table', $downloadedFile, []);
-        $table = $this->clientWrapper->getBasicClient()->parseCsv((string) file_get_contents($downloadedFile));
+        $table = $this->clientWrapper->getTableAndFileStorageClient()->parseCsv(
+            (string) file_get_contents($downloadedFile)
+        );
         self::assertCount(1, $table);
         self::assertEquals([['Id' => 'test', 'Name' => 'test']], $table);
     }
@@ -163,17 +169,19 @@ class StorageApiHeadlessWriterTest extends AbstractTestCase
         $jobIds = $tableQueue->waitForAll();
         self::assertCount(1, $jobIds);
 
-        $tables = $this->clientWrapper->getBasicClient()->listTables($this->emptyOutputBucketId);
+        $tables = $this->clientWrapper->getTableAndFileStorageClient()->listTables($this->emptyOutputBucketId);
         self::assertCount(1, $tables);
         self::assertEquals($this->emptyOutputBucketId . '.table', $tables[0]['id']);
-        $table = $this->clientWrapper->getBasicClient()->getTable($this->emptyOutputBucketId . '.table');
+        $table = $this->clientWrapper->getTableAndFileStorageClient()->getTable($this->emptyOutputBucketId . '.table');
         self::assertEquals(['Id', 'Name'], $table['primaryKey']);
         self::assertEquals(['Id', 'Name'], $table['columns']);
 
-        $exporter = new TableExporter($this->clientWrapper->getBasicClient());
+        $exporter = new TableExporter($this->clientWrapper->getTableAndFileStorageClient());
         $downloadedFile = $this->temp->getTmpFolder() . DIRECTORY_SEPARATOR . 'download.csv';
         $exporter->exportTable($this->emptyOutputBucketId . '.table', $downloadedFile, []);
-        $table = $this->clientWrapper->getBasicClient()->parseCsv((string) file_get_contents($downloadedFile));
+        $table = $this->clientWrapper->getTableAndFileStorageClient()->parseCsv(
+            (string) file_get_contents($downloadedFile)
+        );
         self::assertCount(1, $table);
         self::assertEquals([['Id' => 'test', 'Name' => 'test']], $table);
     }
@@ -183,10 +191,14 @@ class StorageApiHeadlessWriterTest extends AbstractTestCase
     {
         $csvFile = new CsvFile($this->temp->createFile('header')->getPathname());
         $csvFile->writeRow(['Id', 'Name']);
-        $this->clientWrapper->getBasicClient()->createTable($this->emptyOutputBucketId, 'table', $csvFile);
-        $tables = $this->clientWrapper->getBasicClient()->listTables($this->emptyOutputBucketId);
+        $this->clientWrapper->getTableAndFileStorageClient()->createTable(
+            $this->emptyOutputBucketId,
+            'table',
+            $csvFile
+        );
+        $tables = $this->clientWrapper->getTableAndFileStorageClient()->listTables($this->emptyOutputBucketId);
         self::assertCount(1, $tables);
-        $table = $this->clientWrapper->getBasicClient()->getTable($this->emptyOutputBucketId . '.table');
+        $table = $this->clientWrapper->getTableAndFileStorageClient()->getTable($this->emptyOutputBucketId . '.table');
         self::assertEquals(['Id', 'Name'], $table['columns']);
 
         $root = $this->temp->getTmpFolder();
@@ -212,15 +224,17 @@ class StorageApiHeadlessWriterTest extends AbstractTestCase
         $jobIds = $tableQueue->waitForAll();
         self::assertCount(1, $jobIds);
 
-        $tables = $this->clientWrapper->getBasicClient()->listTables($this->emptyOutputBucketId);
+        $tables = $this->clientWrapper->getTableAndFileStorageClient()->listTables($this->emptyOutputBucketId);
         self::assertCount(1, $tables);
-        $table = $this->clientWrapper->getBasicClient()->getTable($this->emptyOutputBucketId . '.table');
+        $table = $this->clientWrapper->getTableAndFileStorageClient()->getTable($this->emptyOutputBucketId . '.table');
         self::assertEquals(['Id', 'Name'], $table['columns']);
 
-        $exporter = new TableExporter($this->clientWrapper->getBasicClient());
+        $exporter = new TableExporter($this->clientWrapper->getTableAndFileStorageClient());
         $downloadedFile = $this->temp->getTmpFolder() . DIRECTORY_SEPARATOR . 'download.csv';
         $exporter->exportTable($this->emptyOutputBucketId . '.table', $downloadedFile, []);
-        $table = $this->clientWrapper->getBasicClient()->parseCsv((string) file_get_contents($downloadedFile));
+        $table = $this->clientWrapper->getTableAndFileStorageClient()->parseCsv(
+            (string) file_get_contents($downloadedFile)
+        );
         self::assertCount(2, $table);
         self::assertContains(['Id' => 'test', 'Name' => 'test'], $table);
         self::assertContains(['Id' => 'aabb', 'Name' => 'ccdd'], $table);

--- a/libs/output-mapping/tests/Writer/StorageApiLocalTableWriterTest.php
+++ b/libs/output-mapping/tests/Writer/StorageApiLocalTableWriterTest.php
@@ -75,7 +75,7 @@ class StorageApiLocalTableWriterTest extends AbstractTestCase
         self::assertNotEmpty($jobIds[0]);
         self::assertNotEmpty($jobIds[1]);
 
-        $job = $this->clientWrapper->getBasicClient()->getJob($jobIds[0]);
+        $job = $this->clientWrapper->getBranchClientIfAvailable()->getJob($jobIds[0]);
         $fileId = $job['operationParams']['source']['fileId'];
         $file = $this->clientWrapper->getTableAndFileStorageClient()->getFile($fileId);
         self::assertEquals([], $file['tags']);
@@ -135,6 +135,7 @@ class StorageApiLocalTableWriterTest extends AbstractTestCase
         $client->method('verifyToken')->willReturn($tokenInfo);
         $clientWrapper = $this->createMock(ClientWrapper::class);
         $clientWrapper->method('getBranchClientIfAvailable')->willReturn($client);
+        $clientWrapper->method('getTableAndFileStorageClient')->willReturn($client);
         $writer = new TableWriter($this->getLocalStagingFactory($clientWrapper));
 
         $tableQueue =  $writer->uploadTables(
@@ -158,7 +159,7 @@ class StorageApiLocalTableWriterTest extends AbstractTestCase
             ]
         );
 
-        $job = $this->clientWrapper->getBasicClient()->getJob($jobIds[0]);
+        $job = $this->clientWrapper->getBranchClientIfAvailable()->getJob($jobIds[0]);
         $fileId = $job['operationParams']['source']['fileId'];
         $file = $this->clientWrapper->getTableAndFileStorageClient()->getFile($fileId);
         self::assertEquals(
@@ -219,9 +220,9 @@ class StorageApiLocalTableWriterTest extends AbstractTestCase
         self::assertNotEmpty($jobIds[0]);
         self::assertNotEmpty($jobIds[1]);
 
-        $jobDetail = $this->clientWrapper->getBasicClient()->getJob($jobIds[0]);
+        $jobDetail = $this->clientWrapper->getBranchClientIfAvailable()->getJob($jobIds[0]);
         $tableIds[] = $jobDetail['results']['id'];
-        $jobDetail = $this->clientWrapper->getBasicClient()->getJob($jobIds[1]);
+        $jobDetail = $this->clientWrapper->getBranchClientIfAvailable()->getJob($jobIds[1]);
         $tableIds[] = $jobDetail['results']['id'];
 
         sort($tableIds);
@@ -545,7 +546,7 @@ class StorageApiLocalTableWriterTest extends AbstractTestCase
         );
         $jobIds = $tableQueue->waitForAll();
         self::assertCount(1, $jobIds);
-        $this->clientWrapper->getBasicClient()->handleAsyncTasks($jobIds);
+        $this->clientWrapper->getBranchClientIfAvailable()->handleAsyncTasks($jobIds);
 
         // And again, check first incremental table
         $tableQueue =  $writer->uploadTables(
@@ -772,7 +773,7 @@ class StorageApiLocalTableWriterTest extends AbstractTestCase
         );
         $jobIds = $tableQueue->waitForAll();
         self::assertCount(1, $jobIds);
-        $this->clientWrapper->getBasicClient()->handleAsyncTasks($jobIds);
+        $this->clientWrapper->getBranchClientIfAvailable()->handleAsyncTasks($jobIds);
         self::assertFalse($testLogger->hasWarningThatContains('Output mapping does not match destination table'));
         $tableInfo = $this->clientWrapper->getTableAndFileStorageClient()->getTable(
             $this->emptyOutputBucketId . '.table12'
@@ -1108,7 +1109,7 @@ class StorageApiLocalTableWriterTest extends AbstractTestCase
         );
         $jobIds = $tableQueue->waitForAll();
         self::assertCount(1, $jobIds);
-        $jobDetail = $this->clientWrapper->getBasicClient()->getJob($jobIds[0]);
+        $jobDetail = $this->clientWrapper->getBranchClientIfAvailable()->getJob($jobIds[0]);
         $tableId = $jobDetail['results']['id'];
         $tableParts = explode('.', $tableId);
         array_pop($tableParts);

--- a/libs/output-mapping/tests/Writer/StorageApiSlicedWriterTest.php
+++ b/libs/output-mapping/tests/Writer/StorageApiSlicedWriterTest.php
@@ -69,7 +69,7 @@ class StorageApiSlicedWriterTest extends AbstractTestCase
         self::assertContains(['Id' => 'test', 'Name' => 'test'], $table);
         self::assertContains(['Id' => 'aabb', 'Name' => 'ccdd'], $table);
 
-        $job = $this->clientWrapper->getBasicClient()->getJob($jobIds[0]);
+        $job = $this->clientWrapper->getBranchClientIfAvailable()->getJob($jobIds[0]);
         $fileId = $job['operationParams']['source']['fileId'];
         $file = $this->clientWrapper->getTableAndFileStorageClient()->getFile($fileId);
         self::assertEquals([], $file['tags']);
@@ -103,6 +103,7 @@ class StorageApiSlicedWriterTest extends AbstractTestCase
         $client->method('verifyToken')->willReturn($tokenInfo);
         $clientWrapper = $this->createMock(ClientWrapper::class);
         $clientWrapper->method('getBranchClientIfAvailable')->willReturn($client);
+        $clientWrapper->method('getTableAndFileStorageClient')->willReturn($client);
         $writer = new TableWriter($this->getWorkspaceStagingFactory($clientWrapper));
 
         $tableQueue =  $writer->uploadTables(
@@ -131,7 +132,7 @@ class StorageApiSlicedWriterTest extends AbstractTestCase
         self::assertContains(['Id' => 'test', 'Name' => 'test'], $table);
         self::assertContains(['Id' => 'aabb', 'Name' => 'ccdd'], $table);
 
-        $job = $this->clientWrapper->getBasicClient()->getJob($jobIds[0]);
+        $job = $this->clientWrapper->getBranchClientIfAvailable()->getJob($jobIds[0]);
         $fileId = $job['operationParams']['source']['fileId'];
         $file = $this->clientWrapper->getTableAndFileStorageClient()->getFile($fileId);
         self::assertEquals(

--- a/libs/output-mapping/tests/Writer/TableDefinitionTest.php
+++ b/libs/output-mapping/tests/Writer/TableDefinitionTest.php
@@ -25,7 +25,7 @@ class TableDefinitionTest extends AbstractTestCase
             'tables-definition',
         ];
 
-        $tokenData = $this->clientWrapper->getBasicClient()->verifyToken();
+        $tokenData = $this->clientWrapper->getBranchClientIfAvailable()->verifyToken();
         foreach ($requiredFeatures as $requiredFeature) {
             if (!in_array($requiredFeature, $tokenData['owner']['features'])) {
                 self::fail(sprintf(
@@ -72,7 +72,7 @@ class TableDefinitionTest extends AbstractTestCase
         );
         $jobIds = $tableQueue->waitForAll();
         self::assertCount(1, $jobIds);
-        $tableDetails = $this->clientWrapper->getBasicClient()->getTable($tableId);
+        $tableDetails = $this->clientWrapper->getTableAndFileStorageClient()->getTable($tableId);
         self::assertFalse($tableDetails['isTyped']);
     }
 
@@ -149,7 +149,7 @@ class TableDefinitionTest extends AbstractTestCase
         );
         $jobIds = $tableQueue->waitForAll();
         self::assertCount(1, $jobIds);
-        $tableDetails = $this->clientWrapper->getBasicClient()->getTable($config['destination']);
+        $tableDetails = $this->clientWrapper->getTableAndFileStorageClient()->getTable($config['destination']);
         self::assertTrue($tableDetails['isTyped']);
 
         self::assertDataTypeDefinition($tableDetails['columnMetadata']['Id'], $expectedTypes['Id']);
@@ -277,7 +277,7 @@ class TableDefinitionTest extends AbstractTestCase
             ],
         ];
 
-        $this->clientWrapper->getBasicClient()->createTableDefinition($this->emptyInputBucketId, [
+        $this->clientWrapper->getTableAndFileStorageClient()->createTableDefinition($this->emptyInputBucketId, [
             'name' => 'tableDefinition',
             'primaryKeysNames' => [],
             'columns' => [
@@ -293,7 +293,7 @@ class TableDefinitionTest extends AbstractTestCase
         ]);
 
         $runId = $this->clientWrapper->getBasicClient()->generateRunId();
-        $this->clientWrapper->getBasicClient()->setRunId($runId);
+        $this->clientWrapper->getTableAndFileStorageClient()->setRunId($runId);
 
         $root = $this->temp->getTmpFolder();
         file_put_contents(
@@ -320,7 +320,7 @@ class TableDefinitionTest extends AbstractTestCase
         self::assertCount(1, $jobIds);
 
         $writerJobs = array_filter(
-            $this->clientWrapper->getBasicClient()->listJobs(),
+            $this->clientWrapper->getTableAndFileStorageClient()->listJobs(),
             function (array $job) use ($runId) {
                 return $runId === $job['runId'];
             }
@@ -352,7 +352,7 @@ class TableDefinitionTest extends AbstractTestCase
         self::assertSame($incrementalFlag, $job['operationParams']['params']['incremental']);
         self::assertSame([], $job['results']['newColumns']);
 
-        $tableDetails = $this->clientWrapper->getBasicClient()->getTable($tableId);
+        $tableDetails = $this->clientWrapper->getTableAndFileStorageClient()->getTable($tableId);
         self::assertTrue($tableDetails['isTyped']);
 
         self::assertDataTypeDefinition($tableDetails['columnMetadata']['Id'], [
@@ -410,7 +410,7 @@ class TableDefinitionTest extends AbstractTestCase
             ],
         ];
 
-        $this->clientWrapper->getBasicClient()->createTableDefinition($this->emptyOutputBucketId, [
+        $this->clientWrapper->getTableAndFileStorageClient()->createTableDefinition($this->emptyOutputBucketId, [
             'name' => 'tableDefinition',
             'primaryKeysNames' => [],
             'columns' => [
@@ -426,7 +426,7 @@ class TableDefinitionTest extends AbstractTestCase
         ]);
 
         $runId = $this->clientWrapper->getBasicClient()->generateRunId();
-        $this->clientWrapper->getBasicClient()->setRunId($runId);
+        $this->clientWrapper->getTableAndFileStorageClient()->setRunId($runId);
 
         $root = $this->temp->getTmpFolder();
         file_put_contents(
@@ -453,7 +453,7 @@ class TableDefinitionTest extends AbstractTestCase
         self::assertCount(1, $jobIds);
 
         $writerJobs = array_filter(
-            $this->clientWrapper->getBasicClient()->listJobs(),
+            $this->clientWrapper->getTableAndFileStorageClient()->listJobs(),
             function (array $job) use ($runId) {
                 return $runId === $job['runId'];
             }
@@ -483,7 +483,7 @@ class TableDefinitionTest extends AbstractTestCase
         self::assertTablePrimaryKeyAddJob(array_pop($writerJobs), ['Id', 'Name']);
         self::assertTableImportJob(array_pop($writerJobs), $incrementalFlag);
 
-        $tableDetails = $this->clientWrapper->getBasicClient()->getTable($tableId);
+        $tableDetails = $this->clientWrapper->getTableAndFileStorageClient()->getTable($tableId);
         self::assertTrue($tableDetails['isTyped']);
 
         self::assertDataTypeDefinition($tableDetails['columnMetadata']['Id'], [
@@ -573,7 +573,7 @@ class TableDefinitionTest extends AbstractTestCase
             $config['column_metadata'] = $columnMetadata;
         }
 
-        $this->clientWrapper->getBasicClient()->createTableDefinition($this->emptyOutputBucketId, [
+        $this->clientWrapper->getTableAndFileStorageClient()->createTableDefinition($this->emptyOutputBucketId, [
             'name' => 'tableDefinition',
             'primaryKeysNames' => [],
             'columns' => [
@@ -589,7 +589,7 @@ class TableDefinitionTest extends AbstractTestCase
         ]);
 
         $runId = $this->clientWrapper->getBasicClient()->generateRunId();
-        $this->clientWrapper->getBasicClient()->setRunId($runId);
+        $this->clientWrapper->getTableAndFileStorageClient()->setRunId($runId);
 
         $root = $this->temp->getTmpFolder();
         file_put_contents(
@@ -616,7 +616,7 @@ class TableDefinitionTest extends AbstractTestCase
         self::assertCount(1, $jobIds);
 
         $writerJobs = array_filter(
-            $this->clientWrapper->getBasicClient()->listJobs(),
+            $this->clientWrapper->getTableAndFileStorageClient()->listJobs(),
             function (array $job) use ($runId) {
                 return $runId === $job['runId'];
             }
@@ -638,7 +638,7 @@ class TableDefinitionTest extends AbstractTestCase
         self::assertTablePrimaryKeyAddJob(array_pop($writerJobs), ['Id', 'Name']);
         self::assertTableImportJob(array_pop($writerJobs), $incrementalFlag);
 
-        $tableDetails = $this->clientWrapper->getBasicClient()->getTable($tableId);
+        $tableDetails = $this->clientWrapper->getTableAndFileStorageClient()->getTable($tableId);
         self::assertTrue($tableDetails['isTyped']);
 
         self::assertDataTypeDefinition($tableDetails['columnMetadata']['Id'], [

--- a/libs/output-mapping/tests/Writer/Workspace/AbsWriterWorkspaceTest.php
+++ b/libs/output-mapping/tests/Writer/Workspace/AbsWriterWorkspaceTest.php
@@ -50,12 +50,12 @@ class AbsWriterWorkspaceTest extends AbstractTestCase
         $bucketName = 'testAbsTableSlicedManifestOutputMapping';
         $bucketId = TestSatisfyer::getBucketIdByDisplayName($this->clientWrapper, $bucketName, Client::STAGE_IN);
         if ($bucketId !== null) {
-            $tables = $this->clientWrapper->getBasicClient()->listTables($bucketId, ['include' => '']);
+            $tables = $this->clientWrapper->getTableAndFileStorageClient()->listTables($bucketId, ['include' => '']);
             foreach ($tables as $table) {
-                $this->clientWrapper->getBasicClient()->dropTable($table['id']);
+                $this->clientWrapper->getTableAndFileStorageClient()->dropTable($table['id']);
             }
         } else {
-            $bucketId  = $this->clientWrapper->getBasicClient()->createBucket(
+            $bucketId  = $this->clientWrapper->getTableAndFileStorageClient()->createBucket(
                 name: $bucketName,
                 stage: Client::STAGE_IN,
                 backend: 'synapse'
@@ -69,7 +69,7 @@ class AbsWriterWorkspaceTest extends AbstractTestCase
         $csv->writeRow(['id3', 'name3', 'foo3', 'bar3']);
 
         for ($i = 0; $i < 2; $i++) {
-            $tableIds[$i] = $this->clientWrapper->getBasicClient()->createTableAsync(
+            $tableIds[$i] = $this->clientWrapper->getTableAndFileStorageClient()->createTableAsync(
                 $bucketId,
                 'test' . ($i + 1),
                 $csv
@@ -108,7 +108,7 @@ class AbsWriterWorkspaceTest extends AbstractTestCase
         $jobIds = $tableQueue->waitForAll();
         self::assertCount(1, $jobIds);
 
-        $tables = $this->clientWrapper->getBasicClient()->listTables($this->emptyOutputBucketId);
+        $tables = $this->clientWrapper->getTableAndFileStorageClient()->listTables($this->emptyOutputBucketId);
         self::assertCount(1, $tables);
         self::assertEquals($this->emptyOutputBucketId . '.table1a', $tables[0]['id']);
 
@@ -178,7 +178,7 @@ class AbsWriterWorkspaceTest extends AbstractTestCase
         $jobIds = $tableQueue->waitForAll();
         self::assertCount(1, $jobIds);
 
-        $tables = $this->clientWrapper->getBasicClient()->listTables($this->emptyOutputBucketId);
+        $tables = $this->clientWrapper->getTableAndFileStorageClient()->listTables($this->emptyOutputBucketId);
         self::assertCount(1, $tables);
         self::assertEquals($this->emptyOutputBucketId . '.table1a', $tables[0]['id']);
         self::assertNotEmpty($jobIds[0]);
@@ -356,7 +356,7 @@ class AbsWriterWorkspaceTest extends AbstractTestCase
 
         $options = new ListFilesOptions();
         $options->setTags([self::FILE_TAG]);
-        $files = $this->clientWrapper->getBasicClient()->listFiles($options);
+        $files = $this->clientWrapper->getTableAndFileStorageClient()->listFiles($options);
         self::assertCount(3, $files);
 
         $file1 = $file2 = $file3 = null;

--- a/libs/output-mapping/tests/Writer/Workspace/SynapseWriterWorkspaceTest.php
+++ b/libs/output-mapping/tests/Writer/Workspace/SynapseWriterWorkspaceTest.php
@@ -41,12 +41,12 @@ class SynapseWriterWorkspaceTest extends AbstractTestCase
 
         $outBucketId = TestSatisfyer::getBucketIdByDisplayName($this->clientWrapper, $bucketName, Client::STAGE_OUT);
         if ($outBucketId !== null) {
-            $tables = $this->clientWrapper->getBasicClient()->listTables($outBucketId, ['include' => '']);
+            $tables = $this->clientWrapper->getTableAndFileStorageClient()->listTables($outBucketId, ['include' => '']);
             foreach ($tables as $table) {
-                $this->clientWrapper->getBasicClient()->dropTable($table['id']);
+                $this->clientWrapper->getTableAndFileStorageClient()->dropTable($table['id']);
             }
         } else {
-            $outBucketId  = $this->clientWrapper->getBasicClient()->createBucket(
+            $outBucketId  = $this->clientWrapper->getTableAndFileStorageClient()->createBucket(
                 name: $bucketName,
                 stage: Client::STAGE_OUT,
                 backend: 'synapse'
@@ -55,12 +55,12 @@ class SynapseWriterWorkspaceTest extends AbstractTestCase
 
         $bucketId = TestSatisfyer::getBucketIdByDisplayName($this->clientWrapper, $bucketName, Client::STAGE_IN);
         if ($bucketId !== null) {
-            $tables = $this->clientWrapper->getBasicClient()->listTables($bucketId, ['include' => '']);
+            $tables = $this->clientWrapper->getTableAndFileStorageClient()->listTables($bucketId, ['include' => '']);
             foreach ($tables as $table) {
-                $this->clientWrapper->getBasicClient()->dropTable($table['id']);
+                $this->clientWrapper->getTableAndFileStorageClient()->dropTable($table['id']);
             }
         } else {
-            $bucketId  = $this->clientWrapper->getBasicClient()->createBucket(
+            $bucketId  = $this->clientWrapper->getTableAndFileStorageClient()->createBucket(
                 name: $bucketName,
                 stage: Client::STAGE_IN,
                 backend: 'synapse'
@@ -76,7 +76,7 @@ class SynapseWriterWorkspaceTest extends AbstractTestCase
         $tableIds = [];
         // Create table
         for ($i = 0; $i < 2; $i++) {
-            $tableIds[$i] = $this->clientWrapper->getBasicClient()->createTableAsync(
+            $tableIds[$i] = $this->clientWrapper->getTableAndFileStorageClient()->createTableAsync(
                 $bucketId,
                 'test' . ($i + 1),
                 $csv
@@ -131,7 +131,7 @@ class SynapseWriterWorkspaceTest extends AbstractTestCase
         $jobIds = $tableQueue->waitForAll();
         self::assertCount(2, $jobIds);
 
-        $tables = $this->clientWrapper->getBasicClient()->listTables($outBucketId);
+        $tables = $this->clientWrapper->getTableAndFileStorageClient()->listTables($outBucketId);
         self::assertCount(2, $tables);
         $sortedTables = [$tables[0]['id'] => $tables[0], $tables[1]['id'] => $tables[1]];
         ksort($sortedTables);

--- a/libs/output-mapping/tests/Writer/Workspace/WriterWorkspaceTest.php
+++ b/libs/output-mapping/tests/Writer/Workspace/WriterWorkspaceTest.php
@@ -447,9 +447,9 @@ class WriterWorkspaceTest extends AbstractTestCase
         );
         $jobIds = $tableQueue->waitForAll();
         self::assertCount(2, $jobIds);
-        $jobDetail = $this->clientWrapper->getBasicClient()->getJob($jobIds[0]);
+        $jobDetail = $this->clientWrapper->getBranchClientIfAvailable()->getJob($jobIds[0]);
         $tableIds[] = $jobDetail['tableId'];
-        $jobDetail = $this->clientWrapper->getBasicClient()->getJob($jobIds[1]);
+        $jobDetail = $this->clientWrapper->getBranchClientIfAvailable()->getJob($jobIds[1]);
         $tableIds[] = $jobDetail['tableId'];
 
         self::assertMatchesRegularExpression(

--- a/libs/output-mapping/tests/Writer/Workspace/WriterWorkspaceTest.php
+++ b/libs/output-mapping/tests/Writer/Workspace/WriterWorkspaceTest.php
@@ -27,7 +27,7 @@ class WriterWorkspaceTest extends AbstractTestCase
     #[NeedsTestTables(2), NeedsEmptyOutputBucket]
     public function testSnowflakeTableOutputMapping(): void
     {
-        $tokenInfo = $this->clientWrapper->getBasicClient()->verifyToken();
+        $tokenInfo = $this->clientWrapper->getBranchClientIfAvailable()->verifyToken();
         $factory = $this->getWorkspaceStagingFactory();
         // initialize the workspace mock
         $factory->getTableOutputStrategy(
@@ -169,7 +169,7 @@ class WriterWorkspaceTest extends AbstractTestCase
     #[NeedsTestTables(2), NeedsEmptyOutputBucket]
     public function testMappingMerge(): void
     {
-        $tokenInfo = $this->clientWrapper->getBasicClient()->verifyToken();
+        $tokenInfo = $this->clientWrapper->getBranchClientIfAvailable()->verifyToken();
         $factory = $this->getWorkspaceStagingFactory(
             null,
             'json',
@@ -229,7 +229,7 @@ class WriterWorkspaceTest extends AbstractTestCase
         $jobIds = $tableQueue->waitForAll();
         self::assertCount(1, $jobIds);
 
-        $metadata = new Metadata($this->clientWrapper->getBasicClient());
+        $metadata = new Metadata($this->clientWrapper->getTableAndFileStorageClient());
         $tableMetadata = $metadata->listTableMetadata($this->emptyOutputBucketId . '.table1a');
         $tableMetadataValues = [];
         self::assertCount(4, $tableMetadata);
@@ -249,7 +249,7 @@ class WriterWorkspaceTest extends AbstractTestCase
 
     public function testTableOutputMappingMissingDestinationManifest(): void
     {
-        $tokenInfo = $this->clientWrapper->getBasicClient()->verifyToken();
+        $tokenInfo = $this->clientWrapper->getBranchClientIfAvailable()->verifyToken();
         $factory = $this->getWorkspaceStagingFactory(
             null,
             'json',
@@ -291,7 +291,7 @@ class WriterWorkspaceTest extends AbstractTestCase
 
     public function testTableOutputMappingMissingDestinationNoManifest(): void
     {
-        $tokenInfo = $this->clientWrapper->getBasicClient()->verifyToken();
+        $tokenInfo = $this->clientWrapper->getBranchClientIfAvailable()->verifyToken();
         $factory = $this->getWorkspaceStagingFactory(
             null,
             'json',
@@ -327,7 +327,7 @@ class WriterWorkspaceTest extends AbstractTestCase
     #[NeedsTestTables(2), NeedsEmptyOutputBucket]
     public function testSnowflakeTableOutputBucketNoDestination(): void
     {
-        $tokenInfo = $this->clientWrapper->getBasicClient()->verifyToken();
+        $tokenInfo = $this->clientWrapper->getBranchClientIfAvailable()->verifyToken();
         $factory = $this->getWorkspaceStagingFactory(
             null,
             'json',
@@ -397,7 +397,7 @@ class WriterWorkspaceTest extends AbstractTestCase
             )
         );
 
-        $tokenInfo = $this->clientWrapper->getBasicClient()->verifyToken();
+        $tokenInfo = $this->clientWrapper->getBranchClientIfAvailable()->verifyToken();
         $factory = $this->getWorkspaceStagingFactory(
             null,
             'json',
@@ -465,7 +465,7 @@ class WriterWorkspaceTest extends AbstractTestCase
     #[NeedsTestTables(2), NeedsEmptyOutputBucket]
     public function testSnowflakeMultipleMappingOfSameSource(): void
     {
-        $tokenInfo = $this->clientWrapper->getBasicClient()->verifyToken();
+        $tokenInfo = $this->clientWrapper->getBranchClientIfAvailable()->verifyToken();
         $factory = $this->getWorkspaceStagingFactory(
             null,
             'json',
@@ -531,7 +531,7 @@ class WriterWorkspaceTest extends AbstractTestCase
     #[NeedsTestTables(2), NeedsEmptyOutputBucket]
     public function testWriteOnlyOnJobFailure(): void
     {
-        $tokenInfo = $this->clientWrapper->getBasicClient()->verifyToken();
+        $tokenInfo = $this->clientWrapper->getBranchClientIfAvailable()->verifyToken();
         $factory = $this->getWorkspaceStagingFactory(
             null,
             'json',
@@ -585,7 +585,7 @@ class WriterWorkspaceTest extends AbstractTestCase
     #[NeedsTestTables(2), NeedsEmptyOutputBucket]
     public function testSnowflakeTableOutputMappingSkipsTimestampColumn(): void
     {
-        $tokenInfo = $this->clientWrapper->getBasicClient()->verifyToken();
+        $tokenInfo = $this->clientWrapper->getBranchClientIfAvailable()->verifyToken();
         $factory = $this->getWorkspaceStagingFactory();
         // initialize the workspace mock
         $factory->getTableOutputStrategy(


### PR DESCRIPTION
https://keboola.atlassian.net/browse/SOX-138

Pointa změny je v tom, že basicClient se nadále používá jen u věcí, který nejsou nikdy branchovaný:

![image](https://github.com/keboola/platform-libraries/assets/4319320/93b993c0-1757-4541-af2a-1361e7034bbf)

Depends on https://github.com/keboola/storage-api-php-client-branch-wrapper/pull/17