### PR TITLE
GCP-332 [permission-checker] Project-wide OAuth authorization

### DIFF
--- a/libs/permission-checker/src/Check/OAuth/CanModifyAuthorization.php
+++ b/libs/permission-checker/src/Check/OAuth/CanModifyAuthorization.php
@@ -22,7 +22,7 @@ class CanModifyAuthorization implements PermissionCheckInterface
     {
         if ($token->hasFeature(Feature::PROTECTED_DEFAULT_BRANCH)) {
             $isRoleAllowed = match ($token->getRole()) {
-                Role::PRODUCTION_MANAGER => $this->branchType === BranchType::DEFAULT,
+                Role::PRODUCTION_MANAGER => $this->branchType === null || $this->branchType === BranchType::DEFAULT,
                 Role::DEVELOPER, Role::REVIEWER => $this->branchType === BranchType::DEV,
                 default => false,
             };

--- a/libs/permission-checker/tests/Check/OAuth/CanModifyAuthorizationTest.php
+++ b/libs/permission-checker/tests/Check/OAuth/CanModifyAuthorizationTest.php
@@ -34,6 +34,11 @@ class CanModifyAuthorizationTest extends TestCase
             'token' => new StorageApiToken(features: ['protected-default-branch'], role: 'productionManager'),
         ];
 
+        yield 'productionManager without branch (project-wide)' => [
+            'branchType' => null,
+            'token' => new StorageApiToken(features: ['protected-default-branch'], role: 'productionManager'),
+        ];
+
         yield 'developer on protected dev branch' => [
             'branchType' => BranchType::DEV,
             'token' => new StorageApiToken(features: ['protected-default-branch'], role: 'developer'),
@@ -102,12 +107,6 @@ class CanModifyAuthorizationTest extends TestCase
 
         yield 'productionManager role on protected dev branch' => [
             'branchType' => BranchType::DEV,
-            'token' => new StorageApiToken(features: ['protected-default-branch'], role: 'productionManager'),
-            'error' => new PermissionDeniedException('Role "productionManager" is not allowed to modify authorization'),
-        ];
-
-        yield 'productionManager role without branch' => [
-            'branchType' => null,
             'token' => new StorageApiToken(features: ['protected-default-branch'], role: 'productionManager'),
             'error' => new PermissionDeniedException('Role "productionManager" is not allowed to modify authorization'),
         ];


### PR DESCRIPTION
https://keboola.atlassian.net/browse/GCP-332
https://keboolaglobal.slack.com/archives/C0551J4J70B/p1695298303430559

Povoluje manipulaci s project-wide (bez `branchId`) OAuth credentials pro production managera.

Navazovat bude PR na update v `oauth-service`