### PR TITLE
GCP-290 + GCP-291 Use "scoped" endpoint, flags replacing "isEncrypted" property

### DIFF
--- a/libs/configuration-variables-resolver/src/ComponentsClientHelper.php
+++ b/libs/configuration-variables-resolver/src/ComponentsClientHelper.php
@@ -47,7 +47,7 @@ class ComponentsClientHelper
             $vRow = $this->componentsApiClient->getConfigurationRow(
                 self::KEBOOLA_VARIABLES,
                 $variablesId,
-                $variableValuesId
+                $variableValuesId,
             );
             /** @var array{values: list<array{name: non-empty-string, value: scalar}>} $normalized */
             $normalized = (new VariableValues())->process($vRow['configuration']);
@@ -60,7 +60,7 @@ class ComponentsClientHelper
                     $variablesId,
                 ),
                 400,
-                $e
+                $e,
             );
         } catch (InvalidConfigurationException $e) {
             throw new UserException('Variable values configuration is invalid: ' . $e->getMessage(), 400, $e);
@@ -73,7 +73,7 @@ class ComponentsClientHelper
             $sharedCodeConfiguration = $this->componentsApiClient->getConfigurationRow(
                 self::KEBOOLA_SHARED_CODE,
                 $sharedCodeId,
-                $sharedCodeRowId
+                $sharedCodeRowId,
             );
             return (new SharedCodeRow())->process($sharedCodeConfiguration['configuration']);
         } catch (ClientException $e) {

--- a/libs/configuration-variables-resolver/src/SharedCodeResolver.php
+++ b/libs/configuration-variables-resolver/src/SharedCodeResolver.php
@@ -39,16 +39,16 @@ class SharedCodeResolver
         foreach ($sharedCodeRowIds as $sharedCodeRowId) {
             $sharedCodeConfiguration = $this->componentsHelper->getSharedCodeConfigurationRow(
                 $sharedCodeId,
-                $sharedCodeRowId
+                $sharedCodeRowId,
             );
             $context->pushValue(
                 $sharedCodeRowId,
-                $sharedCodeConfiguration['code_content']
+                $sharedCodeConfiguration['code_content'],
             );
         }
         $this->logger->info(sprintf(
             'Loaded shared code snippets with ids: "%s".',
-            implode(', ', $context->getKeys())
+            implode(', ', $context->getKeys()),
         ));
 
         $newConfiguration = $configuration;
@@ -90,7 +90,7 @@ class SharedCodeResolver
                 $matches,
                 function (&$v) {
                     $v = trim($v);
-                }
+                },
             );
             $filteredMatches = array_intersect($context->getKeys(), $matches);
             if (count($filteredMatches) === 0) {

--- a/libs/configuration-variables-resolver/src/VariablesRenderer/MustacheRenderer.php
+++ b/libs/configuration-variables-resolver/src/VariablesRenderer/MustacheRenderer.php
@@ -40,7 +40,7 @@ class MustacheRenderer
             $configuration = (array) json_decode($renderedConfiguration, true, flags: JSON_THROW_ON_ERROR);
         } catch (JsonException $e) {
             throw new UserException(
-                'Variable replacement resulted in invalid configuration, error: ' . $e->getMessage()
+                'Variable replacement resulted in invalid configuration, error: ' . $e->getMessage(),
             );
         }
 

--- a/libs/configuration-variables-resolver/src/VariablesRenderer/RegexRenderer.php
+++ b/libs/configuration-variables-resolver/src/VariablesRenderer/RegexRenderer.php
@@ -54,7 +54,7 @@ class RegexRenderer
             $configuration = (array) json_decode((string) $renderedString, true, flags: JSON_THROW_ON_ERROR);
         } catch (JsonException $e) {
             throw new UserException(
-                'Variable replacement resulted in invalid configuration, error: ' . $e->getMessage()
+                'Variable replacement resulted in invalid configuration, error: ' . $e->getMessage(),
             );
         }
 

--- a/libs/configuration-variables-resolver/src/VariablesResolver.php
+++ b/libs/configuration-variables-resolver/src/VariablesResolver.php
@@ -74,7 +74,7 @@ class VariablesResolver
         if (count($missingVariables) > 0) {
             throw new UserException(sprintf(
                 'Missing values for placeholders: %s',
-                implode(', ', $missingVariables)
+                implode(', ', $missingVariables),
             ));
         }
 

--- a/libs/configuration-variables-resolver/src/VariablesResolver/ConfigurationVariablesResolver.php
+++ b/libs/configuration-variables-resolver/src/VariablesResolver/ConfigurationVariablesResolver.php
@@ -68,7 +68,7 @@ class ConfigurationVariablesResolver
         string $variablesId,
         ?string $variablesValuesId,
         ?string $variableValuesId,
-        ?array $variableValuesData
+        ?array $variableValuesData,
     ): array {
         $variablesConfiguration = $this->componentsHelper->getVariablesConfiguration($variablesId);
         $variablesData = $this->loadVariablesData(
@@ -139,7 +139,7 @@ class ConfigurationVariablesResolver
 
         throw new UserException(sprintf(
             'No variable values provided for variables configuration "%s".',
-            $variablesId
+            $variablesId,
         ));
     }
 }

--- a/libs/configuration-variables-resolver/src/VariablesResolver/VaultVariablesResolver.php
+++ b/libs/configuration-variables-resolver/src/VariablesResolver/VaultVariablesResolver.php
@@ -22,7 +22,7 @@ class VaultVariablesResolver
     public function resolveVariables(array $configuration, string $branchId): RenderResults
     {
         $loadVariables = function () use ($branchId): array {
-            $variables = $this->variablesApiClient->listMergedVariablesForBranch($branchId);
+            $variables = $this->variablesApiClient->listScopedVariablesForBranch($branchId);
 
             $keyVal = [];
             foreach ($variables as $variable) {

--- a/libs/configuration-variables-resolver/tests/SharedCodeResolverTest.php
+++ b/libs/configuration-variables-resolver/tests/SharedCodeResolverTest.php
@@ -32,7 +32,7 @@ class SharedCodeResolverTest extends TestCase
             new ClientOptions(
                 (string) getenv('STORAGE_API_URL'),
                 (string) getenv('STORAGE_API_TOKEN'),
-            )
+            ),
         );
         $components = new Components($this->clientWrapper->getBasicClient());
         $listOptions = new ListComponentConfigurationsOptions();
@@ -89,7 +89,7 @@ class SharedCodeResolverTest extends TestCase
                 'first_code' => ['code_content' => ['SELECT * FROM {{tab1}} LEFT JOIN {{tab2}} ON b.a_id = a.id']],
                 // bwd compatible shared code configuration where the code is not array
                 'secondCode' => ['code_content' => 'bar'],
-            ]
+            ],
         );
         $configuration = [
             'shared_code_id' => $sharedConfigurationId,
@@ -158,7 +158,7 @@ class SharedCodeResolverTest extends TestCase
             $newConfiguration,
         );
         self::assertTrue(
-            $this->testLogger->hasInfoThatContains('Loaded shared code snippets with ids: "first_code, secondCode".')
+            $this->testLogger->hasInfoThatContains('Loaded shared code snippets with ids: "first_code, secondCode".'),
         );
     }
 
@@ -169,7 +169,7 @@ class SharedCodeResolverTest extends TestCase
             [
                 'first_code' => ['code_content' => 'SELECT * FROM {{tab1}} LEFT JOIN {{tab2}} ON b.a_id = a.id'],
                 'secondCode' => ['code_content' => 'bar'],
-            ]
+            ],
         );
         $configuration = [
             'shared_code_row_ids' => $sharedCodeRowIds,
@@ -187,10 +187,10 @@ class SharedCodeResolverTest extends TestCase
                 ],
                 'shared_code_row_ids' => ['first_code', 'secondCode'],
             ],
-            $newConfiguration
+            $newConfiguration,
         );
         self::assertFalse(
-            $this->testLogger->hasInfoThatContains('Loaded shared code snippets with ids: "first_code, secondCode".')
+            $this->testLogger->hasInfoThatContains('Loaded shared code snippets with ids: "first_code, secondCode".'),
         );
     }
 
@@ -201,7 +201,7 @@ class SharedCodeResolverTest extends TestCase
             [
                 'first_code' => ['code_content' => 'SELECT * FROM {{tab1}} LEFT JOIN {{tab2}} ON b.a_id = a.id'],
                 'secondCode' => ['code_content' => 'bar'],
-            ]
+            ],
         );
         $configuration = [
             'shared_code_id' => $sharedConfigurationId,
@@ -219,10 +219,10 @@ class SharedCodeResolverTest extends TestCase
                 ],
                 'shared_code_id' => $sharedConfigurationId,
             ],
-            $newConfiguration
+            $newConfiguration,
         );
         self::assertFalse(
-            $this->testLogger->hasInfoThatContains('Loaded shared code snippets with ids: "first_code, secondCode".')
+            $this->testLogger->hasInfoThatContains('Loaded shared code snippets with ids: "first_code, secondCode".'),
         );
     }
 
@@ -233,7 +233,7 @@ class SharedCodeResolverTest extends TestCase
             [
                 'first_code' => ['code_content' => 'SELECT * FROM {{tab1}} LEFT JOIN {{tab2}} ON b.a_id = a.id'],
                 'secondCode' => ['code_content' => 'bar'],
-            ]
+            ],
         );
         $configuration = [
             'shared_code_id' => 'non-existent',
@@ -245,7 +245,7 @@ class SharedCodeResolverTest extends TestCase
         $sharedCodeResolver = $this->getSharedCodeResolver();
         self::expectException(UserException::class);
         self::expectExceptionMessage(
-            'Shared code configuration cannot be read: Configuration non-existent not found'
+            'Shared code configuration cannot be read: Configuration non-existent not found',
         );
         $sharedCodeResolver->resolveSharedCode($configuration);
     }
@@ -257,7 +257,7 @@ class SharedCodeResolverTest extends TestCase
             [
                 'first_code' => ['code_content' => 'SELECT * FROM {{tab1}} LEFT JOIN {{tab2}} ON b.a_id = a.id'],
                 'secondCode' => ['code_content' => 'bar'],
-            ]
+            ],
         );
         $configuration = [
             'shared_code_id' => $sharedConfigurationId,
@@ -269,7 +269,7 @@ class SharedCodeResolverTest extends TestCase
         $sharedCodeResolver = $this->getSharedCodeResolver();
         self::expectException(UserException::class);
         self::expectExceptionMessage(
-            'Shared code configuration cannot be read: Row foo not found'
+            'Shared code configuration cannot be read: Row foo not found',
         );
         $sharedCodeResolver->resolveSharedCode($configuration);
     }
@@ -281,7 +281,7 @@ class SharedCodeResolverTest extends TestCase
             [
                 'first_code' => ['this is broken' => 'SELECT * FROM {{tab1}} LEFT JOIN {{tab2}} ON b.a_id = a.id'],
                 'secondCode' => ['code_content' => 'bar'],
-            ]
+            ],
         );
         $configuration = [
             'shared_code_id' => $sharedConfigurationId,
@@ -293,7 +293,7 @@ class SharedCodeResolverTest extends TestCase
         $sharedCodeResolver = $this->getSharedCodeResolver();
         self::expectException(UserException::class);
         self::expectExceptionMessage(
-            'Shared code configuration is invalid: Unrecognized option "this is broken" under "configuration"'
+            'Shared code configuration is invalid: Unrecognized option "this is broken" under "configuration"',
         );
         $sharedCodeResolver->resolveSharedCode($configuration);
     }
@@ -305,21 +305,21 @@ class SharedCodeResolverTest extends TestCase
             [
                 'first_code' => ['code_content' => ['SELECT * FROM {{tab1}} LEFT JOIN {{tab2}} ON b.a_id = a.id']],
                 'secondCode' => ['code_content' => ['bar']],
-            ]
+            ],
         );
         $clientWrapper = new ClientWrapper(
             new ClientOptions(
                 (string) getenv('STORAGE_API_URL'),
                 (string) getenv('STORAGE_API_TOKEN_MASTER'),
-            )
+            ),
         );
         $branchId = $this->createBranch('my-dev-branch', $clientWrapper);
         $this->clientWrapper = new ClientWrapper(
             new ClientOptions(
                 (string) getenv('STORAGE_API_URL'),
                 (string) getenv('STORAGE_API_TOKEN'),
-                (string) $branchId
-            )
+                (string) $branchId,
+            ),
         );
 
         // modify the dev branch shared code configuration to "dev-bar"
@@ -357,10 +357,10 @@ class SharedCodeResolverTest extends TestCase
                 'shared_code_id' => $sharedConfigurationId,
                 'shared_code_row_ids' => [0 => 'first_code', 1 => 'secondCode'],
             ],
-            $newConfiguration
+            $newConfiguration,
         );
         self::assertTrue(
-            $this->testLogger->hasInfoThatContains('Loaded shared code snippets with ids: "first_code, secondCode".')
+            $this->testLogger->hasInfoThatContains('Loaded shared code snippets with ids: "first_code, secondCode".'),
         );
     }
 
@@ -372,7 +372,7 @@ class SharedCodeResolverTest extends TestCase
                 '123456' => ['code_content' => ['SELECT * FROM {{tab1}} LEFT JOIN {{tab2}} ON b.a_id = a.id']],
                 // bwd compatible shared code configuration where the code is not array
                 1234567 => ['code_content' => 'bar'],
-            ]
+            ],
         );
         $configuration = [
             'shared_code_id' => $sharedConfigurationId,
@@ -396,10 +396,10 @@ class SharedCodeResolverTest extends TestCase
                     '1234567',
                 ],
             ],
-            $newConfiguration
+            $newConfiguration,
         );
         self::assertTrue(
-            $this->testLogger->hasInfoThatContains('Loaded shared code snippets with ids: "123456, 1234567".')
+            $this->testLogger->hasInfoThatContains('Loaded shared code snippets with ids: "123456, 1234567".'),
         );
     }
 }

--- a/libs/configuration-variables-resolver/tests/VariableResolverTest.php
+++ b/libs/configuration-variables-resolver/tests/VariableResolverTest.php
@@ -44,7 +44,7 @@ class VariableResolverTest extends TestCase
             new ClientOptions(
                 (string) getenv('STORAGE_API_URL'),
                 (string) getenv('STORAGE_API_TOKEN'),
-            )
+            ),
         );
     }
 
@@ -97,7 +97,7 @@ class VariableResolverTest extends TestCase
         list ($vConfigurationId, $vRowId) = $this->createVariablesConfiguration(
             $this->clientWrapper->getBasicClient(),
             ['variables' => [['name' => 'foo', 'type' => 'string']]],
-            ['values' => [['name' => 'foo', 'value' => 'bar']]]
+            ['values' => [['name' => 'foo', 'value' => 'bar']]],
         );
         $configuration = [
             'variables_id' => $vConfigurationId,
@@ -113,7 +113,7 @@ class VariableResolverTest extends TestCase
                 ],
                 'variables_id' => $vConfigurationId,
             ],
-            $newConfiguration
+            $newConfiguration,
         );
         self::assertTrue($this->logsHandler->hasInfoThatContains('Replacing variables using values with ID:'));
         self::assertTrue($this->logsHandler->hasInfoThatContains('Replaced values for variables: foo'));
@@ -124,7 +124,7 @@ class VariableResolverTest extends TestCase
         list ($vConfigurationId, $vRowId) = $this->createVariablesConfiguration(
             $this->clientWrapper->getBasicClient(),
             ['variables' => [['name' => 'foo', 'type' => 'string']]],
-            []
+            [],
         );
         $configuration = [
             'variables_id' => $vConfigurationId,
@@ -135,7 +135,7 @@ class VariableResolverTest extends TestCase
             $configuration,
             self::BRANCH_ID,
             null,
-            ['values' => [['name' => 'foo', 'value' => 'bar']]]
+            ['values' => [['name' => 'foo', 'value' => 'bar']]],
         );
         self::assertEquals(
             [
@@ -144,7 +144,7 @@ class VariableResolverTest extends TestCase
                 ],
                 'variables_id' => $vConfigurationId,
             ],
-            $newConfiguration
+            $newConfiguration,
         );
         self::assertTrue($this->logsHandler->hasInfoThatContains('Replacing variables using inline values.'));
         self::assertTrue($this->logsHandler->hasInfoThatContains('Replaced values for variables: foo'));
@@ -155,7 +155,7 @@ class VariableResolverTest extends TestCase
         list ($vConfigurationId, $vRowId) = $this->createVariablesConfiguration(
             $this->clientWrapper->getBasicClient(),
             ['variables' => [['name' => 'foo', 'type' => 'string']]],
-            ['values' => [['name' => 'foo', 'value' => 'bar']]]
+            ['values' => [['name' => 'foo', 'value' => 'bar']]],
         );
         $configuration = [
             'variables_id' => $vConfigurationId,
@@ -172,7 +172,7 @@ class VariableResolverTest extends TestCase
                 'variables_id' => $vConfigurationId,
                 'variables_values_id' => $vRowId,
             ],
-            $newConfiguration
+            $newConfiguration,
         );
         self::assertTrue($this->logsHandler->hasInfoThatContains('Replacing variables using default values with ID:'));
         self::assertTrue($this->logsHandler->hasInfoThatContains('Replaced values for variables: foo'));
@@ -183,7 +183,7 @@ class VariableResolverTest extends TestCase
         list ($vConfigurationId, $vRowId) = $this->createVariablesConfiguration(
             $this->clientWrapper->getBasicClient(),
             ['variables' => [['name' => 'foo', 'type' => 'string']]],
-            ['values' => [['name' => 'foo', 'value' => 'bar']]]
+            ['values' => [['name' => 'foo', 'value' => 'bar']]],
         );
         $configuration = [
             'variables_id' => $vConfigurationId,
@@ -200,7 +200,7 @@ class VariableResolverTest extends TestCase
                 'variables_id' => $vConfigurationId,
                 'variables_values_id' => 'not-used',
             ],
-            $newConfiguration
+            $newConfiguration,
         );
         self::assertTrue($this->logsHandler->hasInfoThatContains('Replacing variables using values with ID:'));
         self::assertTrue($this->logsHandler->hasInfoThatContains('Replaced values for variables: foo'));
@@ -211,7 +211,7 @@ class VariableResolverTest extends TestCase
         list ($vConfigurationId, $vRowId) = $this->createVariablesConfiguration(
             $this->clientWrapper->getBasicClient(),
             ['variables' => [['name' => 'foo', 'type' => 'string']]],
-            ['values' => [['name' => 'foo', 'value' => 'bar']]]
+            ['values' => [['name' => 'foo', 'value' => 'bar']]],
         );
         $configuration = [
             'variables_id' => $vConfigurationId,
@@ -223,7 +223,7 @@ class VariableResolverTest extends TestCase
             $configuration,
             self::BRANCH_ID,
             null,
-            ['values' => [['name' => 'foo', 'value' => 'bazooka']]]
+            ['values' => [['name' => 'foo', 'value' => 'bazooka']]],
         );
         self::assertEquals(
             [
@@ -233,7 +233,7 @@ class VariableResolverTest extends TestCase
                 'variables_id' => $vConfigurationId,
                 'variables_values_id' => $vRowId,
             ],
-            $newConfiguration
+            $newConfiguration,
         );
         self::assertTrue($this->logsHandler->hasInfoThatContains('Replacing variables using inline values.'));
         self::assertTrue($this->logsHandler->hasInfoThatContains('Replaced values for variables: foo'));
@@ -244,7 +244,7 @@ class VariableResolverTest extends TestCase
         list ($vConfigurationId) = $this->createVariablesConfiguration(
             $this->clientWrapper->getBasicClient(),
             ['variables' => [['name' => 'foo', 'type' => 'string']]],
-            []
+            [],
         );
         $configuration = [
             'variables_id' => $vConfigurationId,
@@ -255,7 +255,7 @@ class VariableResolverTest extends TestCase
         self::expectException(UserException::class);
         self::expectExceptionMessage(
             'No variable values provided for variables configuration "' .
-            $vConfigurationId . '".'
+            $vConfigurationId . '".',
         );
         $variableResolver->resolveVariables($configuration, self::BRANCH_ID, null, null);
     }
@@ -265,7 +265,7 @@ class VariableResolverTest extends TestCase
         list ($vConfigurationId) = $this->createVariablesConfiguration(
             $this->clientWrapper->getBasicClient(),
             ['variables' => [['name' => 'foo', 'type' => 'string']]],
-            []
+            [],
         );
         $configuration = [
             'variables_id' => $vConfigurationId,
@@ -275,7 +275,7 @@ class VariableResolverTest extends TestCase
         $variableResolver = $this->getVariablesResolver();
         self::expectException(UserException::class);
         self::expectExceptionMessage(
-            'Cannot read variable values "non-existent" of variables configuration "' . $vConfigurationId .'".'
+            'Cannot read variable values "non-existent" of variables configuration "' . $vConfigurationId .'".',
         );
         $variableResolver->resolveVariables($configuration, self::BRANCH_ID, null, null);
     }
@@ -285,7 +285,7 @@ class VariableResolverTest extends TestCase
         list ($vConfigurationId) = $this->createVariablesConfiguration(
             $this->clientWrapper->getBasicClient(),
             ['variables' => [['name' => 'foo', 'type' => 'string']]],
-            []
+            [],
         );
         $configuration = [
             'variables_id' => $vConfigurationId,
@@ -294,7 +294,7 @@ class VariableResolverTest extends TestCase
         $variableResolver = $this->getVariablesResolver();
         self::expectException(UserException::class);
         self::expectExceptionMessage(
-            'Cannot read variable values "non-existent" of variables configuration "' . $vConfigurationId .'".'
+            'Cannot read variable values "non-existent" of variables configuration "' . $vConfigurationId .'".',
         );
         $variableResolver->resolveVariables($configuration, self::BRANCH_ID, 'non-existent', null);
     }
@@ -304,7 +304,7 @@ class VariableResolverTest extends TestCase
         list ($vConfigurationId) = $this->createVariablesConfiguration(
             $this->clientWrapper->getBasicClient(),
             ['variables' => [['name' => 'foo', 'type' => 'string']]],
-            []
+            [],
         );
         $configuration = [
             'variables_id' => $vConfigurationId,
@@ -313,13 +313,13 @@ class VariableResolverTest extends TestCase
         $variableResolver = $this->getVariablesResolver();
         self::expectException(UserException::class);
         self::expectExceptionMessage(
-            'Only one of variableValuesId and variableValuesData can be entered.'
+            'Only one of variableValuesId and variableValuesData can be entered.',
         );
         $variableResolver->resolveVariables(
             $configuration,
             self::BRANCH_ID,
             'non-existent',
-            ['values' => [['name' => 'foo', 'value' => 'bar']]]
+            ['values' => [['name' => 'foo', 'value' => 'bar']]],
         );
     }
 
@@ -328,7 +328,7 @@ class VariableResolverTest extends TestCase
         list ($vConfigurationId, $vRowId) = $this->createVariablesConfiguration(
             $this->clientWrapper->getBasicClient(),
             ['variables' => [['name' => 'foo', 'type' => 'string']]],
-            ['values' => [['name' => 'foo', 'value' => 'bar']]]
+            ['values' => [['name' => 'foo', 'value' => 'bar']]],
         );
         $configuration = [
             'variables_id' => $vConfigurationId,
@@ -339,7 +339,7 @@ class VariableResolverTest extends TestCase
             $configuration,
             self::BRANCH_ID,
             $vRowId,
-            ['values' => []]
+            ['values' => []],
         );
         self::assertEquals(
             [
@@ -348,7 +348,7 @@ class VariableResolverTest extends TestCase
                 ],
                 'variables_id' => $vConfigurationId,
             ],
-            $newConfiguration
+            $newConfiguration,
         );
         self::assertTrue($this->logsHandler->hasInfoThatContains('Replacing variables using values with ID:'));
         self::assertTrue($this->logsHandler->hasInfoThatContains('Replaced values for variables: foo'));
@@ -363,7 +363,7 @@ class VariableResolverTest extends TestCase
         $variableResolver = $this->getVariablesResolver();
         self::expectException(UserException::class);
         self::expectExceptionMessage(
-            'Variable configuration cannot be read: Configuration non-existent not found'
+            'Variable configuration cannot be read: Configuration non-existent not found',
         );
         $variableResolver->resolveVariables($configuration, self::BRANCH_ID, 'non-existent', null);
     }
@@ -373,7 +373,7 @@ class VariableResolverTest extends TestCase
         list ($vConfigurationId) = $this->createVariablesConfiguration(
             $this->clientWrapper->getBasicClient(),
             ['invalid' => 'data'],
-            []
+            [],
         );
         $configuration = [
             'variables_id' => $vConfigurationId,
@@ -383,7 +383,7 @@ class VariableResolverTest extends TestCase
         self::expectException(UserException::class);
         self::expectExceptionMessage(
             'Variable configuration is invalid: Unrecognized option "invalid" under "variables". ' .
-            'Available option is "variables".'
+            'Available option is "variables".',
         );
         $variableResolver->resolveVariables($configuration, self::BRANCH_ID, 'non-existent', null);
     }
@@ -401,7 +401,7 @@ class VariableResolverTest extends TestCase
                     'some_parameter' => 'foo is {{ foo }}',
                 ],
             ],
-            $newConfiguration
+            $newConfiguration,
         );
         self::assertFalse($this->logsHandler->hasInfoThatContains('Replacing variables using default values with ID:'));
     }
@@ -411,7 +411,7 @@ class VariableResolverTest extends TestCase
         list ($vConfigurationId, $vRowId) = $this->createVariablesConfiguration(
             $this->clientWrapper->getBasicClient(),
             ['variables' => [['name' => 'foo', 'type' => 'string']]],
-            ['invalid' => [['name' => 'foo', 'value' => 'bar']]]
+            ['invalid' => [['name' => 'foo', 'value' => 'bar']]],
         );
         $configuration = [
             'variables_id' => $vConfigurationId,
@@ -421,7 +421,7 @@ class VariableResolverTest extends TestCase
         self::expectException(UserException::class);
         self::expectExceptionMessage(
             'Variable values configuration is invalid: Unrecognized option "invalid" under "values". ' .
-            'Available option is "values".'
+            'Available option is "values".',
         );
         $variableResolver->resolveVariables($configuration, self::BRANCH_ID, $vRowId, []);
     }
@@ -431,7 +431,7 @@ class VariableResolverTest extends TestCase
         list ($vConfigurationId, $vRowId) = $this->createVariablesConfiguration(
             $this->clientWrapper->getBasicClient(),
             ['variables' => [['name' => 'foo', 'type' => 'string']]],
-            []
+            [],
         );
         $configuration = [
             'variables_id' => $vConfigurationId,
@@ -442,7 +442,7 @@ class VariableResolverTest extends TestCase
             $configuration,
             self::BRANCH_ID,
             null,
-            ['values' => [['name' => 'foo', 'value' => 'special " \' { } characters']]]
+            ['values' => [['name' => 'foo', 'value' => 'special " \' { } characters']]],
         );
         self::assertEquals(
             [
@@ -451,7 +451,7 @@ class VariableResolverTest extends TestCase
                 ],
                 'variables_id' => $vConfigurationId,
             ],
-            $newConfiguration
+            $newConfiguration,
         );
         self::assertTrue($this->logsHandler->hasInfoThatContains('Replacing variables using inline values.'));
         self::assertTrue($this->logsHandler->hasInfoThatContains('Replaced values for variables: foo'));
@@ -462,7 +462,7 @@ class VariableResolverTest extends TestCase
         list ($vConfigurationId, $vRowId) = $this->createVariablesConfiguration(
             $this->clientWrapper->getBasicClient(),
             ['variables' => [['name' => 'foo', 'type' => 'string'], ['name' => 'goo', 'type' => 'string']]],
-            []
+            [],
         );
         $configuration = [
             'variables_id' => $vConfigurationId,
@@ -475,7 +475,7 @@ class VariableResolverTest extends TestCase
             $configuration,
             self::BRANCH_ID,
             null,
-            ['values' => [['name' => 'foo', 'value' => 'bar']]]
+            ['values' => [['name' => 'foo', 'value' => 'bar']]],
         );
     }
 
@@ -484,7 +484,7 @@ class VariableResolverTest extends TestCase
         list ($vConfigurationId, $vRowId) = $this->createVariablesConfiguration(
             $this->clientWrapper->getBasicClient(),
             ['variables' => [['name' => 'foo', 'type' => 'string']]],
-            []
+            [],
         );
         $configuration = [
             'variables_id' => $vConfigurationId,
@@ -497,7 +497,7 @@ class VariableResolverTest extends TestCase
             $configuration,
             self::BRANCH_ID,
             null,
-            ['values' => [['name' => 'foo', 'value' => 'bar']]]
+            ['values' => [['name' => 'foo', 'value' => 'bar']]],
         );
     }
 
@@ -506,13 +506,13 @@ class VariableResolverTest extends TestCase
         list ($vConfigurationId, $vRowId) = $this->createVariablesConfiguration(
             $this->clientWrapper->getBasicClient(),
             ['variables' => [['name' => 'foo', 'type' => 'string']]],
-            ['values' => [['name' => 'foo', 'value' => 'bar']]]
+            ['values' => [['name' => 'foo', 'value' => 'bar']]],
         );
         $clientWrapper = new ClientWrapper(
             new ClientOptions(
                 (string) getenv('STORAGE_API_URL'),
                 (string) getenv('STORAGE_API_TOKEN_MASTER'),
-            )
+            ),
         );
 
         $branchId = $this->createBranch('my-dev-branch', $clientWrapper);
@@ -520,8 +520,8 @@ class VariableResolverTest extends TestCase
             new ClientOptions(
                 (string) getenv('STORAGE_API_URL'),
                 (string) getenv('STORAGE_API_TOKEN_MASTER'),
-                (string) $branchId
-            )
+                (string) $branchId,
+            ),
         );
 
         // modify the dev branch variable configuration to "dev-bar"
@@ -547,7 +547,7 @@ class VariableResolverTest extends TestCase
                 ],
                 'variables_id' => $vConfigurationId,
             ],
-            $newConfiguration
+            $newConfiguration,
         );
         self::assertTrue($this->logsHandler->hasInfoThatContains('Replacing variables using values with ID:'));
         self::assertTrue($this->logsHandler->hasInfoThatContains('Replaced values for variables: foo'));
@@ -558,7 +558,7 @@ class VariableResolverTest extends TestCase
         list ($vConfigurationId, $vRowId) = $this->createVariablesConfiguration(
             $this->clientWrapper->getBasicClient(),
             ['variables' => [['name' => 4321, 'type' => 'string']]],
-            []
+            [],
         );
         $configuration = [
             'variables_id' => $vConfigurationId,
@@ -569,7 +569,7 @@ class VariableResolverTest extends TestCase
             $configuration,
             self::BRANCH_ID,
             null,
-            ['values' => [['name' => 4321, 'value' => 1234]]]
+            ['values' => [['name' => 4321, 'value' => 1234]]],
         );
         self::assertEquals(
             [
@@ -578,7 +578,7 @@ class VariableResolverTest extends TestCase
                 ],
                 'variables_id' => $vConfigurationId,
             ],
-            $newConfiguration
+            $newConfiguration,
         );
         self::assertTrue($this->logsHandler->hasInfoThatContains('Replacing variables using inline values.'));
         self::assertTrue($this->logsHandler->hasInfoThatContains('Replaced values for variables: 4321'));

--- a/libs/configuration-variables-resolver/tests/VariableResolverTest.php
+++ b/libs/configuration-variables-resolver/tests/VariableResolverTest.php
@@ -52,7 +52,7 @@ class VariableResolverTest extends TestCase
     {
         $variablesApiClient = $this->createMock(VariablesApiClient::class);
         $variablesApiClient
-            ->method('listMergedVariablesForBranch')
+            ->method('listScopedVariablesForBranch')
             ->with(self::BRANCH_ID)
             ->willReturn([])
         ;

--- a/libs/configuration-variables-resolver/tests/VariablesRenderer/MustacheRendererTest.php
+++ b/libs/configuration-variables-resolver/tests/VariablesRenderer/MustacheRendererTest.php
@@ -22,7 +22,7 @@ class MustacheRendererTest extends TestCase
             [
                 'foo' => 'bar',
                 'goo' => 'gar',
-            ]
+            ],
         );
 
         self::assertSame(
@@ -48,7 +48,7 @@ class MustacheRendererTest extends TestCase
             ],
             [
                 'foo' => 'bar',
-            ]
+            ],
         );
 
         self::assertSame(
@@ -74,7 +74,7 @@ class MustacheRendererTest extends TestCase
             ],
             [
                 'key1' => 'val1',
-            ]
+            ],
         );
 
         self::assertSame(
@@ -100,7 +100,7 @@ class MustacheRendererTest extends TestCase
             ],
             [
                 'foo' => 'special " \' { } characters',
-            ]
+            ],
         );
 
         self::assertSame(
@@ -126,7 +126,7 @@ class MustacheRendererTest extends TestCase
             ],
             [
                 'key1' => '"',
-            ]
+            ],
         );
 
         self::assertSame(
@@ -158,7 +158,7 @@ class MustacheRendererTest extends TestCase
             ],
             [
                 'key1' => 'value"',
-            ]
+            ],
         );
     }
 }

--- a/libs/configuration-variables-resolver/tests/VariablesResolver/ConfigurationVariablesResolverTest.php
+++ b/libs/configuration-variables-resolver/tests/VariablesResolver/ConfigurationVariablesResolverTest.php
@@ -42,7 +42,7 @@ class ConfigurationVariablesResolverTest extends TestCase
             new ClientOptions(
                 (string) getenv('STORAGE_API_URL'),
                 (string) getenv('STORAGE_API_TOKEN'),
-            )
+            ),
         );
     }
 
@@ -90,7 +90,7 @@ class ConfigurationVariablesResolverTest extends TestCase
         list ($vConfigurationId, $vRowId) = $this->createVariablesConfiguration(
             $this->clientWrapper->getBasicClient(),
             ['variables' => [['name' => 'foo', 'type' => 'string']]],
-            ['values' => [['name' => 'foo', 'value' => 'bar']]]
+            ['values' => [['name' => 'foo', 'value' => 'bar']]],
         );
         $configuration = [
             'variables_id' => $vConfigurationId,
@@ -118,7 +118,7 @@ class ConfigurationVariablesResolverTest extends TestCase
         list ($vConfigurationId, $vRowId) = $this->createVariablesConfiguration(
             $this->clientWrapper->getBasicClient(),
             ['variables' => [['name' => 'foo', 'type' => 'string']]],
-            []
+            [],
         );
         $configuration = [
             'variables_id' => $vConfigurationId,
@@ -128,7 +128,7 @@ class ConfigurationVariablesResolverTest extends TestCase
         $results = $variableResolver->resolveVariables(
             $configuration,
             null,
-            ['values' => [['name' => 'foo', 'value' => 'bar']]]
+            ['values' => [['name' => 'foo', 'value' => 'bar']]],
         );
         self::assertEquals(
             [
@@ -149,7 +149,7 @@ class ConfigurationVariablesResolverTest extends TestCase
         list ($vConfigurationId, $vRowId) = $this->createVariablesConfiguration(
             $this->clientWrapper->getBasicClient(),
             ['variables' => [['name' => 'foo', 'type' => 'string']]],
-            ['values' => [['name' => 'foo', 'value' => 'bar']]]
+            ['values' => [['name' => 'foo', 'value' => 'bar']]],
         );
         $configuration = [
             'variables_id' => $vConfigurationId,
@@ -178,7 +178,7 @@ class ConfigurationVariablesResolverTest extends TestCase
         list ($vConfigurationId, $vRowId) = $this->createVariablesConfiguration(
             $this->clientWrapper->getBasicClient(),
             ['variables' => [['name' => 'foo', 'type' => 'string']]],
-            ['values' => [['name' => 'foo', 'value' => 'bar']]]
+            ['values' => [['name' => 'foo', 'value' => 'bar']]],
         );
         $configuration = [
             'variables_id' => $vConfigurationId,
@@ -207,7 +207,7 @@ class ConfigurationVariablesResolverTest extends TestCase
         list ($vConfigurationId, $vRowId) = $this->createVariablesConfiguration(
             $this->clientWrapper->getBasicClient(),
             ['variables' => [['name' => 'foo', 'type' => 'string']]],
-            ['values' => [['name' => 'foo', 'value' => 'bar']]]
+            ['values' => [['name' => 'foo', 'value' => 'bar']]],
         );
         $configuration = [
             'variables_id' => $vConfigurationId,
@@ -218,7 +218,7 @@ class ConfigurationVariablesResolverTest extends TestCase
         $results = $variableResolver->resolveVariables(
             $configuration,
             null,
-            ['values' => [['name' => 'foo', 'value' => 'bazooka']]]
+            ['values' => [['name' => 'foo', 'value' => 'bazooka']]],
         );
         self::assertEquals(
             [
@@ -240,7 +240,7 @@ class ConfigurationVariablesResolverTest extends TestCase
         list ($vConfigurationId) = $this->createVariablesConfiguration(
             $this->clientWrapper->getBasicClient(),
             ['variables' => [['name' => 'foo', 'type' => 'string']]],
-            []
+            [],
         );
         $configuration = [
             'variables_id' => $vConfigurationId,
@@ -251,7 +251,7 @@ class ConfigurationVariablesResolverTest extends TestCase
         self::expectException(UserException::class);
         self::expectExceptionMessage(sprintf(
             'No variable values provided for variables configuration "%s".',
-            $vConfigurationId
+            $vConfigurationId,
         ));
         $variableResolver->resolveVariables($configuration, null, null);
     }
@@ -261,7 +261,7 @@ class ConfigurationVariablesResolverTest extends TestCase
         list ($vConfigurationId) = $this->createVariablesConfiguration(
             $this->clientWrapper->getBasicClient(),
             ['variables' => [['name' => 'foo', 'type' => 'string']]],
-            []
+            [],
         );
         $configuration = [
             'variables_id' => $vConfigurationId,
@@ -282,7 +282,7 @@ class ConfigurationVariablesResolverTest extends TestCase
         list ($vConfigurationId) = $this->createVariablesConfiguration(
             $this->clientWrapper->getBasicClient(),
             ['variables' => [['name' => 'foo', 'type' => 'string']]],
-            []
+            [],
         );
         $configuration = [
             'variables_id' => $vConfigurationId,
@@ -302,7 +302,7 @@ class ConfigurationVariablesResolverTest extends TestCase
         list ($vConfigurationId) = $this->createVariablesConfiguration(
             $this->clientWrapper->getBasicClient(),
             ['variables' => [['name' => 'foo', 'type' => 'string']]],
-            []
+            [],
         );
         $configuration = [
             'variables_id' => $vConfigurationId,
@@ -314,7 +314,7 @@ class ConfigurationVariablesResolverTest extends TestCase
         $variableResolver->resolveVariables(
             $configuration,
             'non-existent',
-            ['values' => [['name' => 'foo', 'value' => 'bar']]]
+            ['values' => [['name' => 'foo', 'value' => 'bar']]],
         );
     }
 
@@ -323,7 +323,7 @@ class ConfigurationVariablesResolverTest extends TestCase
         list ($vConfigurationId, $vRowId) = $this->createVariablesConfiguration(
             $this->clientWrapper->getBasicClient(),
             ['variables' => [['name' => 'foo', 'type' => 'string']]],
-            ['values' => [['name' => 'foo', 'value' => 'bar']]]
+            ['values' => [['name' => 'foo', 'value' => 'bar']]],
         );
         $configuration = [
             'variables_id' => $vConfigurationId,
@@ -333,7 +333,7 @@ class ConfigurationVariablesResolverTest extends TestCase
         $results = $variableResolver->resolveVariables(
             $configuration,
             $vRowId,
-            ['values' => []]
+            ['values' => []],
         );
         self::assertEquals(
             [
@@ -366,7 +366,7 @@ class ConfigurationVariablesResolverTest extends TestCase
         list ($vConfigurationId) = $this->createVariablesConfiguration(
             $this->clientWrapper->getBasicClient(),
             ['invalid' => 'data'],
-            []
+            [],
         );
         $configuration = [
             'variables_id' => $vConfigurationId,
@@ -376,7 +376,7 @@ class ConfigurationVariablesResolverTest extends TestCase
         self::expectException(UserException::class);
         self::expectExceptionMessage(
             'Variable configuration is invalid: Unrecognized option "invalid" under "variables". ' .
-            'Available option is "variables".'
+            'Available option is "variables".',
         );
         $variableResolver->resolveVariables($configuration, 'non-existent', null);
     }
@@ -404,7 +404,7 @@ class ConfigurationVariablesResolverTest extends TestCase
         list ($vConfigurationId, $vRowId) = $this->createVariablesConfiguration(
             $this->clientWrapper->getBasicClient(),
             ['variables' => [['name' => 'foo', 'type' => 'string']]],
-            ['invalid' => [['name' => 'foo', 'value' => 'bar']]]
+            ['invalid' => [['name' => 'foo', 'value' => 'bar']]],
         );
         $configuration = [
             'variables_id' => $vConfigurationId,
@@ -414,7 +414,7 @@ class ConfigurationVariablesResolverTest extends TestCase
         self::expectException(UserException::class);
         self::expectExceptionMessage(
             'Variable values configuration is invalid: Unrecognized option "invalid" under "values". ' .
-            'Available option is "values".'
+            'Available option is "values".',
         );
         $variableResolver->resolveVariables($configuration, $vRowId, []);
     }
@@ -424,7 +424,7 @@ class ConfigurationVariablesResolverTest extends TestCase
         list ($vConfigurationId, $vRowId) = $this->createVariablesConfiguration(
             $this->clientWrapper->getBasicClient(),
             ['variables' => [['name' => 'foo', 'type' => 'string']]],
-            []
+            [],
         );
         $configuration = [
             'variables_id' => $vConfigurationId,
@@ -434,7 +434,7 @@ class ConfigurationVariablesResolverTest extends TestCase
         $results = $variableResolver->resolveVariables(
             $configuration,
             null,
-            ['values' => [['name' => 'foo', 'value' => 'special " \' { } characters']]]
+            ['values' => [['name' => 'foo', 'value' => 'special " \' { } characters']]],
         );
         self::assertEquals(
             [
@@ -455,7 +455,7 @@ class ConfigurationVariablesResolverTest extends TestCase
         list ($vConfigurationId, $vRowId) = $this->createVariablesConfiguration(
             $this->clientWrapper->getBasicClient(),
             ['variables' => [['name' => 'foo', 'type' => 'string'], ['name' => 'goo', 'type' => 'string']]],
-            []
+            [],
         );
         $configuration = [
             'variables_id' => $vConfigurationId,
@@ -467,7 +467,7 @@ class ConfigurationVariablesResolverTest extends TestCase
         $variableResolver->resolveVariables(
             $configuration,
             null,
-            ['values' => [['name' => 'foo', 'value' => 'bar']]]
+            ['values' => [['name' => 'foo', 'value' => 'bar']]],
         );
     }
 
@@ -476,7 +476,7 @@ class ConfigurationVariablesResolverTest extends TestCase
         list ($vConfigurationId, $vRowId) = $this->createVariablesConfiguration(
             $this->clientWrapper->getBasicClient(),
             ['variables' => [['name' => 'foo', 'type' => 'string']]],
-            []
+            [],
         );
         $configuration = [
             'variables_id' => $vConfigurationId,
@@ -486,7 +486,7 @@ class ConfigurationVariablesResolverTest extends TestCase
         $results = $variableResolver->resolveVariables(
             $configuration,
             null,
-            ['values' => [['name' => 'foo', 'value' => 'bar']]]
+            ['values' => [['name' => 'foo', 'value' => 'bar']]],
         );
         self::assertSame([
             'variables_id' => $vConfigurationId,
@@ -501,13 +501,13 @@ class ConfigurationVariablesResolverTest extends TestCase
         list ($vConfigurationId, $vRowId) = $this->createVariablesConfiguration(
             $this->clientWrapper->getBasicClient(),
             ['variables' => [['name' => 'foo', 'type' => 'string']]],
-            ['values' => [['name' => 'foo', 'value' => 'bar']]]
+            ['values' => [['name' => 'foo', 'value' => 'bar']]],
         );
         $clientWrapper = new ClientWrapper(
             new ClientOptions(
                 (string) getenv('STORAGE_API_URL'),
                 (string) getenv('STORAGE_API_TOKEN_MASTER'),
-            )
+            ),
         );
 
         $branchId = $this->createBranch('my-dev-branch', $clientWrapper);
@@ -515,8 +515,8 @@ class ConfigurationVariablesResolverTest extends TestCase
             new ClientOptions(
                 (string) getenv('STORAGE_API_URL'),
                 (string) getenv('STORAGE_API_TOKEN_MASTER'),
-                (string) $branchId
-            )
+                (string) $branchId,
+            ),
         );
 
         // modify the dev branch variable configuration to "dev-bar"
@@ -554,7 +554,7 @@ class ConfigurationVariablesResolverTest extends TestCase
         list ($vConfigurationId, $vRowId) = $this->createVariablesConfiguration(
             $this->clientWrapper->getBasicClient(),
             ['variables' => [['name' => 4321, 'type' => 'string']]],
-            []
+            [],
         );
         $configuration = [
             'variables_id' => $vConfigurationId,
@@ -564,7 +564,7 @@ class ConfigurationVariablesResolverTest extends TestCase
         $results = $variableResolver->resolveVariables(
             $configuration,
             null,
-            ['values' => [['name' => 4321, 'value' => 1234]]]
+            ['values' => [['name' => 4321, 'value' => 1234]]],
         );
         self::assertEquals(
             [

--- a/libs/configuration-variables-resolver/tests/VariablesResolver/VaultVariablesResolverTest.php
+++ b/libs/configuration-variables-resolver/tests/VariablesResolver/VaultVariablesResolverTest.php
@@ -23,7 +23,7 @@ class VaultVariablesResolverTest extends TestCase
 
         $vaultApiClient = $this->createMock(VariablesApiClient::class);
         $vaultApiClient->expects(self::once())
-            ->method('listMergedVariablesForBranch')
+            ->method('listScopedVariablesForBranch')
             ->with('branch-id')
             ->willReturn([
                 new Variable('hash1', 'foo', 'bar', false, ['branchId' => 'branch-id']),

--- a/libs/configuration-variables-resolver/tests/VariablesResolver/VaultVariablesResolverTest.php
+++ b/libs/configuration-variables-resolver/tests/VariablesResolver/VaultVariablesResolverTest.php
@@ -26,7 +26,7 @@ class VaultVariablesResolverTest extends TestCase
             ->method('listScopedVariablesForBranch')
             ->with('branch-id')
             ->willReturn([
-                new Variable('hash1', 'foo', 'bar', false, ['branchId' => 'branch-id']),
+                new Variable('hash1', 'foo', 'bar', [], ['branchId' => 'branch-id']),
             ])
         ;
 

--- a/libs/configuration-variables-resolver/tests/VariablesResolverFunctionalTest.php
+++ b/libs/configuration-variables-resolver/tests/VariablesResolverFunctionalTest.php
@@ -47,7 +47,7 @@ class VariablesResolverFunctionalTest extends TestCase
             new ClientOptions(
                 self::getRequiredEnv('STORAGE_API_URL'),
                 self::getRequiredEnv('STORAGE_API_TOKEN'),
-            )
+            ),
         );
 
         $this->variablesApiClient = new VariablesApiClient(
@@ -122,7 +122,7 @@ class VariablesResolverFunctionalTest extends TestCase
     {
         $this->setupConfigurationVariables(
             ['variables' => [['name' => 'foo', 'type' => 'string']]],
-            ['values' => [['name' => 'foo', 'value' => 'config foo']]]
+            ['values' => [['name' => 'foo', 'value' => 'config foo']]],
         );
         $this->setupVaultVariables([
             'foo' => 'vault foo',
@@ -154,7 +154,7 @@ class VariablesResolverFunctionalTest extends TestCase
                 ],
                 'variables_id' => self::CONFIG_ID,
             ],
-            $newConfiguration
+            $newConfiguration,
         );
 
         self::assertTrue($this->logsHandler->hasInfoThatContains('Replaced values for variables: vault.foo, foo'));
@@ -164,7 +164,7 @@ class VariablesResolverFunctionalTest extends TestCase
     {
         $this->setupConfigurationVariables(
             ['variables' => [['name' => 'foo', 'type' => 'string']]],
-            ['values' => [['name' => 'foo', 'value' => 'main config foo']]]
+            ['values' => [['name' => 'foo', 'value' => 'main config foo']]],
         );
         $this->setupVaultVariables([
             'foo' => 'main vault foo',
@@ -241,7 +241,7 @@ class VariablesResolverFunctionalTest extends TestCase
                 ],
                 'variables_id' => self::CONFIG_ID,
             ],
-            $newConfiguration
+            $newConfiguration,
         );
 
         self::assertTrue($this->logsHandler->hasInfoThatContains('Replaced values for variables: vault.foo, foo'));
@@ -251,7 +251,7 @@ class VariablesResolverFunctionalTest extends TestCase
     {
         $this->setupConfigurationVariables(
             ['variables' => []],
-            []
+            [],
         );
         $this->setupVaultVariables([]);
 
@@ -283,7 +283,7 @@ class VariablesResolverFunctionalTest extends TestCase
     {
         $this->setupConfigurationVariables(
             ['variables' => [['name' => 'foo', 'type' => 'string']]],
-            ['values' => [['name' => 'foo', 'value' => 'config foo']]]
+            ['values' => [['name' => 'foo', 'value' => 'config foo']]],
         );
 
         $configuration = [
@@ -315,7 +315,7 @@ class VariablesResolverFunctionalTest extends TestCase
                 ],
                 'variables_id' => self::CONFIG_ID,
             ],
-            $newConfiguration
+            $newConfiguration,
         );
 
         self::assertTrue($this->logsHandler->hasInfoThatContains('Replaced values for variables: foo'));

--- a/libs/vault-api-client/src/Variables/Model/Variable.php
+++ b/libs/vault-api-client/src/Variables/Model/Variable.php
@@ -8,18 +8,21 @@ use Keboola\VaultApiClient\ResponseModelInterface;
 
 final readonly class Variable implements ResponseModelInterface
 {
+    public const FLAG_ENCRYPTED = 'encrypted';
+    public const FLAG_OAUTH_CREDENTIALS_ID = 'oauthCredentialsId';
+
     /**
      * @param non-empty-string $hash
      * @param non-empty-string $key
      * @param string $value
-     * @param bool $isEncrypted
+     * @param array<self::FLAG_*> $flags
      * @param array<non-empty-string, string> $attributes
      */
     public function __construct(
         public string $hash,
         public string $key,
         public string $value,
-        public bool $isEncrypted,
+        public array $flags,
         public array $attributes,
     ) {
     }
@@ -30,7 +33,7 @@ final readonly class Variable implements ResponseModelInterface
             $data['hash'],
             $data['key'],
             $data['value'],
-            $data['isEncrypted'] ?? false,
+            $data['flags'] ?? [],
             $data['attributes'] ?? [],
         );
     }

--- a/libs/vault-api-client/src/Variables/VariablesApiClient.php
+++ b/libs/vault-api-client/src/Variables/VariablesApiClient.php
@@ -87,14 +87,12 @@ class VariablesApiClient
      * @param non-empty-string $branchId
      * @return array<Variable>
      */
-    public function listMergedVariablesForBranch(string $branchId): array
+    public function listScopedVariablesForBranch(string $branchId): array
     {
         return $this->apiClient->sendRequestAndMapResponse(
             new Request(
                 'GET',
-                'variables/merged/branch?' . http_build_query([
-                    'branchId' => $branchId,
-                ]),
+                'variables/scoped/branch/' . $branchId,
             ),
             Variable::class,
             [],

--- a/libs/vault-api-client/src/Variables/VariablesApiClient.php
+++ b/libs/vault-api-client/src/Variables/VariablesApiClient.php
@@ -29,11 +29,12 @@ class VariablesApiClient
 
     /**
      * @param non-empty-string $key
+     * @param array<Variable::FLAG_*> $flags
      */
     public function createVariable(
         string $key,
         string $value,
-        bool $isEncrypted = false,
+        array $flags = [],
         array $attributes = [],
     ): Variable {
         return $this->apiClient->sendRequestAndMapResponse(
@@ -46,7 +47,7 @@ class VariablesApiClient
                 Json::encodeArray([
                     'key' => $key,
                     'value' => $value,
-                    'isEncrypted' => $isEncrypted,
+                    'flags' => $flags,
                     'attributes' => $attributes,
                 ])
             ),

--- a/libs/vault-api-client/tests/Variables/Model/VariableTest.php
+++ b/libs/vault-api-client/tests/Variables/Model/VariableTest.php
@@ -15,7 +15,7 @@ class VariableTest extends TestCase
             'hash' => 'hash',
             'key' => 'key',
             'value' => 'value',
-            'isEncrypted' => true,
+            'flags' => ['encrypted'],
             'attributes' => [
                 'attr1' => 'val1',
                 'attr2' => 'val2',
@@ -27,7 +27,7 @@ class VariableTest extends TestCase
             hash: 'hash',
             key: 'key',
             value: 'value',
-            isEncrypted: true,
+            flags: [Variable::FLAG_ENCRYPTED],
             attributes: [
                 'attr1' => 'val1',
                 'attr2' => 'val2',

--- a/libs/vault-api-client/tests/Variables/VariablesApiClientTest.php
+++ b/libs/vault-api-client/tests/Variables/VariablesApiClientTest.php
@@ -177,7 +177,7 @@ class VariablesApiClientTest extends TestCase
         );
     }
 
-    public function testListMergedVariablesFor(): void
+    public function testListScopedVariablesForBranch(): void
     {
         $requestHandler = self::createRequestHandler($requestsHistory, [
             new Response(
@@ -200,12 +200,12 @@ class VariablesApiClientTest extends TestCase
             ),
         );
 
-        $variables = $client->listMergedVariablesForBranch('123');
+        $variables = $client->listScopedVariablesForBranch('123');
 
         self::assertCount(1, $requestsHistory);
         self::assertRequestEquals(
             'GET',
-            self::BASE_URL . '/variables/merged/branch?branchId=123',
+            self::BASE_URL . '/variables/scoped/branch/123',
             [
                 'X-StorageApi-Token' => self::API_TOKEN,
             ],

--- a/libs/vault-api-client/tests/Variables/VariablesApiClientTest.php
+++ b/libs/vault-api-client/tests/Variables/VariablesApiClientTest.php
@@ -32,7 +32,7 @@ class VariablesApiClientTest extends TestCase
                     'hash' => 'hash',
                     'key' => 'key',
                     'value' => 'val',
-                    'isEncrypted' => true,
+                    'flags' => ['encrypted'],
                     'attributes' => [
                         'branchId' => '123',
                     ],
@@ -51,10 +51,8 @@ class VariablesApiClientTest extends TestCase
         $variable = $client->createVariable(
             'key',
             'val',
-            true,
-            [
-                'branchId' => '123',
-            ]
+            [Variable::FLAG_ENCRYPTED],
+            ['branchId' => '123'],
         );
 
         self::assertCount(1, $requestsHistory);
@@ -68,7 +66,7 @@ class VariablesApiClientTest extends TestCase
             Json::encodeArray([
                 'key' => 'key',
                 'value' => 'val',
-                'isEncrypted' => true,
+                'flags' => ['encrypted'],
                 'attributes' => [
                     'branchId' => '123',
                 ],
@@ -81,7 +79,7 @@ class VariablesApiClientTest extends TestCase
                 hash: 'hash',
                 key: 'key',
                 value: 'val',
-                isEncrypted: true,
+                flags: [Variable::FLAG_ENCRYPTED],
                 attributes: [
                     'branchId' => '123',
                 ],
@@ -127,8 +125,8 @@ class VariablesApiClientTest extends TestCase
                     'Content-Type' => 'application/json',
                 ],
                 Json::encodeArray([
-                    ['hash' => 'hash1', 'key' => 'key1', 'value' => 'val1', 'isEncrypted' => false, 'attributes' => []],
-                    ['hash' => 'hash2', 'key' => 'key2', 'value' => 'val2', 'isEncrypted' => false, 'attributes' => []],
+                    ['hash' => 'hash1', 'key' => 'key1', 'value' => 'val1', 'flags' => [], 'attributes' => []],
+                    ['hash' => 'hash2', 'key' => 'key2', 'value' => 'val2', 'flags' => [], 'attributes' => []],
                 ])
             ),
         ]);
@@ -160,7 +158,7 @@ class VariablesApiClientTest extends TestCase
                 hash: 'hash1',
                 key: 'key1',
                 value: 'val1',
-                isEncrypted: false,
+                flags: [],
                 attributes: [],
             ),
             $variables[0],
@@ -170,7 +168,7 @@ class VariablesApiClientTest extends TestCase
                 hash: 'hash2',
                 key: 'key2',
                 value: 'val2',
-                isEncrypted: false,
+                flags: [],
                 attributes: [],
             ),
             $variables[1],
@@ -186,8 +184,8 @@ class VariablesApiClientTest extends TestCase
                     'Content-Type' => 'application/json',
                 ],
                 Json::encodeArray([
-                    ['hash' => 'hash1', 'key' => 'key1', 'value' => 'val1', 'isEncrypted' => false, 'attributes' => []],
-                    ['hash' => 'hash2', 'key' => 'key2', 'value' => 'val2', 'isEncrypted' => false, 'attributes' => []],
+                    ['hash' => 'hash1', 'key' => 'key1', 'value' => 'val1', 'flags' => [], 'attributes' => []],
+                    ['hash' => 'hash2', 'key' => 'key2', 'value' => 'val2', 'flags' => [], 'attributes' => []],
                 ])
             ),
         ]);
@@ -219,7 +217,7 @@ class VariablesApiClientTest extends TestCase
                 hash: 'hash1',
                 key: 'key1',
                 value: 'val1',
-                isEncrypted: false,
+                flags: [],
                 attributes: [],
             ),
             $variables[0],
@@ -229,7 +227,7 @@ class VariablesApiClientTest extends TestCase
                 hash: 'hash2',
                 key: 'key2',
                 value: 'val2',
-                isEncrypted: false,
+                flags: [],
                 attributes: [],
             ),
             $variables[1],


### PR DESCRIPTION
https://keboola.atlassian.net/browse/GCP-290
https://keboola.atlassian.net/browse/GCP-291

Sesli se nam ted 2 BC (v ramci cleanupu), tak jsem je odbavil najednou:
* nahrazeni `isEncrypted` property za `flags`
* nahrazeni `/variables/merged/branch` endpointu za `/variables/scoped/branch/{branchId}`

Trochu nesikovne se tam pripletl update code-style, protoze nemame locknutou verzi `keboola/coding-standard`. Je aspon izolovany do samostatnyho commitu.

Vydam to jako
* major verzi `vault-api-client`
* patch verzi `configuration-variables-resolver`

Potom je potreba updatnout v
* `job-runner`
* `job-queue-daemon`
* `data-loader-api`
* `runner-sync-api`