### PR TITLE
SOX-232 Azure Client tests stabilization

### DIFF
--- a/libs/azure-api-client/tests/Authentication/Authenticator/ClientCredentialsAuthTest.php
+++ b/libs/azure-api-client/tests/Authentication/Authenticator/ClientCredentialsAuthTest.php
@@ -18,6 +18,9 @@ use Monolog\Logger;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 
+/**
+ * @runTestsInSeparateProcesses because of env variables
+ */
 class ClientCredentialsAuthTest extends TestCase
 {
     private readonly LoggerInterface $logger;
@@ -29,12 +32,6 @@ class ClientCredentialsAuthTest extends TestCase
 
         $this->logsHandler = new TestHandler();
         $this->logger = new Logger('tests', [$this->logsHandler]);
-
-        putenv('AZURE_TENANT_ID');
-        putenv('AZURE_CLIENT_ID');
-        putenv('AZURE_CLIENT_SECRET');
-        putenv('AZURE_AD_RESOURCE');
-        putenv('AZURE_ENVIRONMENT');
     }
 
     public function testOptionalEnvsFallback(): void

--- a/libs/azure-api-client/tests/Authentication/Authenticator/Internal/SystemAuthenticatorResolverTest.php
+++ b/libs/azure-api-client/tests/Authentication/Authenticator/Internal/SystemAuthenticatorResolverTest.php
@@ -16,6 +16,9 @@ use Monolog\Logger;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 
+/**
+ * @runTestsInSeparateProcesses because of env variables
+ */
 class SystemAuthenticatorResolverTest extends TestCase
 {
     private readonly LoggerInterface $logger;
@@ -27,10 +30,6 @@ class SystemAuthenticatorResolverTest extends TestCase
 
         $this->logsHandler = new TestHandler();
         $this->logger = new Logger('tests', [$this->logsHandler]);
-
-        putenv('AZURE_TENANT_ID');
-        putenv('AZURE_CLIENT_ID');
-        putenv('AZURE_CLIENT_SECRET');
     }
 
     public function testClientCredentialsAuthenticatorIsUsedWhenEnvIsSet(): void


### PR DESCRIPTION
https://keboola.atlassian.net/browse/SOX-232

By default vsechny testy jedou postupne v jednom procesu, takze zmena envu v jednom testu se propaguje do dalsich. Normalne PHPUnit pousti testy stale ve stejnem poradi a na to to bylo "odladene". Ale Infection by default pousti testy v random poradi, coz vlastne odhalilo skrytou zavislost mezi testama skrz ENV.

* postizeny testy, ktery hodne zavisi na uprave ENV jsem nastavil aby jely v separatnim procesu, tim padem se nijak novlivnuji
* nastavil jsem i PHPunit, aby postel testy v random poradi