### PR TITLE
[input-mapping] composer: storage-api-php-client-branch-wrapper >=5.0.1

### DIFF
--- a/libs/input-mapping/composer.json
+++ b/libs/input-mapping/composer.json
@@ -14,7 +14,7 @@
         "ext-json": "*",
         "keboola/php-file-storage-utils": "^0.2",
         "keboola/storage-api-client": "^14.11.2",
-        "keboola/storage-api-php-client-branch-wrapper": "^5.0",
+        "keboola/storage-api-php-client-branch-wrapper": "^5.0.1",
         "symfony/config": "^5.4|^6.0",
         "symfony/finder": "^5.4|^6.0",
         "symfony/serializer": "^5.4|^6.0",


### PR DESCRIPTION
Fixes: https://keboola.atlassian.net/browse/SOX-333

jeste vynucenej update client wrapperu, aby pri zadani neexistujici branche to nepadalo na app erroru