### PR TITLE
SOX-327 [permission-checker] Support for branched/cross-branch notifications

### DIFF
--- a/libs/permission-checker/src/Check/Notification/CanModifySubscriptions.php
+++ b/libs/permission-checker/src/Check/Notification/CanModifySubscriptions.php
@@ -14,7 +14,7 @@ use Keboola\PermissionChecker\StorageApiToken;
 class CanModifySubscriptions implements PermissionCheckInterface
 {
     public function __construct(
-        private readonly BranchType $branchType,
+        private readonly ?BranchType $branchType,
     ) {
     }
 
@@ -23,6 +23,7 @@ class CanModifySubscriptions implements PermissionCheckInterface
         if ($token->hasFeature(Feature::PROTECTED_DEFAULT_BRANCH)) {
             $isRoleAllowed = match ($token->getRole()) {
                 Role::PRODUCTION_MANAGER => $this->branchType === BranchType::DEFAULT,
+                Role::DEVELOPER, Role::REVIEWER => $this->branchType === BranchType::DEV,
                 default => false,
             };
         } else {

--- a/libs/permission-checker/tests/Check/Notification/CanModifySubscriptionsTest.php
+++ b/libs/permission-checker/tests/Check/Notification/CanModifySubscriptionsTest.php
@@ -24,15 +24,30 @@ class CanModifySubscriptionsTest extends TestCase
             'token' => new StorageApiToken(role: null),
         ];
 
+        yield 'regular token on regular project without branch' => [
+            'branchType' => null,
+            'token' => new StorageApiToken(role: null),
+        ];
+
         yield 'productionManager on protected default branch' => [
             'branchType' => BranchType::DEFAULT,
             'token' => new StorageApiToken(features: ['protected-default-branch'], role: 'productionManager'),
+        ];
+
+        yield 'developer on protected dev branch' => [
+            'branchType' => BranchType::DEV,
+            'token' => new StorageApiToken(features: ['protected-default-branch'], role: 'developer'),
+        ];
+
+        yield 'reviewer on protected dev branch' => [
+            'branchType' => BranchType::DEV,
+            'token' => new StorageApiToken(features: ['protected-default-branch'], role: 'reviewer'),
         ];
     }
 
     /** @dataProvider provideValidPermissionsCheckData */
     public function testValidPermissionsCheck(
-        BranchType $branchType,
+        ?BranchType $branchType,
         StorageApiToken $token,
     ): void {
         $this->expectNotToPerformAssertions();
@@ -67,8 +82,20 @@ class CanModifySubscriptionsTest extends TestCase
             'error' => new PermissionDeniedException('Role "developer" is not allowed to modify subscriptions'),
         ];
 
+        yield 'developer role without branch' => [
+            'branchType' => null,
+            'token' => new StorageApiToken(features: ['protected-default-branch'], role: 'developer'),
+            'error' => new PermissionDeniedException('Role "developer" is not allowed to modify subscriptions'),
+        ];
+
         yield 'reviewer role on protected default branch' => [
             'branchType' => BranchType::DEFAULT,
+            'token' => new StorageApiToken(features: ['protected-default-branch'], role: 'reviewer'),
+            'error' => new PermissionDeniedException('Role "reviewer" is not allowed to modify subscriptions'),
+        ];
+
+        yield 'reviewer role without branch' => [
+            'branchType' => null,
             'token' => new StorageApiToken(features: ['protected-default-branch'], role: 'reviewer'),
             'error' => new PermissionDeniedException('Role "reviewer" is not allowed to modify subscriptions'),
         ];
@@ -78,11 +105,17 @@ class CanModifySubscriptionsTest extends TestCase
             'token' => new StorageApiToken(features: ['protected-default-branch'], role: 'productionManager'),
             'error' => new PermissionDeniedException('Role "productionManager" is not allowed to modify subscriptions'),
         ];
+
+        yield 'productionManager role without branch' => [
+            'branchType' => null,
+            'token' => new StorageApiToken(features: ['protected-default-branch'], role: 'productionManager'),
+            'error' => new PermissionDeniedException('Role "productionManager" is not allowed to modify subscriptions'),
+        ];
     }
 
     /** @dataProvider provideInvalidPermissionsCheckData */
     public function testInvalidPermissionsCheck(
-        BranchType $branchType,
+        ?BranchType $branchType,
         StorageApiToken $token,
         PermissionDeniedException $error,
     ): void {


### PR DESCRIPTION
https://keboola.atlassian.net/browse/SOX-327

V description tasku toho moc nemame :slightly_smiling_face:, ale tak logicky jsem dosle k tomu, ze:
* na SOX projektu
  * PM muze delat notifikace na main branch (to uz tam bylo)
  * dev/reviewer muze delat notifikace na dev branch
  * nikdo nemuze delat notifikace cross-branch
* na ne-SOX muze kdokoliv cokoliv (krome read-only)