### PR TITLE
fix: variable resolver tests

### DIFF
--- a/libs/configuration-variables-resolver/tests/VariablesResolverFunctionalTest.php
+++ b/libs/configuration-variables-resolver/tests/VariablesResolverFunctionalTest.php
@@ -55,7 +55,7 @@ class VariablesResolverFunctionalTest extends TestCase
             self::getRequiredEnv('STORAGE_API_TOKEN'),
         );
 
-        $branchesApiClient = new DevBranches($this->clientWrapper->getBranchClientIfAvailable());
+        $branchesApiClient = new DevBranches($this->clientWrapper->getBasicClient());
         $branches = $branchesApiClient->listBranches();
         foreach ($branches as $branch) {
             if ($branch['isDefault']) {


### PR DESCRIPTION
Devbranches can't use branch client https://dev.azure.com/keboola-dev/Platform%20Libraries/_build/results?buildId=36052&view=logs&j=a0249fe8-9f74-548a-8eb7-2720f4b41755&t=b2f4e1af-2aa0-5a3d-c143-f86d8e3027d2