### PR TITLE
SOX-435 Connection events support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ COPY docker/php/xdebug.ini /usr/local/etc/php/conf.d/
 
 RUN apt update -q \
  && apt install -y --no-install-recommends git zip unzip libzip4 libzip-dev zlib1g-dev \
- && docker-php-ext-install zip \
+ && docker-php-ext-install pcntl zip \
  && apt-get remove --autoremove -y libzip-dev zlib1g-dev \
  && rm -rf /var/lib/apt/lists/*
 

--- a/libs/messenger-bundle/README.md
+++ b/libs/messenger-bundle/README.md
@@ -8,18 +8,25 @@ composer require keboola/messenger-bundle
 ```
 
 ## Configuration
-Bundle supportf following configuration options:
-* **platform** - required, `aws`, `azure` or `gcp`
-* **connection_events_queue_dsn** - required, DSN for connection events queue
-  * for AWS use the queue URL, ex. `https://sqs.eu-central-1.amazonaws.com/025303414634/queue-name`
+Bundle supports following configuration options:
+* **platform** - required, `aws` or `azure`
+* **connection_events_queue_dsn** - optional, DSN for connection events queue
+* **connection_audit_log_queue_dsn** - optional, DSN for connection audit log queue
+ 
+See documentation of each platform driver for details on DSN syntax
+  * for AWS use the queue URL, ex. `https://sqs.eu-central-1.amazonaws.com/025303414634/queue-name`,
+    see https://symfony.com/doc/current/messenger.html#amazon-sqs for details
   * for Azure use format `azure://<sas-key-name>:<sas-kev-value>@<servicebus-namespace>?entity_name=<servicebus-queue-name>`,
     see https://github.com/AymDev/MessengerAzureBundle for details
+  * for GCP use format `gps://default/<topic-name>`,
+    see https://github.com/petitpress/gps-messenger-bundle for details
 
 Reference:
 ```yaml
 keboola_messenger:
   platform: "%env(PLATFORM)%"
   connection_events_queue_dsn: "%env(CONNECTION_EVENTS_QUEUE_DSN)%"
+  connection_audit_log_queue_dsn: "%env(CONNECTION_AUDIT_LOG_QUEUE_DSN)%"
 ```
 
 ## Development

--- a/libs/messenger-bundle/README.md
+++ b/libs/messenger-bundle/README.md
@@ -9,7 +9,7 @@ composer require keboola/messenger-bundle
 
 ## Configuration
 Bundle supportf following configuration options:
-* **platform** - required, `aws` or `azure`
+* **platform** - required, `aws`, `azure` or `gcp`
 * **connection_events_queue_dsn** - required, DSN for connection events queue
   * for AWS use the queue URL, ex. `https://sqs.eu-central-1.amazonaws.com/025303414634/queue-name`
   * for Azure use format `azure://<sas-key-name>:<sas-kev-value>@<servicebus-namespace>?entity_name=<servicebus-queue-name>`,

--- a/libs/messenger-bundle/README.md
+++ b/libs/messenger-bundle/README.md
@@ -9,7 +9,8 @@ composer require keboola/messenger-bundle
 
 ## Configuration
 Bundle supports following configuration options:
-* **platform** - required, `aws` or `azure`
+* **platform** - optional, `aws`, `azure`, `gcp` or `null`
+  * when not set (or set to `null`) the bundle will not set up any transport 
 * **connection_events_queue_dsn** - optional, DSN for connection events queue
 * **connection_audit_log_queue_dsn** - optional, DSN for connection audit log queue
  

--- a/libs/messenger-bundle/azure-pipelines.tests.yml
+++ b/libs/messenger-bundle/azure-pipelines.tests.yml
@@ -52,3 +52,30 @@ jobs:
       - script: docker-compose logs
         displayName: Show logs
         condition: failed()
+
+  - job:
+    displayName: Tests - GCP
+    steps:
+      - template: ../../azure-pipelines/steps/restore-docker-artifacts.yml
+
+      - script: ./libs/messenger-bundle/provisioning/ci/pipelines-scripts/terraform-install.sh
+        displayName: Install Terraform
+
+      - script: ./libs/messenger-bundle/provisioning/ci/pipelines-scripts/terraform-init.sh
+        displayName: Configure Terraform
+        env:
+          AWS_ACCESS_KEY_ID: $(MESSENGER_BUNDLE_TERRAFORM_AWS_ACCESS_KEY_ID)
+          AWS_SECRET_ACCESS_KEY: $(MESSENGER_BUNDLE_TERRAFORM_AWS_SECRET_ACCESS_KEY)
+
+      - script: ./libs/messenger-bundle/provisioning/ci/update-env.sh -v -e .env -a gcp
+        displayName: Configure ENV
+        env:
+          AWS_ACCESS_KEY_ID: $(MESSENGER_BUNDLE_TERRAFORM_AWS_ACCESS_KEY_ID)
+          AWS_SECRET_ACCESS_KEY: $(MESSENGER_BUNDLE_TERRAFORM_AWS_SECRET_ACCESS_KEY)
+
+      - script: docker-compose run --rm dev-messenger-bundle bash -c "composer install && composer ci"
+        displayName: Run tests
+
+      - script: docker-compose logs
+        displayName: Show logs
+        condition: failed()

--- a/libs/messenger-bundle/composer.json
+++ b/libs/messenger-bundle/composer.json
@@ -29,7 +29,9 @@
 
     "require": {
         "php": ">=8.2",
+        "ext-pcntl": "*",
         "aymdev/messenger-azure-bundle": "dev-dsnParser",
+        "petitpress/gps-messenger-bundle": "^1.6",
         "symfony/amazon-sqs-messenger": "^6.3",
         "symfony/dependency-injection": "^6.0",
         "symfony/messenger": "^6.0"

--- a/libs/messenger-bundle/phpcs.xml
+++ b/libs/messenger-bundle/phpcs.xml
@@ -4,6 +4,7 @@
         <exclude name="SlevomatCodingStandard.TypeHints.ParameterTypeHint"/>
         <exclude name="SlevomatCodingStandard.TypeHints.PropertyTypeHint"/>
         <exclude name="SlevomatCodingStandard.TypeHints.ReturnTypeHint"/>
+        <exclude name="Squiz.Functions.MultiLineFunctionDeclaration.EmptyLine"/>
     </rule>
     <exclude-pattern>*/src/Kernel.php</exclude-pattern>
 </ruleset>

--- a/libs/messenger-bundle/provisioning/ci/.terraform.lock.hcl
+++ b/libs/messenger-bundle/provisioning/ci/.terraform.lock.hcl
@@ -63,3 +63,23 @@ provider "registry.terraform.io/hashicorp/azurerm" {
     "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
   ]
 }
+
+provider "registry.terraform.io/hashicorp/google" {
+  version     = "4.74.0"
+  constraints = "~> 4.74.0"
+  hashes = [
+    "h1:sod0KZScwUDWiOEEBY7JSXj8kNxiP8wPjqpAauiaTeI=",
+    "zh:60904193c367b1ba9a3cb1bd86ca469ffcec2f7237e59adf4b0a34c84b2fa9ff",
+    "zh:6e5ac12f3fefc23907a94e5f6040118c978af76ab5deb60a5b80110c1c8ade09",
+    "zh:9fc0ae0f97ab598c27fae0a6b19e82c13fd59d020d7cdfeeebdbe41c4a8216ef",
+    "zh:aa2346dbd9f22e56d011b1b741e1829bc78633cc3da704d7c4e9636c314541fa",
+    "zh:ca692e666253cca77c6ff68423bf940c7f249a8b4f4af9b80c1a7079808b8ada",
+    "zh:cbaf541db823cff4379e294ad696bef2940c3eff863fa7fd340ea978872dfdaf",
+    "zh:d1f6fba2f64d51a804bf4f4e90b7809e26fa0539a1119e55907cc501add6a5d2",
+    "zh:d556680c85b8c90557b469d30a8082f056a2b724f812b97da6505a9d78139854",
+    "zh:ea7cd2d4fa940e3518221a67f24b2ff8d795c325fe8b95fd149ac0cc3e1e944a",
+    "zh:eca542a0e4caed8ab6a30eb0199755dfc2938083942a233d6a5ef60e204ac67c",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+    "zh:f729b6f01050dd443b98cc5e7911102cdc8209e250cc1c2568aa37ba74b7c894",
+  ]
+}

--- a/libs/messenger-bundle/provisioning/ci/env-scripts/extract-variables-aws.sh
+++ b/libs/messenger-bundle/provisioning/ci/env-scripts/extract-variables-aws.sh
@@ -7,6 +7,7 @@ source ./functions.sh
 # output variables
 output_var 'TEST_CLOUD_PLATFORM' 'aws'
 output_var 'CONNECTION_EVENTS_QUEUE_DSN' "$(terraform_output 'aws_sqs_queue_url')"
+output_var 'CONNECTION_AUDIT_LOG_QUEUE_DSN' "$(terraform_output 'aws_sqs_queue_url')"
 echo ''
 
 output_var 'AWS_DEFAULT_REGION' "$(terraform_output 'aws_region')"

--- a/libs/messenger-bundle/provisioning/ci/env-scripts/extract-variables-azure.sh
+++ b/libs/messenger-bundle/provisioning/ci/env-scripts/extract-variables-azure.sh
@@ -7,6 +7,7 @@ source ./functions.sh
 # output variables
 output_var 'TEST_CLOUD_PLATFORM' 'azure'
 output_var 'CONNECTION_EVENTS_QUEUE_DSN' "$(print_url 'azure://%s:%s@%s?entity_path=%s' "$(terraform_output 'az_servicebus_sas_key_name')" "$(terraform_output 'az_servicebus_sas_key_value')" "$(terraform_output 'az_servicebus_namespace')" "$(terraform_output 'az_servicebus_queue_name')")"
+output_var 'CONNECTION_AUDIT_LOG_QUEUE_DSN' "$(print_url 'azure://%s:%s@%s?entity_path=%s' "$(terraform_output 'az_servicebus_sas_key_name')" "$(terraform_output 'az_servicebus_sas_key_value')" "$(terraform_output 'az_servicebus_namespace')" "$(terraform_output 'az_servicebus_queue_name')")"
 echo ''
 
 output_var 'AZURE_TENANT_ID' "$(terraform_output 'az_tenant_id')"

--- a/libs/messenger-bundle/provisioning/ci/env-scripts/extract-variables-gcp.sh
+++ b/libs/messenger-bundle/provisioning/ci/env-scripts/extract-variables-gcp.sh
@@ -7,6 +7,7 @@ source ./functions.sh
 # output variables
 output_var 'TEST_CLOUD_PLATFORM' 'gcp'
 output_var 'CONNECTION_EVENTS_QUEUE_DSN' "$(print_url 'gps://default/%s' "$(terraform_output 'gcp_topic_name')")"
+output_var 'CONNECTION_AUDIT_LOG_QUEUE_DSN' "$(print_url 'gps://default/%s' "$(terraform_output 'gcp_topic_name')")"
 echo ''
 
 output_file 'var/gcp/private-key.json' "$(terraform_output 'gcp_application_credentials' | base64 --decode)"

--- a/libs/messenger-bundle/provisioning/ci/env-scripts/extract-variables-gcp.sh
+++ b/libs/messenger-bundle/provisioning/ci/env-scripts/extract-variables-gcp.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+cd "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source ./functions.sh
+
+# output variables
+output_var 'TEST_CLOUD_PLATFORM' 'gcp'
+output_var 'CONNECTION_EVENTS_QUEUE_DSN' "$(print_url 'gps://default/%s' "$(terraform_output 'gcp_topic_name')")"
+echo ''
+
+output_file 'var/gcp/private-key.json' "$(terraform_output 'gcp_application_credentials' | base64 --decode)"
+output_var 'GOOGLE_APPLICATION_CREDENTIALS' 'var/gcp/private-key.json'
+echo ''

--- a/libs/messenger-bundle/provisioning/ci/env-scripts/functions.sh
+++ b/libs/messenger-bundle/provisioning/ci/env-scripts/functions.sh
@@ -9,7 +9,6 @@ terraform_output () {
 }
 
 output_var () {
-  >&2 echo "VAR: ${1:-}, VAL: ${2:-}"
   echo "${1}=\"${2}\""
 }
 

--- a/libs/messenger-bundle/provisioning/ci/gcp.tf
+++ b/libs/messenger-bundle/provisioning/ci/gcp.tf
@@ -1,0 +1,24 @@
+locals {
+  gcp_project = "kbc-ci-platform-services"
+  gcp_region = "us-central1"
+}
+
+provider "google" {
+  project = local.gcp_project
+}
+
+resource "google_service_account" "messenger_bundle" {
+  account_id   = "${var.name_prefix}-${local.app_name}"
+  display_name = "${var.name_prefix} ${local.app_display_name}"
+}
+
+resource "google_service_account_key" "messenger_bundle" {
+  service_account_id = google_service_account.messenger_bundle.name
+  public_key_type    = "TYPE_X509_PEM_FILE"
+  private_key_type   = "TYPE_GOOGLE_CREDENTIALS_FILE"
+}
+
+output "gcp_application_credentials" {
+  value     = google_service_account_key.messenger_bundle.private_key
+  sensitive = true
+}

--- a/libs/messenger-bundle/provisioning/ci/gcp_queue.tf
+++ b/libs/messenger-bundle/provisioning/ci/gcp_queue.tf
@@ -1,0 +1,35 @@
+resource "google_pubsub_topic" "testing_queue" {
+  name = "${var.name_prefix}-${local.app_name}"
+}
+
+resource "google_pubsub_subscription" "testing_queue" {
+  name  = "${var.name_prefix}-${local.app_name}"
+  topic = google_pubsub_topic.testing_queue.name
+
+  ack_deadline_seconds       = 30
+  message_retention_duration = "3600s"
+  retain_acked_messages      = false
+  enable_message_ordering    = false
+}
+
+resource "google_pubsub_topic_iam_binding" "messenger_bundle_iam" {
+  topic = google_pubsub_topic.testing_queue.name
+  role  = "roles/pubsub.publisher"
+
+  members = [
+    google_service_account.messenger_bundle.member,
+  ]
+}
+
+resource "google_pubsub_subscription_iam_binding" "messenger_bundle_iam" {
+  subscription = google_pubsub_subscription.testing_queue.name
+  role         = "roles/pubsub.subscriber"
+
+  members = [
+    google_service_account.messenger_bundle.member,
+  ]
+}
+
+output "gcp_topic_name" {
+  value = google_pubsub_topic.testing_queue.name
+}

--- a/libs/messenger-bundle/provisioning/ci/main.tf
+++ b/libs/messenger-bundle/provisioning/ci/main.tf
@@ -14,6 +14,11 @@ terraform {
       source  = "hashicorp/azuread"
       version = "~> 2.41"
     }
+
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 4.74.0"
+    }
   }
 
   backend "s3" {}

--- a/libs/messenger-bundle/provisioning/ci/update-env.sh
+++ b/libs/messenger-bundle/provisioning/ci/update-env.sh
@@ -6,7 +6,7 @@ INSERT_MODE=prepend
 VERBOSE=false
 
 help () {
-  echo "Syntax: update-env.sh [-v] [-a] [-e ${ENV_FILE}] <aws|azure>"
+  echo "Syntax: update-env.sh [-v] [-a] [-e ${ENV_FILE}] <aws|azure|gcp>"
   echo "Options:"
   echo "  -a|--append         Append mode (used only when creating new env file, by default values are prepended to the env file)"
   echo "  -e|--env-file file  Env file to write (default: ${ENV_FILE})"
@@ -54,8 +54,8 @@ done
 set -- "${POSITIONAL_ARGS[@]}"
 
 ENV_NAME=${1:-}
-if [[ $ENV_NAME != "aws" && $ENV_NAME != "azure" ]]; then
-    echo "Invalid environment name '${ENV_NAME}'. Possible values are: aws, azure"
+if [[ $ENV_NAME != "aws" && $ENV_NAME != "azure" && $ENV_NAME != "gcp" ]]; then
+    echo "Invalid environment name '${ENV_NAME}'. Possible values are: aws, azure, gpc"
     echo ""
     help
     exit 1

--- a/libs/messenger-bundle/provisioning/local/.terraform.lock.hcl
+++ b/libs/messenger-bundle/provisioning/local/.terraform.lock.hcl
@@ -63,3 +63,23 @@ provider "registry.terraform.io/hashicorp/azurerm" {
     "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
   ]
 }
+
+provider "registry.terraform.io/hashicorp/google" {
+  version     = "4.74.0"
+  constraints = "~> 4.74.0"
+  hashes = [
+    "h1:sod0KZScwUDWiOEEBY7JSXj8kNxiP8wPjqpAauiaTeI=",
+    "zh:60904193c367b1ba9a3cb1bd86ca469ffcec2f7237e59adf4b0a34c84b2fa9ff",
+    "zh:6e5ac12f3fefc23907a94e5f6040118c978af76ab5deb60a5b80110c1c8ade09",
+    "zh:9fc0ae0f97ab598c27fae0a6b19e82c13fd59d020d7cdfeeebdbe41c4a8216ef",
+    "zh:aa2346dbd9f22e56d011b1b741e1829bc78633cc3da704d7c4e9636c314541fa",
+    "zh:ca692e666253cca77c6ff68423bf940c7f249a8b4f4af9b80c1a7079808b8ada",
+    "zh:cbaf541db823cff4379e294ad696bef2940c3eff863fa7fd340ea978872dfdaf",
+    "zh:d1f6fba2f64d51a804bf4f4e90b7809e26fa0539a1119e55907cc501add6a5d2",
+    "zh:d556680c85b8c90557b469d30a8082f056a2b724f812b97da6505a9d78139854",
+    "zh:ea7cd2d4fa940e3518221a67f24b2ff8d795c325fe8b95fd149ac0cc3e1e944a",
+    "zh:eca542a0e4caed8ab6a30eb0199755dfc2938083942a233d6a5ef60e204ac67c",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+    "zh:f729b6f01050dd443b98cc5e7911102cdc8209e250cc1c2568aa37ba74b7c894",
+  ]
+}

--- a/libs/messenger-bundle/provisioning/local/env-scripts/extract-variables-aws.sh
+++ b/libs/messenger-bundle/provisioning/local/env-scripts/extract-variables-aws.sh
@@ -7,6 +7,7 @@ source ./functions.sh
 # output variables
 output_var 'TEST_CLOUD_PLATFORM' 'aws'
 output_var 'CONNECTION_EVENTS_QUEUE_DSN' "$(terraform_output 'aws_sqs_queue_url')"
+output_var 'CONNECTION_AUDIT_LOG_QUEUE_DSN' "$(terraform_output 'aws_sqs_queue_url')"
 echo ''
 
 output_var 'AWS_DEFAULT_REGION' "$(terraform_output 'aws_region')"

--- a/libs/messenger-bundle/provisioning/local/env-scripts/extract-variables-azure.sh
+++ b/libs/messenger-bundle/provisioning/local/env-scripts/extract-variables-azure.sh
@@ -7,6 +7,7 @@ source ./functions.sh
 # output variables
 output_var 'TEST_CLOUD_PLATFORM' 'azure'
 output_var 'CONNECTION_EVENTS_QUEUE_DSN' "$(print_url 'azure://%s:%s@%s?entity_path=%s' "$(terraform_output 'az_servicebus_sas_key_name')" "$(terraform_output 'az_servicebus_sas_key_value')" "$(terraform_output 'az_servicebus_namespace')" "$(terraform_output 'az_servicebus_queue_name')")"
+output_var 'CONNECTION_AUDIT_LOG_QUEUE_DSN' "$(print_url 'azure://%s:%s@%s?entity_path=%s' "$(terraform_output 'az_servicebus_sas_key_name')" "$(terraform_output 'az_servicebus_sas_key_value')" "$(terraform_output 'az_servicebus_namespace')" "$(terraform_output 'az_servicebus_queue_name')")"
 echo ''
 
 output_var 'AZURE_TENANT_ID' "$(terraform_output 'az_tenant_id')"

--- a/libs/messenger-bundle/provisioning/local/env-scripts/extract-variables-gcp.sh
+++ b/libs/messenger-bundle/provisioning/local/env-scripts/extract-variables-gcp.sh
@@ -7,6 +7,7 @@ source ./functions.sh
 # output variables
 output_var 'TEST_CLOUD_PLATFORM' 'gcp'
 output_var 'CONNECTION_EVENTS_QUEUE_DSN' "$(print_url 'gps://default/%s' "$(terraform_output 'gcp_topic_name')")"
+output_var 'CONNECTION_AUDIT_LOG_QUEUE_DSN' "$(print_url 'gps://default/%s' "$(terraform_output 'gcp_topic_name')")"
 echo ''
 
 output_file 'var/gcp/private-key.json' "$(terraform_output 'gcp_application_credentials' | base64 --decode)"

--- a/libs/messenger-bundle/provisioning/local/env-scripts/extract-variables-gcp.sh
+++ b/libs/messenger-bundle/provisioning/local/env-scripts/extract-variables-gcp.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+cd "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source ./functions.sh
+
+# output variables
+output_var 'TEST_CLOUD_PLATFORM' 'gcp'
+output_var 'CONNECTION_EVENTS_QUEUE_DSN' "$(print_url 'gps://default/%s' "$(terraform_output 'gcp_topic_name')")"
+echo ''
+
+output_file 'var/gcp/private-key.json' "$(terraform_output 'gcp_application_credentials' | base64 --decode)"
+output_var 'GOOGLE_APPLICATION_CREDENTIALS' 'var/gcp/private-key.json'
+echo ''

--- a/libs/messenger-bundle/provisioning/local/env-scripts/functions.sh
+++ b/libs/messenger-bundle/provisioning/local/env-scripts/functions.sh
@@ -9,7 +9,6 @@ terraform_output () {
 }
 
 output_var () {
-  >&2 echo "VAR: ${1:-}, VAL: ${2:-}"
   echo "${1}=\"${2}\""
 }
 

--- a/libs/messenger-bundle/provisioning/local/gcp.tf
+++ b/libs/messenger-bundle/provisioning/local/gcp.tf
@@ -1,0 +1,24 @@
+locals {
+  gcp_project = "kbc-dev-platform-services"
+  gcp_region = "europe-west1"
+}
+
+provider "google" {
+  project = local.gcp_project
+}
+
+resource "google_service_account" "messenger_bundle" {
+  account_id   = "${var.name_prefix}-${local.app_name}"
+  display_name = "${var.name_prefix} ${local.app_display_name}"
+}
+
+resource "google_service_account_key" "messenger_bundle" {
+  service_account_id = google_service_account.messenger_bundle.name
+  public_key_type    = "TYPE_X509_PEM_FILE"
+  private_key_type   = "TYPE_GOOGLE_CREDENTIALS_FILE"
+}
+
+output "gcp_application_credentials" {
+  value     = google_service_account_key.messenger_bundle.private_key
+  sensitive = true
+}

--- a/libs/messenger-bundle/provisioning/local/gcp_queue.tf
+++ b/libs/messenger-bundle/provisioning/local/gcp_queue.tf
@@ -1,0 +1,35 @@
+resource "google_pubsub_topic" "testing_queue" {
+  name = "${var.name_prefix}-${local.app_name}"
+}
+
+resource "google_pubsub_subscription" "testing_queue" {
+  name  = "${var.name_prefix}-${local.app_name}"
+  topic = google_pubsub_topic.testing_queue.name
+
+  ack_deadline_seconds       = 30
+  message_retention_duration = "3600s"
+  retain_acked_messages      = false
+  enable_message_ordering    = false
+}
+
+resource "google_pubsub_topic_iam_binding" "messenger_bundle_iam" {
+  topic = google_pubsub_topic.testing_queue.name
+  role  = "roles/pubsub.publisher"
+
+  members = [
+    google_service_account.messenger_bundle.member,
+  ]
+}
+
+resource "google_pubsub_subscription_iam_binding" "messenger_bundle_iam" {
+  subscription = google_pubsub_subscription.testing_queue.name
+  role         = "roles/pubsub.subscriber"
+
+  members = [
+    google_service_account.messenger_bundle.member,
+  ]
+}
+
+output "gcp_topic_name" {
+  value = google_pubsub_topic.testing_queue.name
+}

--- a/libs/messenger-bundle/provisioning/local/main.tf
+++ b/libs/messenger-bundle/provisioning/local/main.tf
@@ -14,6 +14,11 @@ terraform {
       source  = "hashicorp/azuread"
       version = "~> 2.41"
     }
+
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 4.74.0"
+    }
   }
 
   backend "s3" {

--- a/libs/messenger-bundle/provisioning/local/update-env.sh
+++ b/libs/messenger-bundle/provisioning/local/update-env.sh
@@ -6,7 +6,7 @@ INSERT_MODE=prepend
 VERBOSE=false
 
 help () {
-  echo "Syntax: update-env.sh [-v] [-a] [-e ${ENV_FILE}] <aws|azure>"
+  echo "Syntax: update-env.sh [-v] [-a] [-e ${ENV_FILE}] <aws|azure|gcp>"
   echo "Options:"
   echo "  -a|--append         Append mode (used only when creating new env file, by default values are prepended to the env file)"
   echo "  -e|--env-file file  Env file to write (default: ${ENV_FILE})"
@@ -54,8 +54,8 @@ done
 set -- "${POSITIONAL_ARGS[@]}"
 
 ENV_NAME=${1:-}
-if [[ $ENV_NAME != "aws" && $ENV_NAME != "azure" ]]; then
-    echo "Invalid environment name '${ENV_NAME}'. Possible values are: aws, azure"
+if [[ $ENV_NAME != "aws" && $ENV_NAME != "azure" && $ENV_NAME != "gcp" ]]; then
+    echo "Invalid environment name '${ENV_NAME}'. Possible values are: aws, azure, gpc"
     echo ""
     help
     exit 1

--- a/libs/messenger-bundle/src/ConnectionEvent/ApplicationEvent/ApplicationEvent.php
+++ b/libs/messenger-bundle/src/ConnectionEvent/ApplicationEvent/ApplicationEvent.php
@@ -1,0 +1,149 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Keboola\MessengerBundle\ConnectionEvent\ApplicationEvent;
+
+use InvalidArgumentException;
+use Keboola\MessengerBundle\ConnectionEvent\EventInterface;
+
+/**
+ * Application event as defined at https://github.com/keboola/connection/blob/24517a7486e7a0990bad19d80246947d8dd438ef/legacy-app/application/modules/core/events/Application.php
+ */
+class ApplicationEvent implements EventInterface
+{
+    public function __construct(
+        public readonly string $name,
+        public readonly int $idEvent,
+        public readonly string $type,
+
+        // identification
+        public readonly ?int $idAdmin = null,
+        public readonly ?int $idProject = null,
+        public readonly ?int $idAccessToken = null,
+        public readonly ?string $accessTokenName = null,
+
+        public readonly ?string $description = null,
+        public readonly ?string $message = null,
+        public readonly ?string $component = null,
+        public readonly ?string $runId = null,
+
+        // relations
+        public readonly ?int $idBucket = null,
+        public readonly ?string $tableName = null,
+        public readonly ?int $idAccount = null,
+        public readonly ?int $idExport = null,
+        public readonly ?string $configurationId = null,
+        public readonly ?int $idWorkspace = null,
+        public readonly ?array $fileIds = null,
+
+        // target object
+        public readonly ?string $objectType = null, // account, bucket, table ...
+        public readonly ?string $objectName = null, // name of object at log time
+        public readonly ?string $objectId = null, // reference to object - object id or uri
+
+        // context data
+        public readonly ?array $context = null,
+        public readonly ?array $params = null,
+        public readonly ?array $results = null,
+        public readonly ?array $performance = null,
+
+        public readonly ?int $idBranch = null,
+        public readonly ?bool $sendNotificationEmail = null,
+    ) {
+    }
+
+    public static function fromArray(array $data): ApplicationEvent
+    {
+        if (empty($data['name'])) {
+            throw new InvalidArgumentException('Event is missing property "name"');
+        }
+
+        if (empty($data['idEvent'])) {
+            throw new InvalidArgumentException('Event is missing property "idEvent"');
+        }
+
+        if (empty($data['type'])) {
+            throw new InvalidArgumentException('Event is missing property "type"');
+        }
+
+        return new self(
+            $data['name'],
+            $data['idEvent'],
+            $data['type'],
+            isset($data['idAdmin']) ? (int) $data['idAdmin'] : null,
+            isset($data['idProject']) ? (int) $data['idProject'] : null,
+            isset($data['idAccessToken']) ? (int) $data['idAccessToken'] : null,
+            isset($data['accessTokenName']) ? (string) $data['accessTokenName'] : null,
+            isset($data['description']) ? (string) $data['description'] : null,
+            isset($data['message']) ? (string) $data['message'] : null,
+            isset($data['component']) ? (string) $data['component'] : null,
+            isset($data['runId']) ? (string) $data['runId'] : null,
+            isset($data['idBucket']) ? (int) $data['idBucket'] : null,
+            isset($data['tableName']) ? (string) $data['tableName'] : null,
+            isset($data['idAccount']) ? (int) $data['idAccount'] : null,
+            isset($data['idExport']) ? (int) $data['idExport'] : null,
+            isset($data['configurationId']) ? (string) $data['configurationId'] : null,
+            isset($data['idWorkspace']) ? (int) $data['idWorkspace'] : null,
+            isset($data['fileIds']) ? (array) $data['fileIds'] : null,
+            isset($data['objectType']) ? (string) $data['objectType'] : null,
+            isset($data['objectName']) ? (string) $data['objectName'] : null,
+            isset($data['objectId']) ? (string) $data['objectId'] : null,
+            isset($data['context']) ? (array) $data['context'] : null,
+            isset($data['params']) ? (array) $data['params'] : null,
+            isset($data['results']) ? (array) $data['results'] : null,
+            isset($data['performance']) ? (array) $data['performance'] : null,
+            isset($data['idBranch']) ? (int) $data['idBranch'] : null,
+            isset($data['sendNotificationEmail']) ? (bool) $data['sendNotificationEmail'] : null,
+        );
+    }
+
+    public function toArray(): array
+    {
+        return [
+            'name' => $this->name,
+            'idEvent' => $this->idEvent,
+            'type' => $this->type,
+
+            'idAdmin' => $this->idAdmin,
+            'idProject' => $this->idProject,
+            'idAccessToken' => $this->idAccessToken,
+            'accessTokenName' => $this->accessTokenName,
+
+            'description' => $this->description,
+            'message' => $this->message,
+            'component' => $this->component,
+            'runId' => $this->runId,
+
+            'idBucket' => $this->idBucket,
+            'tableName' => $this->tableName,
+            'idAccount' => $this->idAccount,
+            'idExport' => $this->idExport,
+            'configurationId' => $this->configurationId,
+            'idWorkspace' => $this->idWorkspace,
+            'fileIds' => $this->fileIds,
+
+            'objectType' => $this->objectType,
+            'objectName' => $this->objectName,
+            'objectId' => $this->objectId,
+
+            'context' => $this->context,
+            'params' => $this->params,
+            'results' => $this->results,
+            'performance' => $this->performance,
+
+            'idBranch' => $this->idBranch,
+            'sendNotificationEmail' => $this->sendNotificationEmail,
+        ];
+    }
+
+    public function getId(): string
+    {
+        return (string) $this->idEvent;
+    }
+
+    public function getEventName(): string
+    {
+        return $this->name;
+    }
+}

--- a/libs/messenger-bundle/src/ConnectionEvent/ApplicationEvent/ApplicationEventFactory.php
+++ b/libs/messenger-bundle/src/ConnectionEvent/ApplicationEvent/ApplicationEventFactory.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Keboola\MessengerBundle\ConnectionEvent\ApplicationEvent;
+
+use Keboola\MessengerBundle\ConnectionEvent\EventFactoryInterface;
+use Keboola\MessengerBundle\ConnectionEvent\EventInterface;
+use Keboola\MessengerBundle\ConnectionEvent\Exception\EventFactoryException;
+use Throwable;
+
+class ApplicationEventFactory implements EventFactoryInterface
+{
+    public function createEventFromArray(array $data): EventInterface
+    {
+        $eventData = $data['data'] ?? null;
+        if (!is_array($eventData)) {
+            throw new EventFactoryException('Missing or invalid property "data"');
+        }
+
+        try {
+            return ApplicationEvent::fromArray($eventData);
+        } catch (Throwable $e) {
+            throw new EventFactoryException(
+                sprintf('Failed to create %s from event data: %s', ApplicationEventFactory::class, $e->getMessage()),
+                0,
+                $e,
+            );
+        }
+    }
+}

--- a/libs/messenger-bundle/src/ConnectionEvent/ApplicationEvent/ApplicationEventFactory.php
+++ b/libs/messenger-bundle/src/ConnectionEvent/ApplicationEvent/ApplicationEventFactory.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Keboola\MessengerBundle\ConnectionEvent\ApplicationEvent;
 
+use Keboola\MessengerBundle\ConnectionEvent\ApplicationEvent\Storage\DevBranchCreatedEvent;
+use Keboola\MessengerBundle\ConnectionEvent\ApplicationEvent\Storage\DevBranchDeletedEvent;
 use Keboola\MessengerBundle\ConnectionEvent\EventFactoryInterface;
 use Keboola\MessengerBundle\ConnectionEvent\EventInterface;
 use Keboola\MessengerBundle\ConnectionEvent\Exception\EventFactoryException;
@@ -11,6 +13,12 @@ use Throwable;
 
 class ApplicationEventFactory implements EventFactoryInterface
 {
+    /** @var array<string, class-string<EventInterface>> */
+    private const EVENTS = [
+        DevBranchCreatedEvent::NAME => DevBranchCreatedEvent::class,
+        DevBranchDeletedEvent::NAME => DevBranchDeletedEvent::class,
+    ];
+
     public function createEventFromArray(array $data): EventInterface
     {
         $eventData = $data['data'] ?? null;
@@ -18,11 +26,21 @@ class ApplicationEventFactory implements EventFactoryInterface
             throw new EventFactoryException('Missing or invalid property "data"');
         }
 
+        $eventName = $eventData['name'] ?? null;
+        if ($eventName === null) {
+            throw new EventFactoryException('Missing property "data.name"');
+        }
+
+        $eventClass = self::EVENTS[$eventName] ?? null;
+        if ($eventClass === null) {
+            $eventClass = GenericApplicationEvent::class;
+        }
+
         try {
-            return ApplicationEvent::fromArray($eventData);
+            return $eventClass::fromArray($eventData);
         } catch (Throwable $e) {
             throw new EventFactoryException(
-                sprintf('Failed to create %s from event data: %s', ApplicationEventFactory::class, $e->getMessage()),
+                sprintf('Failed to create %s from event data: %s', $eventClass, $e->getMessage()),
                 0,
                 $e,
             );

--- a/libs/messenger-bundle/src/ConnectionEvent/ApplicationEvent/GenericApplicationEvent.php
+++ b/libs/messenger-bundle/src/ConnectionEvent/ApplicationEvent/GenericApplicationEvent.php
@@ -10,11 +10,11 @@ use Keboola\MessengerBundle\ConnectionEvent\EventInterface;
 /**
  * Application event as defined at https://github.com/keboola/connection/blob/24517a7486e7a0990bad19d80246947d8dd438ef/legacy-app/application/modules/core/events/Application.php
  */
-class ApplicationEvent implements EventInterface
+class GenericApplicationEvent implements EventInterface
 {
     public function __construct(
         public readonly string $name,
-        public readonly int $idEvent,
+        public readonly int $id,
         public readonly string $type,
 
         // identification
@@ -40,7 +40,7 @@ class ApplicationEvent implements EventInterface
         // target object
         public readonly ?string $objectType = null, // account, bucket, table ...
         public readonly ?string $objectName = null, // name of object at log time
-        public readonly ?string $objectId = null, // reference to object - object id or uri
+        public readonly string|int|null $objectId = null, // reference to object - object id or uri
 
         // context data
         public readonly ?array $context = null,
@@ -53,7 +53,7 @@ class ApplicationEvent implements EventInterface
     ) {
     }
 
-    public static function fromArray(array $data): ApplicationEvent
+    public static function fromArray(array $data): GenericApplicationEvent
     {
         if (empty($data['name'])) {
             throw new InvalidArgumentException('Event is missing property "name"');
@@ -102,7 +102,7 @@ class ApplicationEvent implements EventInterface
     {
         return [
             'name' => $this->name,
-            'idEvent' => $this->idEvent,
+            'idEvent' => $this->id,
             'type' => $this->type,
 
             'idAdmin' => $this->idAdmin,
@@ -139,7 +139,7 @@ class ApplicationEvent implements EventInterface
 
     public function getId(): string
     {
-        return (string) $this->idEvent;
+        return (string) $this->id;
     }
 
     public function getEventName(): string

--- a/libs/messenger-bundle/src/ConnectionEvent/ApplicationEvent/Storage/DevBranchCreatedEvent.php
+++ b/libs/messenger-bundle/src/ConnectionEvent/ApplicationEvent/Storage/DevBranchCreatedEvent.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Keboola\MessengerBundle\ConnectionEvent\ApplicationEvent\Storage;
+
+use InvalidArgumentException;
+use Keboola\MessengerBundle\ConnectionEvent\EventInterface;
+
+class DevBranchCreatedEvent implements EventInterface
+{
+    public const NAME = 'storage.devBranchCreated';
+
+    public function __construct(
+        public readonly int $id,
+        public readonly int $projectId,
+
+        public readonly int $accessTokenId,
+        public readonly string $accessTokenName,
+
+        public readonly string|int $objectId,
+        public readonly string $objectType,
+        public readonly string $objectName,
+
+        public readonly string $message,
+        public readonly array $params,
+    ) {
+    }
+
+    public static function fromArray(array $data): self
+    {
+        if ($data['name'] !== self::NAME) {
+            throw new InvalidArgumentException(sprintf(
+                '%s expects event name "%s" but is "%s"',
+                static::class,
+                self::NAME,
+                $data['name'],
+            ));
+        }
+
+        return new self(
+            $data['idEvent'],
+            $data['idProject'],
+            $data['idAccessToken'],
+            $data['accessTokenName'],
+            $data['objectId'],
+            $data['objectType'],
+            $data['objectName'],
+            $data['message'],
+            $data['params'],
+        );
+    }
+
+    public function toArray(): array
+    {
+        return [
+            'name' => self::NAME,
+            'idEvent' => $this->id,
+            'idProject' => $this->projectId,
+            'idAccessToken' => $this->accessTokenId,
+            'accessTokenName' => $this->accessTokenName,
+            'objectId' => $this->objectId,
+            'objectType' => $this->objectType,
+            'objectName' => $this->objectName,
+            'message' => $this->message,
+            'params' => $this->params,
+        ];
+    }
+
+    public function getId(): string
+    {
+        return (string) $this->id;
+    }
+
+    public function getEventName(): string
+    {
+        return self::NAME;
+    }
+}

--- a/libs/messenger-bundle/src/ConnectionEvent/ApplicationEvent/Storage/DevBranchDeletedEvent.php
+++ b/libs/messenger-bundle/src/ConnectionEvent/ApplicationEvent/Storage/DevBranchDeletedEvent.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Keboola\MessengerBundle\ConnectionEvent\ApplicationEvent\Storage;
+
+use InvalidArgumentException;
+use Keboola\MessengerBundle\ConnectionEvent\EventInterface;
+use RuntimeException;
+
+class DevBranchDeletedEvent implements EventInterface
+{
+    public const NAME = 'storage.devBranchDeleted';
+
+    public function __construct(
+        public readonly int $id,
+        public readonly int $projectId,
+
+        public readonly int $accessTokenId,
+        public readonly string $accessTokenName,
+
+        public readonly string|int $objectId,
+        public readonly string $objectType,
+        public readonly string $objectName,
+
+        public readonly string $message,
+        public readonly array $params,
+    ) {
+    }
+
+    public static function fromArray(array $data): self
+    {
+        if ($data['name'] !== self::NAME) {
+            throw new InvalidArgumentException(sprintf(
+                '%s expects event name "%s" but is "%s"',
+                static::class,
+                self::NAME,
+                $data['name'],
+            ));
+        }
+
+        return new self(
+            $data['idEvent'],
+            $data['idProject'],
+            $data['idAccessToken'],
+            $data['accessTokenName'],
+            $data['objectId'],
+            $data['objectType'],
+            $data['objectName'],
+            $data['message'],
+            $data['params'],
+        );
+    }
+
+    public function toArray(): array
+    {
+        return [
+            'name' => self::NAME,
+            'idEvent' => $this->id,
+            'idProject' => $this->projectId,
+            'idAccessToken' => $this->accessTokenId,
+            'accessTokenName' => $this->accessTokenName,
+            'objectId' => $this->objectId,
+            'objectType' => $this->objectType,
+            'objectName' => $this->objectName,
+            'message' => $this->message,
+            'params' => $this->params,
+        ];
+    }
+
+    public function getId(): string
+    {
+        return (string) $this->id;
+    }
+
+    public function getEventName(): string
+    {
+        return self::NAME;
+    }
+}

--- a/libs/messenger-bundle/src/ConnectionEvent/AuditLog/AuditEventFactory.php
+++ b/libs/messenger-bundle/src/ConnectionEvent/AuditLog/AuditEventFactory.php
@@ -2,17 +2,20 @@
 
 declare(strict_types=1);
 
-namespace Keboola\MessengerBundle\ConnectionEvent;
+namespace Keboola\MessengerBundle\ConnectionEvent\AuditLog;
 
+use Keboola\MessengerBundle\ConnectionEvent\AuditLog\GenericAuditLogEvent;
 use Keboola\MessengerBundle\ConnectionEvent\AuditLog\Organization\ProjectCreatedEvent;
 use Keboola\MessengerBundle\ConnectionEvent\AuditLog\Project\ProjectDeletedEvent;
 use Keboola\MessengerBundle\ConnectionEvent\AuditLog\Project\ProjectFeatureAddedEvent;
 use Keboola\MessengerBundle\ConnectionEvent\AuditLog\Project\ProjectFeatureRemovedEvent;
 use Keboola\MessengerBundle\ConnectionEvent\AuditLog\Project\ProjectUndeletedEvent;
+use Keboola\MessengerBundle\ConnectionEvent\EventFactoryInterface;
+use Keboola\MessengerBundle\ConnectionEvent\EventInterface;
 use Keboola\MessengerBundle\ConnectionEvent\Exception\EventFactoryException;
 use Throwable;
 
-class EventFactory
+class AuditEventFactory implements EventFactoryInterface
 {
     /** @var array<string, class-string<EventInterface>> */
     private const EVENTS = [
@@ -37,7 +40,7 @@ class EventFactory
 
         $eventClass = self::EVENTS[$eventName] ?? null;
         if ($eventClass === null) {
-            $eventClass = GenericEvent::class;
+            $eventClass = GenericAuditLogEvent::class;
         }
 
         try {

--- a/libs/messenger-bundle/src/ConnectionEvent/AuditLog/BaseAuditLogEvent.php
+++ b/libs/messenger-bundle/src/ConnectionEvent/AuditLog/BaseAuditLogEvent.php
@@ -21,18 +21,15 @@ abstract class BaseAuditLogEvent implements EventInterface
     {
     }
 
-    public static function getEventName(): string
-    {
-        return static::NAME; // @phpstan-ignore-line
-    }
-
     public static function fromArray(array $data): static
     {
-        if ($data['operation'] !== static::getEventName()) {
+        $eventName = static::NAME; // @phpstan-ignore-line
+
+        if ($data['operation'] !== $eventName) {
             throw new RuntimeException(sprintf(
                 '%s expects event name "%s" but operation in data is "%s"',
                 static::class,
-                static::getEventName(),
+                $eventName,
                 $data['operation'],
             ));
         }
@@ -66,6 +63,11 @@ abstract class BaseAuditLogEvent implements EventInterface
     public function getId(): string
     {
         return $this->id;
+    }
+
+    public function getEventName(): string
+    {
+        return static::NAME; // @phpstan-ignore-line
     }
 
     public function getCreatedAt(): DateTimeImmutable

--- a/libs/messenger-bundle/src/ConnectionEvent/AuditLog/GenericAuditLogEvent.php
+++ b/libs/messenger-bundle/src/ConnectionEvent/AuditLog/GenericAuditLogEvent.php
@@ -2,16 +2,18 @@
 
 declare(strict_types=1);
 
-namespace Keboola\MessengerBundle\ConnectionEvent;
+namespace Keboola\MessengerBundle\ConnectionEvent\AuditLog;
 
-class GenericEvent implements EventInterface
+use Keboola\MessengerBundle\ConnectionEvent\EventInterface;
+
+class GenericAuditLogEvent implements EventInterface
 {
     public function __construct(
         private array $data,
     ) {
     }
 
-    public static function getEventName(): string
+    public function getEventName(): string
     {
         return 'genericEvent';
     }

--- a/libs/messenger-bundle/src/ConnectionEvent/EventFactoryInterface.php
+++ b/libs/messenger-bundle/src/ConnectionEvent/EventFactoryInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Keboola\MessengerBundle\ConnectionEvent;
+
+use Keboola\MessengerBundle\ConnectionEvent\Exception\EventFactoryException;
+
+interface EventFactoryInterface
+{
+    /**
+     * @throws EventFactoryException
+     */
+    public function createEventFromArray(array $data): EventInterface;
+}

--- a/libs/messenger-bundle/src/ConnectionEvent/EventInterface.php
+++ b/libs/messenger-bundle/src/ConnectionEvent/EventInterface.php
@@ -6,9 +6,9 @@ namespace Keboola\MessengerBundle\ConnectionEvent;
 
 interface EventInterface
 {
-    public static function getEventName(): string;
     public static function fromArray(array $data): self;
     public function toArray(): array;
 
     public function getId(): string;
+    public function getEventName(): string;
 }

--- a/libs/messenger-bundle/src/ConnectionEvent/Serializer/AwsSqsSerializer.php
+++ b/libs/messenger-bundle/src/ConnectionEvent/Serializer/AwsSqsSerializer.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Keboola\MessengerBundle\ConnectionEvent\Serializer;
 
 use JsonException;
-use Keboola\MessengerBundle\ConnectionEvent\EventFactory;
+use Keboola\MessengerBundle\ConnectionEvent\EventFactoryInterface;
 use Keboola\MessengerBundle\ConnectionEvent\Exception\EventFactoryException;
 use RuntimeException;
 use Symfony\Component\Messenger\Envelope;
@@ -14,11 +14,9 @@ use Symfony\Component\Messenger\Transport\Serialization\SerializerInterface;
 
 class AwsSqsSerializer implements SerializerInterface
 {
-    private EventFactory $eventFactory;
-
-    public function __construct(EventFactory $eventFactory)
-    {
-        $this->eventFactory = $eventFactory;
+    public function __construct(
+        private readonly EventFactoryInterface $eventFactory,
+    ) {
     }
 
     public function decode(array $encodedEnvelope): Envelope

--- a/libs/messenger-bundle/src/ConnectionEvent/Serializer/AzureServiceBusSerializer.php
+++ b/libs/messenger-bundle/src/ConnectionEvent/Serializer/AzureServiceBusSerializer.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Keboola\MessengerBundle\ConnectionEvent\Serializer;
 
 use JsonException;
-use Keboola\MessengerBundle\ConnectionEvent\EventFactory;
+use Keboola\MessengerBundle\ConnectionEvent\EventFactoryInterface;
 use Keboola\MessengerBundle\ConnectionEvent\Exception\EventFactoryException;
 use RuntimeException;
 use Symfony\Component\Messenger\Envelope;
@@ -14,11 +14,9 @@ use Symfony\Component\Messenger\Transport\Serialization\SerializerInterface;
 
 class AzureServiceBusSerializer implements SerializerInterface
 {
-    private EventFactory $eventFactory;
-
-    public function __construct(EventFactory $eventFactory)
-    {
-        $this->eventFactory = $eventFactory;
+    public function __construct(
+        private readonly EventFactoryInterface $eventFactory,
+    ) {
     }
 
     public function decode(array $encodedEnvelope): Envelope

--- a/libs/messenger-bundle/src/ConnectionEvent/Serializer/GooglePubSubSerializer.php
+++ b/libs/messenger-bundle/src/ConnectionEvent/Serializer/GooglePubSubSerializer.php
@@ -4,10 +4,8 @@ declare(strict_types=1);
 
 namespace Keboola\MessengerBundle\ConnectionEvent\Serializer;
 
-use JsonException;
-use Keboola\MessengerBundle\ConnectionEvent\EventFactory;
+use Keboola\MessengerBundle\ConnectionEvent\EventFactoryInterface;
 use Keboola\MessengerBundle\ConnectionEvent\Exception\EventFactoryException;
-use Keboola\MessengerBundle\ConnectionEvent\GenericEvent;
 use RuntimeException;
 use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\Exception\MessageDecodingFailedException;
@@ -15,11 +13,9 @@ use Symfony\Component\Messenger\Transport\Serialization\SerializerInterface;
 
 class GooglePubSubSerializer implements SerializerInterface
 {
-    private EventFactory $eventFactory;
-
-    public function __construct(EventFactory $eventFactory)
-    {
-        $this->eventFactory = $eventFactory;
+    public function __construct(
+        private readonly EventFactoryInterface $eventFactory,
+    ) {
     }
 
     public function decode(array $encodedEnvelope): Envelope

--- a/libs/messenger-bundle/src/ConnectionEvent/Serializer/GooglePubSubSerializer.php
+++ b/libs/messenger-bundle/src/ConnectionEvent/Serializer/GooglePubSubSerializer.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Keboola\MessengerBundle\ConnectionEvent\Serializer;
+
+use JsonException;
+use Keboola\MessengerBundle\ConnectionEvent\EventFactory;
+use Keboola\MessengerBundle\ConnectionEvent\Exception\EventFactoryException;
+use Keboola\MessengerBundle\ConnectionEvent\GenericEvent;
+use RuntimeException;
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Exception\MessageDecodingFailedException;
+use Symfony\Component\Messenger\Transport\Serialization\SerializerInterface;
+
+class GooglePubSubSerializer implements SerializerInterface
+{
+    private EventFactory $eventFactory;
+
+    public function __construct(EventFactory $eventFactory)
+    {
+        $this->eventFactory = $eventFactory;
+    }
+
+    public function decode(array $encodedEnvelope): Envelope
+    {
+        try {
+            $event = $this->eventFactory->createEventFromArray($encodedEnvelope);
+        } catch (EventFactoryException $e) {
+            throw new MessageDecodingFailedException(
+                sprintf('Failed to create an event object from the message: %s', $e->getMessage()),
+                0,
+                $e,
+            );
+        }
+
+        return new Envelope($event, []);
+    }
+
+    public function encode(Envelope $envelope): array
+    {
+        throw new RuntimeException(sprintf('%s does not support encoding messages', static::class));
+    }
+}

--- a/libs/messenger-bundle/src/DependencyInjection/KeboolaMessengerExtension.php
+++ b/libs/messenger-bundle/src/DependencyInjection/KeboolaMessengerExtension.php
@@ -16,6 +16,7 @@ class KeboolaMessengerExtension extends AbstractExtension
 {
     private const PLATFORM_AWS = 'aws';
     private const PLATFORM_AZURE = 'azure';
+    private const PLATFORM_GCP = 'gcp';
 
     public function configure(DefinitionConfigurator $definition): void
     {
@@ -67,6 +68,13 @@ class KeboolaMessengerExtension extends AbstractExtension
                             'token_expiry' => 3600,
                             'receive_mode' => 'peek-lock',
                         ],
+                    ];
+                    break;
+
+                case self::PLATFORM_GCP:
+                    $transportConfig = [
+                        'dsn' => $connectionEventsQueueDsn,
+                        'serializer' => 'keboola.messenger_bundle.serializer.gcp',
                     ];
                     break;
 

--- a/libs/messenger-bundle/src/DependencyInjection/KeboolaMessengerExtension.php
+++ b/libs/messenger-bundle/src/DependencyInjection/KeboolaMessengerExtension.php
@@ -4,31 +4,32 @@ declare(strict_types=1);
 
 namespace Keboola\MessengerBundle\DependencyInjection;
 
-use InvalidArgumentException;
+use Keboola\MessengerBundle\Platform;
 use Symfony\Component\Config\Definition\Configurator\DefinitionConfigurator;
 use Symfony\Component\Config\FileLocator;
+use Symfony\Component\DependencyInjection\ChildDefinition;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Extension\AbstractExtension;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 use Symfony\Component\DependencyInjection\Loader\PhpFileLoader;
+use Symfony\Component\DependencyInjection\Reference;
 
 class KeboolaMessengerExtension extends AbstractExtension
 {
-    private const PLATFORM_AWS = 'aws';
-    private const PLATFORM_AZURE = 'azure';
-    private const PLATFORM_GCP = 'gcp';
-
     public function configure(DefinitionConfigurator $definition): void
     {
         $definition->rootNode() // @phpstan-ignore-line - root node is always ArrayNode
             ->children()
-                ->scalarNode('platform')
+                ->enumNode('platform')
                     ->isRequired()
-                    ->cannotBeEmpty()
+                    ->values(array_map(fn(Platform $v) => $v->value, Platform::cases()))
                 ->end()
 
                 ->scalarNode('connection_events_queue_dsn')
-                    ->isRequired()
+                    ->cannotBeEmpty()
+                ->end()
+
+                ->scalarNode('connection_audit_log_queue_dsn')
                     ->cannotBeEmpty()
                 ->end()
             ->end()
@@ -41,60 +42,79 @@ class KeboolaMessengerExtension extends AbstractExtension
         assert($configuration !== null);
 
         $configs = $builder->getExtensionConfig($this->getAlias());
+        $configs = $builder->resolveEnvPlaceholders($configs, true);
+        assert(is_array($configs));
         $config = $this->processConfiguration($configuration, $configs);
 
-        $platform = $builder->resolveEnvPlaceholders($config['platform'] ?? '', true);
-        assert(is_string($platform));
+        $this->createTransportConfig(
+            $builder,
+            $config,
+            'connection_events',
+            'connection_events_queue_dsn',
+            'keboola.messenger_bundle.event_factory.application_events',
+        );
 
-        $connectionEventsQueueDsn = $config['connection_events_queue_dsn'] ?? '';
-
-        if ($connectionEventsQueueDsn !== '') {
-            switch ($platform) {
-                case self::PLATFORM_AWS:
-                    $transportConfig = [
-                        'dsn' => $connectionEventsQueueDsn,
-                        'serializer' => 'keboola.messenger_bundle.serializer.aws',
-                        'options' => [
-                            'auto_setup' => false,
-                        ],
-                    ];
-                    break;
-
-                case self::PLATFORM_AZURE:
-                    $transportConfig = [
-                        'dsn' => $connectionEventsQueueDsn,
-                        'serializer' => 'keboola.messenger_bundle.serializer.azure',
-                        'options' => [
-                            'token_expiry' => 3600,
-                            'receive_mode' => 'peek-lock',
-                        ],
-                    ];
-                    break;
-
-                case self::PLATFORM_GCP:
-                    $transportConfig = [
-                        'dsn' => $connectionEventsQueueDsn,
-                        'serializer' => 'keboola.messenger_bundle.serializer.gcp',
-                    ];
-                    break;
-
-                default:
-                    throw new InvalidArgumentException(sprintf('Unknown platform "%s".', $platform));
-            };
-
-            $builder->prependExtensionConfig('framework', [
-                'messenger' => [
-                    'transports' => [
-                        'connection_events' => $transportConfig,
-                    ],
-                ],
-            ]);
-        }
+        $this->createTransportConfig(
+            $builder,
+            $config,
+            'connection_audit_log',
+            'connection_audit_log_queue_dsn',
+            'keboola.messenger_bundle.event_factory.audit_log',
+        );
     }
 
     public function loadExtension(array $config, ContainerConfigurator $container, ContainerBuilder $builder): void
     {
         $loader = new PhpFileLoader($builder, new FileLocator(__DIR__ . '/../Resources/config'));
         $loader->load('messenger.php');
+    }
+
+    private function createTransportConfig(
+        ContainerBuilder $builder,
+        array $config,
+        string $transportName,
+        string $dsnProperty,
+        string $eventFactoryService,
+    ): void {
+        $transportDsn = $config[$dsnProperty] ?? '';
+        if ($transportDsn === '') {
+            return;
+        }
+
+        $platform = Platform::from($config['platform']);
+        $serializerServiceName = sprintf('keboola.messenger_bundle.transport_serializer.%s', $transportName);
+        $serializerServiceDefinition =
+            (new ChildDefinition(sprintf('keboola.messenger_bundle.platform_serializer.%s', $platform->value)))
+            ->setArgument('$eventFactory', new Reference($eventFactoryService))
+        ;
+
+        $builder->setDefinition($serializerServiceName, $serializerServiceDefinition);
+        $builder->prependExtensionConfig('framework', [
+            'messenger' => [
+                'transports' => [
+                    $transportName => [
+                        'dsn' => $transportDsn,
+                        'serializer' => $serializerServiceName,
+                        'options' => $this->getTransportDefaultOptions($platform),
+                    ],
+                ],
+            ],
+        ]);
+    }
+
+    private function getTransportDefaultOptions(Platform $platform): array
+    {
+        return match ($platform) {
+            Platform::AWS => [
+                'auto_setup' => false,
+            ],
+
+            Platform::AZURE => [
+                'token_expiry' => 3600,
+                'receive_mode' => 'peek-lock',
+            ],
+
+            Platform::GCP => [],
+        };
     }
 }

--- a/libs/messenger-bundle/src/Platform.php
+++ b/libs/messenger-bundle/src/Platform.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Keboola\MessengerBundle;
+
+enum Platform: string
+{
+    case GCP = 'gcp';
+    case AWS = 'aws';
+    case AZURE = 'azure';
+}

--- a/libs/messenger-bundle/src/Resources/config/messenger.php
+++ b/libs/messenger-bundle/src/Resources/config/messenger.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 use Keboola\MessengerBundle\ConnectionEvent\EventFactory;
 use Keboola\MessengerBundle\ConnectionEvent\Serializer\AwsSqsSerializer;
 use Keboola\MessengerBundle\ConnectionEvent\Serializer\AzureServiceBusSerializer;
-use Keboola\MessengerBundle\Transport\Azure\DsnParser;
+use Keboola\MessengerBundle\ConnectionEvent\Serializer\GooglePubSubSerializer;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 use function Symfony\Component\DependencyInjection\Loader\Configurator\service;
 
@@ -21,6 +21,9 @@ return static function (ContainerConfigurator $container): void {
         ->arg('$eventFactory', service('keboola.messenger_bundle.connection_event_factory'))
 
         ->set('keboola.messenger_bundle.serializer.azure', AzureServiceBusSerializer::class)
+        ->arg('$eventFactory', service('keboola.messenger_bundle.connection_event_factory'))
+
+        ->set('keboola.messenger_bundle.serializer.gcp', GooglePubSubSerializer::class)
         ->arg('$eventFactory', service('keboola.messenger_bundle.connection_event_factory'))
     ;
 };

--- a/libs/messenger-bundle/src/Resources/config/messenger.php
+++ b/libs/messenger-bundle/src/Resources/config/messenger.php
@@ -2,28 +2,29 @@
 
 declare(strict_types=1);
 
-use Keboola\MessengerBundle\ConnectionEvent\EventFactory;
+use Keboola\MessengerBundle\ConnectionEvent\ApplicationEvent\ApplicationEventFactory;
+use Keboola\MessengerBundle\ConnectionEvent\AuditLog\AuditEventFactory;
 use Keboola\MessengerBundle\ConnectionEvent\Serializer\AwsSqsSerializer;
 use Keboola\MessengerBundle\ConnectionEvent\Serializer\AzureServiceBusSerializer;
 use Keboola\MessengerBundle\ConnectionEvent\Serializer\GooglePubSubSerializer;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
-use function Symfony\Component\DependencyInjection\Loader\Configurator\service;
+use function Symfony\Component\DependencyInjection\Loader\Configurator\abstract_arg;
 
 return static function (ContainerConfigurator $container): void {
-    $container->parameters()
-        ->set('env(CONNECTION_EVENTS_QUEUE_DSN)', '')
-    ;
-
     $container->services()
-        ->set('keboola.messenger_bundle.connection_event_factory', EventFactory::class)
+        ->set('keboola.messenger_bundle.event_factory.audit_log', AuditEventFactory::class)
+        ->set('keboola.messenger_bundle.event_factory.application_events', ApplicationEventFactory::class)
 
-        ->set('keboola.messenger_bundle.serializer.aws', AwsSqsSerializer::class)
-        ->arg('$eventFactory', service('keboola.messenger_bundle.connection_event_factory'))
+        ->set('keboola.messenger_bundle.platform_serializer.aws', AwsSqsSerializer::class)
+            ->abstract()
+            ->arg('$eventFactory', abstract_arg('configured in bundle extension'))
 
-        ->set('keboola.messenger_bundle.serializer.azure', AzureServiceBusSerializer::class)
-        ->arg('$eventFactory', service('keboola.messenger_bundle.connection_event_factory'))
+        ->set('keboola.messenger_bundle.platform_serializer.azure', AzureServiceBusSerializer::class)
+            ->abstract()
+            ->arg('$eventFactory', abstract_arg('configured in bundle extension'))
 
-        ->set('keboola.messenger_bundle.serializer.gcp', GooglePubSubSerializer::class)
-        ->arg('$eventFactory', service('keboola.messenger_bundle.connection_event_factory'))
+        ->set('keboola.messenger_bundle.platform_serializer.gcp', GooglePubSubSerializer::class)
+            ->abstract()
+            ->arg('$eventFactory', abstract_arg('configured in bundle extension'))
     ;
 };

--- a/libs/messenger-bundle/tests/ConnectionEvent/AbstractQueueConsumptionTest.php
+++ b/libs/messenger-bundle/tests/ConnectionEvent/AbstractQueueConsumptionTest.php
@@ -42,7 +42,10 @@ abstract class AbstractQueueConsumptionTest extends KernelTestCase
     {
         parent::setUp();
 
-        $this->messengerTransport = self::getContainer()->get('messenger.transport.connection_audit_log');
+        $messengerTransport = self::getContainer()->get('messenger.transport.connection_audit_log');
+        self::assertInstanceOf(TransportInterface::class, $messengerTransport);
+
+        $this->messengerTransport = $messengerTransport;
     }
 
     abstract protected function publishMessage(array $message): void;

--- a/libs/messenger-bundle/tests/ConnectionEvent/AbstractQueueConsumptionTest.php
+++ b/libs/messenger-bundle/tests/ConnectionEvent/AbstractQueueConsumptionTest.php
@@ -42,7 +42,7 @@ abstract class AbstractQueueConsumptionTest extends KernelTestCase
     {
         parent::setUp();
 
-        $this->messengerTransport = self::getContainer()->get('messenger.transport.connection_events');
+        $this->messengerTransport = self::getContainer()->get('messenger.transport.connection_audit_log');
     }
 
     abstract protected function publishMessage(array $message): void;

--- a/libs/messenger-bundle/tests/ConnectionEvent/ApplicationEvent/ApplicationEventFactoryTest.php
+++ b/libs/messenger-bundle/tests/ConnectionEvent/ApplicationEvent/ApplicationEventFactoryTest.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Keboola\MessengerBundle\Tests\ConnectionEvent\ApplicationEvent;
+
+use Keboola\MessengerBundle\ConnectionEvent\ApplicationEvent\ApplicationEvent;
+use Keboola\MessengerBundle\ConnectionEvent\ApplicationEvent\ApplicationEventFactory;
+use Keboola\MessengerBundle\ConnectionEvent\Exception\EventFactoryException;
+use PHPUnit\Framework\TestCase;
+
+class ApplicationEventFactoryTest extends TestCase
+{
+    public function testCreateEvent(): void
+    {
+        $factory = new ApplicationEventFactory();
+        $event = $factory->createEventFromArray([
+            'class' => 'Event_Application',
+            'created' => '2023-10-17T10:29:33+02:00',
+            'data' => [
+                'name' => 'ext.keboola.keboola-buffer.',
+                'objectId' => '',
+                'idProject' => 18,
+                'params' => [
+                    'task' => 'file-import',
+                ],
+                'idEvent' => 20219944,
+                'type' => 'info',
+                'context' => [
+                    'remoteAddr' => '10.11.2.62',
+                    'httpReferer' => null,
+                    'httpUserAgent' => 'keboola-buffer-worker',
+                    'apiVersion' => 'v2',
+                ],
+            ],
+        ]);
+
+        self::assertInstanceOf(ApplicationEvent::class, $event);
+        self::assertSame('ext.keboola.keboola-buffer.', $event->name);
+        self::assertSame('', $event->objectId);
+        self::assertSame(18, $event->idProject);
+        self::assertSame(['task' => 'file-import'], $event->params);
+        self::assertSame(20219944, $event->idEvent);
+        self::assertSame('info', $event->type);
+        self::assertSame([
+            'remoteAddr' => '10.11.2.62',
+            'httpReferer' => null,
+            'httpUserAgent' => 'keboola-buffer-worker',
+            'apiVersion' => 'v2',
+        ], $event->context);
+    }
+
+    public function testMissingDataProperty(): void
+    {
+        $factory = new ApplicationEventFactory();
+
+        $this->expectException(EventFactoryException::class);
+        $this->expectExceptionMessage('Missing or invalid property "data"');
+
+        $factory->createEventFromArray([]);
+    }
+
+    public function testErrorHandlingDuringEventCreation(): void
+    {
+        $factory = new ApplicationEventFactory();
+
+        $this->expectException(EventFactoryException::class);
+        $this->expectExceptionMessage(
+            'Failed to create Keboola\MessengerBundle\ConnectionEvent\ApplicationEvent\ApplicationEventFactory ' .
+            'from event data: Event is missing property "name"',
+        );
+
+        $factory->createEventFromArray([
+            'data' => [],
+        ]);
+    }
+}

--- a/libs/messenger-bundle/tests/ConnectionEvent/ApplicationEvent/ApplicationEventFactoryTest.php
+++ b/libs/messenger-bundle/tests/ConnectionEvent/ApplicationEvent/ApplicationEventFactoryTest.php
@@ -4,21 +4,93 @@ declare(strict_types=1);
 
 namespace Keboola\MessengerBundle\Tests\ConnectionEvent\ApplicationEvent;
 
-use Keboola\MessengerBundle\ConnectionEvent\ApplicationEvent\ApplicationEvent;
 use Keboola\MessengerBundle\ConnectionEvent\ApplicationEvent\ApplicationEventFactory;
+use Keboola\MessengerBundle\ConnectionEvent\ApplicationEvent\GenericApplicationEvent;
+use Keboola\MessengerBundle\ConnectionEvent\ApplicationEvent\Storage\DevBranchCreatedEvent;
 use Keboola\MessengerBundle\ConnectionEvent\Exception\EventFactoryException;
 use PHPUnit\Framework\TestCase;
 
 class ApplicationEventFactoryTest extends TestCase
 {
-    public function testCreateEvent(): void
+    public static function provideInvalidData(): iterable
+    {
+        yield 'no "data"' => [
+            'data' => [],
+            'error' => 'Missing or invalid property "data"',
+        ];
+
+        yield 'no "data.name"' => [
+            'data' => [
+                'data' => [],
+            ],
+            'error' => 'Missing property "data.name"',
+        ];
+    }
+
+    /** @dataProvider provideInvalidData */
+    public function testInvalidData(array $data, string $expectedError): void
     {
         $factory = new ApplicationEventFactory();
+
+        $this->expectException(EventFactoryException::class);
+        $this->expectExceptionMessage($expectedError);
+
+        $factory->createEventFromArray($data);
+    }
+
+    public function testErrorInDataMapping(): void
+    {
+        $factory = new ApplicationEventFactory();
+
+        $this->expectException(EventFactoryException::class);
+        $this->expectExceptionMessage(
+            'Failed to create Keboola\MessengerBundle\ConnectionEvent\ApplicationEvent\GenericApplicationEvent ' .
+            'from event data: Event is missing property "idEvent"',
+        );
+
+        $factory->createEventFromArray([
+            'data' => [
+                'name' => 'some.event',
+            ],
+        ]);
+    }
+
+    public function testCreateRegularEvent(): void
+    {
+        $factory = new ApplicationEventFactory();
+
+        $event = $factory->createEventFromArray([
+            'class' => 'Event_Application',
+            'created' => '2023-10-18T16:08:48+02:00',
+            'data' => [
+                'name' => 'storage.devBranchCreated',
+                'idEvent' => 20224549,
+                'idProject' => 34,
+                'idAccessToken' => 107,
+                'accessTokenName' => 'josef.martinec@keboolaconnection.onmicrosoft.com',
+                'objectId' => 46,
+                'objectType' => 'devBranch',
+                'objectName' => '123',
+                'params' => [
+                    'devBranchName' => '123',
+                ],
+                'message' => 'Development branch "123" created',
+            ],
+        ]);
+
+        self::assertInstanceOf(DevBranchCreatedEvent::class, $event);
+        self::assertSame(20224549, $event->id);
+    }
+
+    public function testCreateGenericEvent(): void
+    {
+        $factory = new ApplicationEventFactory();
+
         $event = $factory->createEventFromArray([
             'class' => 'Event_Application',
             'created' => '2023-10-17T10:29:33+02:00',
             'data' => [
-                'name' => 'ext.keboola.keboola-buffer.',
+                'name' => 'unknown.event',
                 'objectId' => '',
                 'idProject' => 18,
                 'params' => [
@@ -26,52 +98,15 @@ class ApplicationEventFactoryTest extends TestCase
                 ],
                 'idEvent' => 20219944,
                 'type' => 'info',
-                'context' => [
-                    'remoteAddr' => '10.11.2.62',
-                    'httpReferer' => null,
-                    'httpUserAgent' => 'keboola-buffer-worker',
-                    'apiVersion' => 'v2',
-                ],
             ],
         ]);
 
-        self::assertInstanceOf(ApplicationEvent::class, $event);
-        self::assertSame('ext.keboola.keboola-buffer.', $event->name);
+        self::assertInstanceOf(GenericApplicationEvent::class, $event);
+        self::assertSame('unknown.event', $event->name);
         self::assertSame('', $event->objectId);
         self::assertSame(18, $event->idProject);
         self::assertSame(['task' => 'file-import'], $event->params);
-        self::assertSame(20219944, $event->idEvent);
+        self::assertSame(20219944, $event->id);
         self::assertSame('info', $event->type);
-        self::assertSame([
-            'remoteAddr' => '10.11.2.62',
-            'httpReferer' => null,
-            'httpUserAgent' => 'keboola-buffer-worker',
-            'apiVersion' => 'v2',
-        ], $event->context);
-    }
-
-    public function testMissingDataProperty(): void
-    {
-        $factory = new ApplicationEventFactory();
-
-        $this->expectException(EventFactoryException::class);
-        $this->expectExceptionMessage('Missing or invalid property "data"');
-
-        $factory->createEventFromArray([]);
-    }
-
-    public function testErrorHandlingDuringEventCreation(): void
-    {
-        $factory = new ApplicationEventFactory();
-
-        $this->expectException(EventFactoryException::class);
-        $this->expectExceptionMessage(
-            'Failed to create Keboola\MessengerBundle\ConnectionEvent\ApplicationEvent\ApplicationEventFactory ' .
-            'from event data: Event is missing property "name"',
-        );
-
-        $factory->createEventFromArray([
-            'data' => [],
-        ]);
     }
 }

--- a/libs/messenger-bundle/tests/ConnectionEvent/ApplicationEvent/ApplicationEventTest.php
+++ b/libs/messenger-bundle/tests/ConnectionEvent/ApplicationEvent/ApplicationEventTest.php
@@ -5,21 +5,21 @@ declare(strict_types=1);
 namespace Keboola\MessengerBundle\Tests\ConnectionEvent\ApplicationEvent;
 
 use InvalidArgumentException;
-use Keboola\MessengerBundle\ConnectionEvent\ApplicationEvent\ApplicationEvent;
+use Keboola\MessengerBundle\ConnectionEvent\ApplicationEvent\GenericApplicationEvent;
 use PHPUnit\Framework\TestCase;
 
 class ApplicationEventTest extends TestCase
 {
     public function testFromArrayWithMinimalData(): void
     {
-        $event = ApplicationEvent::fromArray([
+        $event = GenericApplicationEvent::fromArray([
             'name' => 'ext.keboola.keboola-buffer.',
             'idEvent' => 20219944,
             'type' => 'info',
         ]);
 
         self::assertSame('ext.keboola.keboola-buffer.', $event->name);
-        self::assertSame(20219944, $event->idEvent);
+        self::assertSame(20219944, $event->id);
         self::assertSame('info', $event->type);
         self::assertNull($event->idAdmin);
         self::assertNull($event->idProject);
@@ -49,7 +49,7 @@ class ApplicationEventTest extends TestCase
 
     public function testFromArrayWithAllData(): void
     {
-        $event = ApplicationEvent::fromArray([
+        $event = GenericApplicationEvent::fromArray([
             'name' => 'ext.keboola.keboola-buffer.',
             'objectId' => 'object-id',
             'idProject' => 18,
@@ -110,7 +110,7 @@ class ApplicationEventTest extends TestCase
         self::assertSame('object-name', $event->objectName);
         self::assertSame(['task' => 'file-import'], $event->params);
         self::assertSame(['foo' => 'bar'], $event->performance);
-        self::assertSame(20219944, $event->idEvent);
+        self::assertSame(20219944, $event->id);
         self::assertSame('info', $event->type);
         self::assertSame('event description', $event->description);
         self::assertSame([
@@ -169,14 +169,14 @@ class ApplicationEventTest extends TestCase
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage($expectedError);
 
-        ApplicationEvent::fromArray($data);
+        GenericApplicationEvent::fromArray($data);
     }
 
     public function testToArrayWithMinimalData(): void
     {
-        $event = new ApplicationEvent(
+        $event = new GenericApplicationEvent(
             name: 'ext.keboola.keboola-buffer.',
-            idEvent: 20219944,
+            id: 20219944,
             type: 'info',
         );
 
@@ -213,9 +213,9 @@ class ApplicationEventTest extends TestCase
 
     public function testToArrayWithAllData(): void
     {
-        $event = new ApplicationEvent(
+        $event = new GenericApplicationEvent(
             name: 'ext.keboola.keboola-buffer.',
-            idEvent: 20219944,
+            id: 20219944,
             type: 'info',
             idAdmin: 19,
             idProject: 18,
@@ -308,7 +308,7 @@ class ApplicationEventTest extends TestCase
 
     public function testGetters(): void
     {
-        $event = ApplicationEvent::fromArray([
+        $event = GenericApplicationEvent::fromArray([
             'name' => 'ext.keboola.keboola-buffer.',
             'idEvent' => 20219944,
             'type' => 'info',

--- a/libs/messenger-bundle/tests/ConnectionEvent/ApplicationEvent/ApplicationEventTest.php
+++ b/libs/messenger-bundle/tests/ConnectionEvent/ApplicationEvent/ApplicationEventTest.php
@@ -1,0 +1,320 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Keboola\MessengerBundle\Tests\ConnectionEvent\ApplicationEvent;
+
+use InvalidArgumentException;
+use Keboola\MessengerBundle\ConnectionEvent\ApplicationEvent\ApplicationEvent;
+use PHPUnit\Framework\TestCase;
+
+class ApplicationEventTest extends TestCase
+{
+    public function testFromArrayWithMinimalData(): void
+    {
+        $event = ApplicationEvent::fromArray([
+            'name' => 'ext.keboola.keboola-buffer.',
+            'idEvent' => 20219944,
+            'type' => 'info',
+        ]);
+
+        self::assertSame('ext.keboola.keboola-buffer.', $event->name);
+        self::assertSame(20219944, $event->idEvent);
+        self::assertSame('info', $event->type);
+        self::assertNull($event->idAdmin);
+        self::assertNull($event->idProject);
+        self::assertNull($event->idAccessToken);
+        self::assertNull($event->accessTokenName);
+        self::assertNull($event->description);
+        self::assertNull($event->message);
+        self::assertNull($event->component);
+        self::assertNull($event->runId);
+        self::assertNull($event->idBucket);
+        self::assertNull($event->tableName);
+        self::assertNull($event->idAccount);
+        self::assertNull($event->idExport);
+        self::assertNull($event->configurationId);
+        self::assertNull($event->idWorkspace);
+        self::assertNull($event->fileIds);
+        self::assertNull($event->objectType);
+        self::assertNull($event->objectName);
+        self::assertNull($event->objectId);
+        self::assertNull($event->context);
+        self::assertNull($event->params);
+        self::assertNull($event->results);
+        self::assertNull($event->performance);
+        self::assertNull($event->idBranch);
+        self::assertNull($event->sendNotificationEmail);
+    }
+
+    public function testFromArrayWithAllData(): void
+    {
+        $event = ApplicationEvent::fromArray([
+            'name' => 'ext.keboola.keboola-buffer.',
+            'objectId' => 'object-id',
+            'idProject' => 18,
+            'idAdmin' => 19,
+            'idAccount' => 20,
+            'idExport' => 21,
+            'idAccessToken' => 130,
+            'accessTokenName' => '[_internal] Buffer Export acceptance-test',
+            'idBucket' => 22,
+            'idWorkspace' => 23,
+            'tableName' => 'table',
+            'objectType' => 'object-type',
+            'objectName' => 'object-name',
+            'params' => [
+                'task' => 'file-import',
+            ],
+            'performance' => [
+                'foo' => 'bar',
+            ],
+            'idEvent' => 20219944,
+            'type' => 'info',
+            'description' => 'event description',
+            'context' => [
+                'remoteAddr' => '10.11.2.62',
+                'httpReferer' => null,
+                'httpUserAgent' => 'keboola-buffer-worker',
+                'apiVersion' => 'v2',
+            ],
+            'results' => [
+                'exportId' => 'acceptance-test-export',
+                'projectId' => 18,
+                'statistics' =>  [
+                    'bodySize' => 0,
+                    'fileGZipSize' => 0,
+                ],
+            ],
+            'component' => 'keboola.keboola-buffer',
+            'message' => 'File import done.',
+            'runId' => '55',
+            'configurationId' => '66',
+            'fileIds' => [11, '12'],
+            'idBranch' => 7,
+            'sendNotificationEmail' => true,
+        ]);
+
+        self::assertSame('ext.keboola.keboola-buffer.', $event->name);
+        self::assertSame('object-id', $event->objectId);
+        self::assertSame(18, $event->idProject);
+        self::assertSame(19, $event->idAdmin);
+        self::assertSame(20, $event->idAccount);
+        self::assertSame(21, $event->idExport);
+        self::assertSame(130, $event->idAccessToken);
+        self::assertSame('[_internal] Buffer Export acceptance-test', $event->accessTokenName);
+        self::assertSame(22, $event->idBucket);
+        self::assertSame(23, $event->idWorkspace);
+        self::assertSame('table', $event->tableName);
+        self::assertSame('object-type', $event->objectType);
+        self::assertSame('object-name', $event->objectName);
+        self::assertSame(['task' => 'file-import'], $event->params);
+        self::assertSame(['foo' => 'bar'], $event->performance);
+        self::assertSame(20219944, $event->idEvent);
+        self::assertSame('info', $event->type);
+        self::assertSame('event description', $event->description);
+        self::assertSame([
+            'remoteAddr' => '10.11.2.62',
+            'httpReferer' => null,
+            'httpUserAgent' => 'keboola-buffer-worker',
+            'apiVersion' => 'v2',
+        ], $event->context);
+        self::assertSame([
+            'exportId' => 'acceptance-test-export',
+            'projectId' => 18,
+            'statistics' =>  [
+                'bodySize' => 0,
+                'fileGZipSize' => 0,
+            ],
+        ], $event->results);
+        self::assertSame('keboola.keboola-buffer', $event->component);
+        self::assertSame('File import done.', $event->message);
+        self::assertSame('55', $event->runId);
+        self::assertSame('66', $event->configurationId);
+        self::assertSame([11, '12'], $event->fileIds);
+        self::assertSame(7, $event->idBranch);
+        self::assertTrue($event->sendNotificationEmail);
+    }
+
+    public static function provideInvalidData(): iterable
+    {
+        yield 'missing name' => [
+            'data' => [
+                'idEvent' => 20219944,
+                'type' => 'info',
+            ],
+            'error' => 'Event is missing property "name"',
+        ];
+
+        yield 'missing idEvent' => [
+            'data' => [
+                'name' => 'ext.keboola.keboola-buffer.',
+                'type' => 'info',
+            ],
+            'error' => 'Event is missing property "idEvent"',
+        ];
+
+        yield 'missing type' => [
+            'data' => [
+                'name' => 'ext.keboola.keboola-buffer.',
+                'idEvent' => 20219944,
+            ],
+            'error' => 'Event is missing property "type"',
+        ];
+    }
+
+    /** @dataProvider provideInvalidData */
+    public function testFromArrayWithMissingRequiredProperty(array $data, string $expectedError): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage($expectedError);
+
+        ApplicationEvent::fromArray($data);
+    }
+
+    public function testToArrayWithMinimalData(): void
+    {
+        $event = new ApplicationEvent(
+            name: 'ext.keboola.keboola-buffer.',
+            idEvent: 20219944,
+            type: 'info',
+        );
+
+        self::assertSame([
+            'name' => 'ext.keboola.keboola-buffer.',
+            'idEvent' => 20219944,
+            'type' => 'info',
+            'idAdmin' => null,
+            'idProject' => null,
+            'idAccessToken' => null,
+            'accessTokenName' => null,
+            'description' => null,
+            'message' => null,
+            'component' => null,
+            'runId' => null,
+            'idBucket' => null,
+            'tableName' => null,
+            'idAccount' => null,
+            'idExport' => null,
+            'configurationId' => null,
+            'idWorkspace' => null,
+            'fileIds' => null,
+            'objectType' => null,
+            'objectName' => null,
+            'objectId' => null,
+            'context' => null,
+            'params' => null,
+            'results' => null,
+            'performance' => null,
+            'idBranch' => null,
+            'sendNotificationEmail' => null,
+        ], $event->toArray());
+    }
+
+    public function testToArrayWithAllData(): void
+    {
+        $event = new ApplicationEvent(
+            name: 'ext.keboola.keboola-buffer.',
+            idEvent: 20219944,
+            type: 'info',
+            idAdmin: 19,
+            idProject: 18,
+            idAccessToken: 130,
+            accessTokenName: '[_internal] Buffer Export acceptance-test',
+            description: 'event description',
+            message: 'File import done.',
+            component: 'keboola.keboola-buffer',
+            runId: '55',
+            idBucket: 22,
+            tableName: 'table',
+            idAccount: 20,
+            idExport: 21,
+            configurationId: '66',
+            idWorkspace: 23,
+            fileIds: [11, '12'],
+            objectType: 'object-type',
+            objectName: 'object-name',
+            objectId: 'object-id',
+            context: [
+                'remoteAddr' => '10.11.2.62',
+                'httpReferer' => null,
+                'httpUserAgent' => 'keboola-buffer-worker',
+                'apiVersion' => 'v2',
+            ],
+            params: [
+                'task' => 'file-import',
+            ],
+            results: [
+                'exportId' => 'acceptance-test-export',
+                'projectId' => 18,
+                'statistics' =>  [
+                    'bodySize' => 0,
+                    'fileGZipSize' => 0,
+                ],
+            ],
+            performance: [
+                'foo' => 'bar',
+            ],
+            idBranch: 7,
+            sendNotificationEmail: true,
+        );
+
+        self::assertSame([
+            'name' => 'ext.keboola.keboola-buffer.',
+            'idEvent' => 20219944,
+            'type' => 'info',
+            'idAdmin' => 19,
+            'idProject' => 18,
+            'idAccessToken' => 130,
+            'accessTokenName' => '[_internal] Buffer Export acceptance-test',
+            'description' => 'event description',
+            'message' => 'File import done.',
+            'component' => 'keboola.keboola-buffer',
+            'runId' => '55',
+            'idBucket' => 22,
+            'tableName' => 'table',
+            'idAccount' => 20,
+            'idExport' => 21,
+            'configurationId' => '66',
+            'idWorkspace' => 23,
+            'fileIds' => [11, '12'],
+            'objectType' => 'object-type',
+            'objectName' => 'object-name',
+            'objectId' => 'object-id',
+            'context' => [
+                'remoteAddr' => '10.11.2.62',
+                'httpReferer' => null,
+                'httpUserAgent' => 'keboola-buffer-worker',
+                'apiVersion' => 'v2',
+            ],
+            'params' => [
+                'task' => 'file-import',
+            ],
+            'results' => [
+                'exportId' => 'acceptance-test-export',
+                'projectId' => 18,
+                'statistics' =>  [
+                    'bodySize' => 0,
+                    'fileGZipSize' => 0,
+                ],
+            ],
+            'performance' => [
+                'foo' => 'bar',
+            ],
+            'idBranch' => 7,
+            'sendNotificationEmail' => true,
+        ], $event->toArray());
+    }
+
+    public function testGetters(): void
+    {
+        $event = ApplicationEvent::fromArray([
+            'name' => 'ext.keboola.keboola-buffer.',
+            'idEvent' => 20219944,
+            'type' => 'info',
+        ]);
+
+        self::assertSame('ext.keboola.keboola-buffer.', $event->getEventName());
+        self::assertSame('20219944', $event->getId());
+    }
+}

--- a/libs/messenger-bundle/tests/ConnectionEvent/ApplicationEvent/Storage/DevBranchCreatedEventTest.php
+++ b/libs/messenger-bundle/tests/ConnectionEvent/ApplicationEvent/Storage/DevBranchCreatedEventTest.php
@@ -1,0 +1,141 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Keboola\MessengerBundle\Tests\ConnectionEvent\ApplicationEvent\Storage;
+
+use InvalidArgumentException;
+use Keboola\MessengerBundle\ConnectionEvent\ApplicationEvent\ApplicationEventFactory;
+use Keboola\MessengerBundle\ConnectionEvent\ApplicationEvent\Storage\DevBranchCreatedEvent;
+use PHPUnit\Framework\TestCase;
+
+class DevBranchCreatedEventTest extends TestCase
+{
+    private const EXAMPLE_EVENT = <<<EOT
+        {
+          "class": "Event_Application",
+          "created": "2023-10-18T16:08:48+02:00",
+          "data": {
+            "name": "storage.devBranchCreated",
+            "objectId": 46,
+            "idProject": 34,
+            "idAdmin": null,
+            "idAccount": null,
+            "idExport": null,
+            "idAccessToken": 107,
+            "accessTokenName": "josef.martinec@keboolaconnection.onmicrosoft.com",
+            "idBucket": null,
+            "idWorkspace": null,
+            "tableName": null,
+            "objectType": "devBranch",
+            "objectName": "123",
+            "params": {
+              "devBranchName": "123"
+            },
+            "performance": [],
+            "idEvent": 20224549,
+            "type": "info",
+            "description": "",
+            "context": {
+              "remoteAddr": null,
+              "httpReferer": null,
+              "httpUserAgent": null,
+              "apiVersion": "v2",
+              "userAgent": "Mozilla\/5.0 (X11; Linux x86_64) AppleWebKit\/537.36 (KHTML, like Gecko)",
+              "async": true
+            },
+            "results": [],
+            "component": "storage",
+            "message": "Development branch \"123\" created",
+            "runId": "75576",
+            "configurationId": null,
+            "fileIds": [],
+            "idBranch": null
+          }
+        }
+        EOT;
+
+    public function testDecodeFromRealEvent(): void
+    {
+        $eventFactory = new ApplicationEventFactory();
+        $event = $eventFactory->createEventFromArray(json_decode(self::EXAMPLE_EVENT, true, JSON_THROW_ON_ERROR));
+
+        self::assertInstanceOf(DevBranchCreatedEvent::class, $event);
+        self::assertSame(20224549, $event->id);
+        self::assertSame(34, $event->projectId);
+        self::assertSame(107, $event->accessTokenId);
+        self::assertSame('josef.martinec@keboolaconnection.onmicrosoft.com', $event->accessTokenName);
+        self::assertSame(46, $event->objectId);
+        self::assertSame('devBranch', $event->objectType);
+        self::assertSame('123', $event->objectName);
+        self::assertSame('Development branch "123" created', $event->message);
+        self::assertSame(['devBranchName' => '123'], $event->params);
+    }
+
+    public function testCreateFromArray(): void
+    {
+        $event = DevBranchCreatedEvent::fromArray([
+            'name' => 'storage.devBranchCreated',
+            'idEvent' => 123,
+            'idProject' => 456,
+            'idAccessToken' => 789,
+            'accessTokenName' => 'test@example.com',
+            'objectId' => 741,
+            'objectType' => 'devBranch',
+            'objectName' => 'testName',
+            'message' => 'testMessage',
+            'params' => ['testParam' => 'testValue'],
+        ]);
+
+        self::assertSame(123, $event->id);
+        self::assertSame(456, $event->projectId);
+        self::assertSame(789, $event->accessTokenId);
+        self::assertSame('test@example.com', $event->accessTokenName);
+        self::assertSame(741, $event->objectId);
+        self::assertSame('devBranch', $event->objectType);
+        self::assertSame('testName', $event->objectName);
+        self::assertSame('testMessage', $event->message);
+        self::assertSame(['testParam' => 'testValue'], $event->params);
+    }
+
+    public function testCreateFromArrayWithInvalidName(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(
+            'Keboola\MessengerBundle\ConnectionEvent\ApplicationEvent\Storage\DevBranchCreatedEvent expects event' .
+            ' name "storage.devBranchCreated" but is "foo"',
+        );
+
+        DevBranchCreatedEvent::fromArray([
+            'name' => 'foo',
+        ]);
+    }
+
+    public function testToArray(): void
+    {
+        $event = new DevBranchCreatedEvent(
+            id: 123,
+            projectId: 456,
+            accessTokenId: 789,
+            accessTokenName: 'test@example.com',
+            objectId: 741,
+            objectType: 'devBranch',
+            objectName: 'testName',
+            message: 'testMessage',
+            params: ['testParam' => 'testValue'],
+        );
+
+        self::assertSame([
+            'name' => 'storage.devBranchCreated',
+            'idEvent' => 123,
+            'idProject' => 456,
+            'idAccessToken' => 789,
+            'accessTokenName' => 'test@example.com',
+            'objectId' => 741,
+            'objectType' => 'devBranch',
+            'objectName' => 'testName',
+            'message' => 'testMessage',
+            'params' => ['testParam' => 'testValue'],
+        ], $event->toArray());
+    }
+}

--- a/libs/messenger-bundle/tests/ConnectionEvent/ApplicationEvent/Storage/DevBranchDeletedEventTest.php
+++ b/libs/messenger-bundle/tests/ConnectionEvent/ApplicationEvent/Storage/DevBranchDeletedEventTest.php
@@ -1,0 +1,142 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Keboola\MessengerBundle\Tests\ConnectionEvent\ApplicationEvent\Storage;
+
+use InvalidArgumentException;
+use Keboola\MessengerBundle\ConnectionEvent\ApplicationEvent\ApplicationEventFactory;
+use Keboola\MessengerBundle\ConnectionEvent\ApplicationEvent\Storage\DevBranchDeletedEvent;
+use PHPUnit\Framework\TestCase;
+
+class DevBranchDeletedEventTest extends TestCase
+{
+    private const EXAMPLE_EVENT = <<<EOT
+        {
+          "class": "Event_Application",
+          "created": "2023-10-18T16:10:32+02:00",
+          "data": {
+            "name": "storage.devBranchDeleted",
+            "objectId": 46,
+            "idProject": 34,
+            "idAdmin": null,
+            "idAccount": null,
+            "idExport": null,
+            "idAccessToken": 107,
+            "accessTokenName": "josef.martinec@keboolaconnection.onmicrosoft.com",
+            "idBucket": null,
+            "idWorkspace": null,
+            "tableName": null,
+            "objectType": "devBranch",
+            "objectName": "",
+            "params": {
+              "devBranchName": "123",
+              "id": 46
+            },
+            "performance": [],
+            "idEvent": 20224558,
+            "type": "info",
+            "description": "",
+            "context": {
+              "remoteAddr": null,
+              "httpReferer": null,
+              "httpUserAgent": null,
+              "apiVersion": "v2",
+              "userAgent": "Mozilla\/5.0 (X11; Linux x86_64) AppleWebKit\/537.36 (KHTML, like Gecko)",
+              "async": true
+            },
+            "results": [],
+            "component": "storage",
+            "message": "Development branch \"123\" deleted",
+            "runId": "75579",
+            "configurationId": null,
+            "fileIds": [],
+            "idBranch": null
+          }
+        }
+        EOT;
+
+    public function testDecodeFromRealEvent(): void
+    {
+        $eventFactory = new ApplicationEventFactory();
+        $event = $eventFactory->createEventFromArray(json_decode(self::EXAMPLE_EVENT, true, JSON_THROW_ON_ERROR));
+
+        self::assertInstanceOf(DevBranchDeletedEvent::class, $event);
+        self::assertSame(20224558, $event->id);
+        self::assertSame(34, $event->projectId);
+        self::assertSame(107, $event->accessTokenId);
+        self::assertSame('josef.martinec@keboolaconnection.onmicrosoft.com', $event->accessTokenName);
+        self::assertSame(46, $event->objectId);
+        self::assertSame('devBranch', $event->objectType);
+        self::assertSame('', $event->objectName);
+        self::assertSame('Development branch "123" deleted', $event->message);
+        self::assertSame(['devBranchName' => '123', 'id' => 46], $event->params);
+    }
+
+    public function testCreateFromArray(): void
+    {
+        $event = DevBranchDeletedEvent::fromArray([
+            'name' => 'storage.devBranchDeleted',
+            'idEvent' => 123,
+            'idProject' => 456,
+            'idAccessToken' => 789,
+            'accessTokenName' => 'test@example.com',
+            'objectId' => 741,
+            'objectType' => 'devBranch',
+            'objectName' => 'testName',
+            'message' => 'testMessage',
+            'params' => ['testParam' => 'testValue'],
+        ]);
+
+        self::assertSame(123, $event->id);
+        self::assertSame(456, $event->projectId);
+        self::assertSame(789, $event->accessTokenId);
+        self::assertSame('test@example.com', $event->accessTokenName);
+        self::assertSame(741, $event->objectId);
+        self::assertSame('devBranch', $event->objectType);
+        self::assertSame('testName', $event->objectName);
+        self::assertSame('testMessage', $event->message);
+        self::assertSame(['testParam' => 'testValue'], $event->params);
+    }
+
+    public function testCreateFromArrayWithInvalidName(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(
+            'Keboola\MessengerBundle\ConnectionEvent\ApplicationEvent\Storage\DevBranchDeletedEvent expects event ' .
+            'name "storage.devBranchDeleted" but is "foo"',
+        );
+
+        DevBranchDeletedEvent::fromArray([
+            'name' => 'foo',
+        ]);
+    }
+
+    public function testToArray(): void
+    {
+        $event = new DevBranchDeletedEvent(
+            id: 123,
+            projectId: 456,
+            accessTokenId: 789,
+            accessTokenName: 'test@example.com',
+            objectId: 741,
+            objectType: 'devBranch',
+            objectName: 'testName',
+            message: 'testMessage',
+            params: ['testParam' => 'testValue'],
+        );
+
+        self::assertSame([
+            'name' => 'storage.devBranchDeleted',
+            'idEvent' => 123,
+            'idProject' => 456,
+            'idAccessToken' => 789,
+            'accessTokenName' => 'test@example.com',
+            'objectId' => 741,
+            'objectType' => 'devBranch',
+            'objectName' => 'testName',
+            'message' => 'testMessage',
+            'params' => ['testParam' => 'testValue'],
+        ], $event->toArray());
+    }
+}

--- a/libs/messenger-bundle/tests/ConnectionEvent/AwsSqsConsumptionTest.php
+++ b/libs/messenger-bundle/tests/ConnectionEvent/AwsSqsConsumptionTest.php
@@ -29,7 +29,7 @@ class AwsSqsConsumptionTest extends AbstractQueueConsumptionTest
     protected function publishMessage(array $message): void
     {
         $this->sqsClient->sendMessage(new SendMessageRequest([
-            'QueueUrl' => self::getRequiredEnv('CONNECTION_EVENTS_QUEUE_DSN'),
+            'QueueUrl' => self::getRequiredEnv('CONNECTION_AUDIT_LOG_QUEUE_DSN'),
             'MessageBody' => json_encode($message, JSON_THROW_ON_ERROR),
         ]))->getMessageId();
     }

--- a/libs/messenger-bundle/tests/ConnectionEvent/AzureServiceBusConsumptionTest.php
+++ b/libs/messenger-bundle/tests/ConnectionEvent/AzureServiceBusConsumptionTest.php
@@ -24,7 +24,11 @@ class AzureServiceBusConsumptionTest extends AbstractQueueConsumptionTest
         parent::setUp();
 
         $dsnParser = self::getContainer()->get('aymdev_azure_service_bus.dsn_parser');
-        $options = $dsnParser->parseDsn(self::getRequiredEnv('CONNECTION_EVENTS_QUEUE_DSN'), [], 'connection_events');
+        $options = $dsnParser->parseDsn(
+            self::getRequiredEnv('CONNECTION_AUDIT_LOG_QUEUE_DSN'),
+            [],
+            'connection_events',
+        );
 
         $httpConfigBuilder = self::getContainer()->get('aymdev_azure_service_bus.http_config_builder');
         $httpClientConfiguration = $httpConfigBuilder->buildSenderConfiguration($options);

--- a/libs/messenger-bundle/tests/ConnectionEvent/GooglePubSubConsumptionTest.php
+++ b/libs/messenger-bundle/tests/ConnectionEvent/GooglePubSubConsumptionTest.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Keboola\MessengerBundle\Tests\ConnectionEvent;
+
+use Google\Cloud\PubSub\PubSubClient;
+use Google\Cloud\PubSub\Topic;
+use Keboola\MessengerBundle\ConnectionEvent\AuditLog\Project\ProjectDeletedEvent;
+use Keboola\MessengerBundle\Tests\TestEnvVarsTrait;
+use Symfony\Component\Messenger\Envelope;
+
+class GooglePubSubConsumptionTest extends AbstractQueueConsumptionTest
+{
+    use TestEnvVarsTrait;
+
+    private readonly Topic $topicClient;
+
+    protected function setUp(): void
+    {
+        if (self::getRequiredEnv('TEST_CLOUD_PLATFORM') !== 'gcp') {
+            $this->markTestSkipped('Only applicable on GCP');
+        }
+
+        parent::setUp();
+
+        $dsnPath = parse_url(self::getRequiredEnv('CONNECTION_EVENTS_QUEUE_DSN'), PHP_URL_PATH);
+        $topicName = ltrim((string) $dsnPath, '/');
+        self::assertNotEmpty($topicName, 'Topic name is empty');
+
+        $pubSubClient = new PubSubClient();
+        $this->topicClient = $pubSubClient->topic($topicName);
+    }
+
+    protected function publishMessage(array $message): void
+    {
+        $this->topicClient->publish([
+            'data' => json_encode($message, JSON_THROW_ON_ERROR),
+        ]);
+    }
+
+    public function testMessageDelivery(): void
+    {
+        // PubSub does not wrap the data
+        $wrappedMessage = self::EVENT_DATA;
+
+        $this->publishMessage($wrappedMessage);
+        $messages = $this->waitAndFetchAllAvailableMessages();
+
+        // result may contain other messages, we need to search for our message
+        self::assertGreaterThanOrEqual(1, count($messages));
+        $events = array_map(fn(Envelope $envelope) => $envelope->getMessage(), $messages);
+        $deleteEvents = array_filter($events, fn(object $event) => $event instanceof ProjectDeletedEvent);
+        $deleteEventsIds = array_map(fn(ProjectDeletedEvent $event) => $event->getId(), $deleteEvents);
+
+        self::assertGreaterThanOrEqual(1, count($deleteEvents));
+        self::assertContains((string) self::EVENT_DATA['data']['id'], $deleteEventsIds);
+    }
+}

--- a/libs/messenger-bundle/tests/ConnectionEvent/GooglePubSubConsumptionTest.php
+++ b/libs/messenger-bundle/tests/ConnectionEvent/GooglePubSubConsumptionTest.php
@@ -24,7 +24,7 @@ class GooglePubSubConsumptionTest extends AbstractQueueConsumptionTest
 
         parent::setUp();
 
-        $dsnPath = parse_url(self::getRequiredEnv('CONNECTION_EVENTS_QUEUE_DSN'), PHP_URL_PATH);
+        $dsnPath = parse_url(self::getRequiredEnv('CONNECTION_AUDIT_LOG_QUEUE_DSN'), PHP_URL_PATH);
         $topicName = ltrim((string) $dsnPath, '/');
         self::assertNotEmpty($topicName, 'Topic name is empty');
 

--- a/libs/messenger-bundle/tests/ConnectionEvent/Serializer/AwsSqsSerializerTest.php
+++ b/libs/messenger-bundle/tests/ConnectionEvent/Serializer/AwsSqsSerializerTest.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Keboola\MessengerBundle\Tests\ConnectionEvent\Serializer;
 
-use Keboola\MessengerBundle\ConnectionEvent\EventFactory;
-use Keboola\MessengerBundle\ConnectionEvent\GenericEvent;
+use Keboola\MessengerBundle\ConnectionEvent\AuditLog\AuditEventFactory;
+use Keboola\MessengerBundle\ConnectionEvent\AuditLog\GenericAuditLogEvent;
 use Keboola\MessengerBundle\ConnectionEvent\Serializer\AwsSqsSerializer;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Messenger\Exception\MessageDecodingFailedException;
@@ -17,7 +17,7 @@ class AwsSqsSerializerTest extends TestCase
      */
     public function testInvalidMessageDecode(array $encodedEnvelope, string $expectedError): void
     {
-        $serializer = new AwsSqsSerializer(new EventFactory());
+        $serializer = new AwsSqsSerializer(new AuditEventFactory());
 
         $this->expectException(MessageDecodingFailedException::class);
         $this->expectExceptionMessage($expectedError);
@@ -71,10 +71,10 @@ class AwsSqsSerializerTest extends TestCase
 
     public function testValidMessageDecode(): void
     {
-        $eventFactory = new class extends EventFactory {
-            public function createEventFromArray(array $data): GenericEvent
+        $eventFactory = new class extends AuditEventFactory {
+            public function createEventFromArray(array $data): GenericAuditLogEvent
             {
-                return new GenericEvent($data['data']);
+                return new GenericAuditLogEvent($data['data']);
             }
         };
 
@@ -97,7 +97,7 @@ class AwsSqsSerializerTest extends TestCase
         self::assertCount(0, $stamps);
 
         $event = $envelope->getMessage();
-        self::assertInstanceOf(GenericEvent::class, $event);
+        self::assertInstanceOf(GenericAuditLogEvent::class, $event);
         self::assertSame($eventData, $event->getData());
     }
 }

--- a/libs/messenger-bundle/tests/ConnectionEvent/Serializer/AzureServiceBusSerializerTest.php
+++ b/libs/messenger-bundle/tests/ConnectionEvent/Serializer/AzureServiceBusSerializerTest.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Keboola\MessengerBundle\Tests\ConnectionEvent\Serializer;
 
-use Keboola\MessengerBundle\ConnectionEvent\EventFactory;
-use Keboola\MessengerBundle\ConnectionEvent\GenericEvent;
+use Keboola\MessengerBundle\ConnectionEvent\AuditLog\AuditEventFactory;
+use Keboola\MessengerBundle\ConnectionEvent\AuditLog\GenericAuditLogEvent;
 use Keboola\MessengerBundle\ConnectionEvent\Serializer\AzureServiceBusSerializer;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Messenger\Exception\MessageDecodingFailedException;
@@ -17,7 +17,7 @@ class AzureServiceBusSerializerTest extends TestCase
      */
     public function testInvalidMessageDecode(array $encodedEnvelope, string $expectedError): void
     {
-        $serializer = new AzureServiceBusSerializer(new EventFactory());
+        $serializer = new AzureServiceBusSerializer(new AuditEventFactory());
 
         $this->expectException(MessageDecodingFailedException::class);
         $this->expectExceptionMessage($expectedError);
@@ -60,10 +60,10 @@ class AzureServiceBusSerializerTest extends TestCase
 
     public function testValidMessageDecode(): void
     {
-        $eventFactory = new class extends EventFactory {
-            public function createEventFromArray(array $data): GenericEvent
+        $eventFactory = new class extends AuditEventFactory {
+            public function createEventFromArray(array $data): GenericAuditLogEvent
             {
-                return new GenericEvent($data['data']);
+                return new GenericAuditLogEvent($data['data']);
             }
         };
 
@@ -86,7 +86,7 @@ class AzureServiceBusSerializerTest extends TestCase
         self::assertCount(0, $stamps);
 
         $event = $envelope->getMessage();
-        self::assertInstanceOf(GenericEvent::class, $event);
+        self::assertInstanceOf(GenericAuditLogEvent::class, $event);
         self::assertSame($eventData, $event->getData());
     }
 }

--- a/libs/messenger-bundle/tests/ConnectionEvent/Serializer/GooglePubSubSerializerTest.php
+++ b/libs/messenger-bundle/tests/ConnectionEvent/Serializer/GooglePubSubSerializerTest.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Keboola\MessengerBundle\Tests\ConnectionEvent\Serializer;
 
-use Keboola\MessengerBundle\ConnectionEvent\EventFactory;
-use Keboola\MessengerBundle\ConnectionEvent\GenericEvent;
+use Keboola\MessengerBundle\ConnectionEvent\AuditLog\AuditEventFactory;
+use Keboola\MessengerBundle\ConnectionEvent\AuditLog\GenericAuditLogEvent;
 use Keboola\MessengerBundle\ConnectionEvent\Serializer\GooglePubSubSerializer;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Messenger\Exception\MessageDecodingFailedException;
@@ -23,7 +23,7 @@ class GooglePubSubSerializerTest extends TestCase
     /** @dataProvider provideInvalidMessageDecodeTestData */
     public function testInvalidMessageDecode(array $encodedEnvelope, string $expectedError): void
     {
-        $serializer = new GooglePubSubSerializer(new EventFactory());
+        $serializer = new GooglePubSubSerializer(new AuditEventFactory());
 
         $this->expectException(MessageDecodingFailedException::class);
         $this->expectExceptionMessage($expectedError);
@@ -33,10 +33,10 @@ class GooglePubSubSerializerTest extends TestCase
 
     public function testValidMessageDecode(): void
     {
-        $eventFactory = new class extends EventFactory {
-            public function createEventFromArray(array $data): GenericEvent
+        $eventFactory = new class extends AuditEventFactory {
+            public function createEventFromArray(array $data): GenericAuditLogEvent
             {
-                return new GenericEvent($data);
+                return new GenericAuditLogEvent($data);
             }
         };
 
@@ -55,7 +55,7 @@ class GooglePubSubSerializerTest extends TestCase
         self::assertCount(0, $stamps);
 
         $event = $envelope->getMessage();
-        self::assertInstanceOf(GenericEvent::class, $event);
+        self::assertInstanceOf(GenericAuditLogEvent::class, $event);
         self::assertSame($eventData, $event->getData());
     }
 }

--- a/libs/messenger-bundle/tests/ConnectionEvent/Serializer/GooglePubSubSerializerTest.php
+++ b/libs/messenger-bundle/tests/ConnectionEvent/Serializer/GooglePubSubSerializerTest.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Keboola\MessengerBundle\Tests\ConnectionEvent\Serializer;
+
+use Keboola\MessengerBundle\ConnectionEvent\EventFactory;
+use Keboola\MessengerBundle\ConnectionEvent\GenericEvent;
+use Keboola\MessengerBundle\ConnectionEvent\Serializer\GooglePubSubSerializer;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Messenger\Exception\MessageDecodingFailedException;
+
+class GooglePubSubSerializerTest extends TestCase
+{
+    public static function provideInvalidMessageDecodeTestData(): iterable
+    {
+        yield 'invalid event data' => [
+            'data' => [],
+            'error' => 'Failed to create an event object from the message: Missing or invalid property "data"',
+        ];
+    }
+
+    /** @dataProvider provideInvalidMessageDecodeTestData */
+    public function testInvalidMessageDecode(array $encodedEnvelope, string $expectedError): void
+    {
+        $serializer = new GooglePubSubSerializer(new EventFactory());
+
+        $this->expectException(MessageDecodingFailedException::class);
+        $this->expectExceptionMessage($expectedError);
+
+        $serializer->decode($encodedEnvelope);
+    }
+
+    public function testValidMessageDecode(): void
+    {
+        $eventFactory = new class extends EventFactory {
+            public function createEventFromArray(array $data): GenericEvent
+            {
+                return new GenericEvent($data);
+            }
+        };
+
+        $serializer = new GooglePubSubSerializer($eventFactory);
+
+        $eventData = [
+            'data' => [
+                'id' => 1234,
+                'operation' => 'keboola.test',
+            ],
+        ];
+
+        $envelope = $serializer->decode($eventData);
+
+        $stamps = $envelope->all();
+        self::assertCount(0, $stamps);
+
+        $event = $envelope->getMessage();
+        self::assertInstanceOf(GenericEvent::class, $event);
+        self::assertSame($eventData, $event->getData());
+    }
+}

--- a/libs/messenger-bundle/tests/KeboolaMessengerBundleTestingKernel.php
+++ b/libs/messenger-bundle/tests/KeboolaMessengerBundleTestingKernel.php
@@ -6,6 +6,7 @@ namespace Keboola\MessengerBundle\Tests;
 
 use AymDev\MessengerAzureBundle\AymDevMessengerAzureBundle;
 use Keboola\MessengerBundle\KeboolaMessengerBundle;
+use PetitPress\GpsMessengerBundle\GpsMessengerBundle;
 use Symfony\Bundle\FrameworkBundle\FrameworkBundle;
 use Symfony\Component\Config\Loader\LoaderInterface;
 use Symfony\Component\HttpKernel\Kernel;
@@ -15,6 +16,7 @@ class KeboolaMessengerBundleTestingKernel extends Kernel
     public function registerBundles(): iterable
     {
         yield new AymDevMessengerAzureBundle();
+        yield new GpsMessengerBundle();
         yield new FrameworkBundle();
         yield new KeboolaMessengerBundle();
     }

--- a/libs/messenger-bundle/tests/config.yaml
+++ b/libs/messenger-bundle/tests/config.yaml
@@ -4,3 +4,4 @@ framework:
 keboola_messenger:
   platform: '%env(TEST_CLOUD_PLATFORM)%'
   connection_events_queue_dsn: '%env(CONNECTION_EVENTS_QUEUE_DSN)%'
+  connection_audit_log_queue_dsn: '%env(CONNECTION_AUDIT_LOG_QUEUE_DSN)%'


### PR DESCRIPTION
https://keboola.atlassian.net/browse/SOX-435

Podpora pro events i audit log fronty z Connection.

Puvodni implementace podporovala jen audit log, ale konfigurace byla mylne pojmenovana `connection_events`. Ted by to melo byt vsechno narovnany a jasne rozliseny, co se tyka events (applicaitn events) a co audit logu.