### PR TITLE
SOX-387 Adjust no role & guest role permissions

### DIFF
--- a/libs/permission-checker/src/Check/Notification/CanModifySubscriptions.php
+++ b/libs/permission-checker/src/Check/Notification/CanModifySubscriptions.php
@@ -28,7 +28,7 @@ class CanModifySubscriptions implements PermissionCheckInterface
             };
         } else {
             $isRoleAllowed = match ($token->getRole()) {
-                Role::GUEST, Role::READ_ONLY => false,
+                Role::NONE, Role::GUEST, Role::READ_ONLY => false,
                 default => true,
             };
         }

--- a/libs/permission-checker/src/Check/Notification/CanModifySubscriptions.php
+++ b/libs/permission-checker/src/Check/Notification/CanModifySubscriptions.php
@@ -28,7 +28,7 @@ class CanModifySubscriptions implements PermissionCheckInterface
             };
         } else {
             $isRoleAllowed = match ($token->getRole()) {
-                Role::NONE, Role::GUEST, Role::READ_ONLY => false,
+                Role::NONE, Role::READ_ONLY => false,
                 default => true,
             };
         }

--- a/libs/permission-checker/src/Check/OAuth/CanModifyAuthorization.php
+++ b/libs/permission-checker/src/Check/OAuth/CanModifyAuthorization.php
@@ -28,7 +28,7 @@ class CanModifyAuthorization implements PermissionCheckInterface
             };
         } else {
             $isRoleAllowed = match ($token->getRole()) {
-                Role::GUEST, Role::READ_ONLY => false,
+                Role::NONE, Role::GUEST, Role::READ_ONLY => false,
                 default => true,
             };
         }

--- a/libs/permission-checker/src/Check/OAuth/CanModifyAuthorization.php
+++ b/libs/permission-checker/src/Check/OAuth/CanModifyAuthorization.php
@@ -28,7 +28,7 @@ class CanModifyAuthorization implements PermissionCheckInterface
             };
         } else {
             $isRoleAllowed = match ($token->getRole()) {
-                Role::NONE, Role::GUEST, Role::READ_ONLY => false,
+                Role::NONE, Role::READ_ONLY => false,
                 default => true,
             };
         }

--- a/libs/permission-checker/src/Check/Vault/CanModifyVariable.php
+++ b/libs/permission-checker/src/Check/Vault/CanModifyVariable.php
@@ -22,7 +22,7 @@ class CanModifyVariable implements PermissionCheckInterface
     {
         if ($token->hasFeature(Feature::PROTECTED_DEFAULT_BRANCH)) {
             $this->checkProtectedDefaultBranch($token->getRole());
-        } elseif ($token->isRole(Role::READ_ONLY)) {
+        } elseif ($token->isOneOfRoles([Role::NONE, Role::READ_ONLY])) {
             throw PermissionDeniedException::roleDenied($token->getRole(), 'modify variable');
         }
     }

--- a/libs/permission-checker/tests/Check/Notification/CanModifySubscriptionsTest.php
+++ b/libs/permission-checker/tests/Check/Notification/CanModifySubscriptionsTest.php
@@ -29,6 +29,11 @@ class CanModifySubscriptionsTest extends TestCase
             'token' => new StorageApiToken(role: 'admin'),
         ];
 
+        yield 'guest user' => [
+            'branchType' => null,
+            'token' => new StorageApiToken(role: 'guest'),
+        ];
+
         yield 'productionManager on protected default branch' => [
             'branchType' => BranchType::DEFAULT,
             'token' => new StorageApiToken(features: ['protected-default-branch'], role: 'productionManager'),
@@ -62,12 +67,6 @@ class CanModifySubscriptionsTest extends TestCase
             'branchType' => BranchType::DEFAULT,
             'token' => new StorageApiToken(role: null),
             'error' => new PermissionDeniedException('Role "none" is not allowed to modify subscriptions'),
-        ];
-
-        yield 'guest role' => [
-            'branchType' => BranchType::DEFAULT,
-            'token' => new StorageApiToken(role: 'guest'),
-            'error' => new PermissionDeniedException('Role "guest" is not allowed to modify subscriptions'),
         ];
 
         yield 'readOnly role' => [

--- a/libs/permission-checker/tests/Check/Notification/CanModifySubscriptionsTest.php
+++ b/libs/permission-checker/tests/Check/Notification/CanModifySubscriptionsTest.php
@@ -14,19 +14,19 @@ class CanModifySubscriptionsTest extends TestCase
 {
     public static function provideValidPermissionsCheckData(): iterable
     {
-        yield 'regular token on regular project default branch' => [
+        yield 'regular user on regular project default branch' => [
             'branchType' => BranchType::DEFAULT,
-            'token' => new StorageApiToken(role: null),
+            'token' => new StorageApiToken(role: 'admin'),
         ];
 
-        yield 'regular token on regular project dev branch' => [
+        yield 'regular user on regular project dev branch' => [
             'branchType' => BranchType::DEV,
-            'token' => new StorageApiToken(role: null),
+            'token' => new StorageApiToken(role: 'admin'),
         ];
 
-        yield 'regular token on regular project without branch' => [
+        yield 'regular user on regular project without branch' => [
             'branchType' => null,
-            'token' => new StorageApiToken(role: null),
+            'token' => new StorageApiToken(role: 'admin'),
         ];
 
         yield 'productionManager on protected default branch' => [
@@ -58,6 +58,12 @@ class CanModifySubscriptionsTest extends TestCase
 
     public static function provideInvalidPermissionsCheckData(): iterable
     {
+        yield 'no role role' => [
+            'branchType' => BranchType::DEFAULT,
+            'token' => new StorageApiToken(role: null),
+            'error' => new PermissionDeniedException('Role "none" is not allowed to modify subscriptions'),
+        ];
+
         yield 'guest role' => [
             'branchType' => BranchType::DEFAULT,
             'token' => new StorageApiToken(role: 'guest'),

--- a/libs/permission-checker/tests/Check/OAuth/CanModifyAuthorizationTest.php
+++ b/libs/permission-checker/tests/Check/OAuth/CanModifyAuthorizationTest.php
@@ -29,6 +29,11 @@ class CanModifyAuthorizationTest extends TestCase
             'token' => new StorageApiToken(role: 'admin'),
         ];
 
+        yield 'guest user' => [
+            'branchType' => null,
+            'token' => new StorageApiToken(role: 'guest'),
+        ];
+
         yield 'productionManager on protected default branch' => [
             'branchType' => BranchType::DEFAULT,
             'token' => new StorageApiToken(features: ['protected-default-branch'], role: 'productionManager'),
@@ -67,12 +72,6 @@ class CanModifyAuthorizationTest extends TestCase
             'branchType' => BranchType::DEFAULT,
             'token' => new StorageApiToken(role: null),
             'error' => new PermissionDeniedException('Role "none" is not allowed to modify authorization'),
-        ];
-
-        yield 'guest role' => [
-            'branchType' => BranchType::DEFAULT,
-            'token' => new StorageApiToken(role: 'guest'),
-            'error' => new PermissionDeniedException('Role "guest" is not allowed to modify authorization'),
         ];
 
         yield 'readOnly role' => [

--- a/libs/permission-checker/tests/Check/OAuth/CanModifyAuthorizationTest.php
+++ b/libs/permission-checker/tests/Check/OAuth/CanModifyAuthorizationTest.php
@@ -14,19 +14,19 @@ class CanModifyAuthorizationTest extends TestCase
 {
     public static function provideValidPermissionsCheckData(): iterable
     {
-        yield 'regular token on regular project default branch' => [
+        yield 'regular user on regular project default branch' => [
             'branchType' => BranchType::DEFAULT,
-            'token' => new StorageApiToken(role: null),
+            'token' => new StorageApiToken(role: 'admin'),
         ];
 
-        yield 'regular token on regular project dev branch' => [
+        yield 'regular user on regular project dev branch' => [
             'branchType' => BranchType::DEV,
-            'token' => new StorageApiToken(role: null),
+            'token' => new StorageApiToken(role: 'admin'),
         ];
 
-        yield 'regular token on regular project without branch' => [
+        yield 'regular user on regular project without branch' => [
             'branchType' => null,
-            'token' => new StorageApiToken(role: null),
+            'token' => new StorageApiToken(role: 'admin'),
         ];
 
         yield 'productionManager on protected default branch' => [
@@ -63,6 +63,12 @@ class CanModifyAuthorizationTest extends TestCase
 
     public static function provideInvalidPermissionsCheckData(): iterable
     {
+        yield 'no role' => [
+            'branchType' => BranchType::DEFAULT,
+            'token' => new StorageApiToken(role: null),
+            'error' => new PermissionDeniedException('Role "none" is not allowed to modify authorization'),
+        ];
+
         yield 'guest role' => [
             'branchType' => BranchType::DEFAULT,
             'token' => new StorageApiToken(role: 'guest'),

--- a/libs/permission-checker/tests/Check/Vault/CanModifyVariableTest.php
+++ b/libs/permission-checker/tests/Check/Vault/CanModifyVariableTest.php
@@ -15,19 +15,19 @@ class CanModifyVariableTest extends TestCase
 {
     public static function provideValidPermissionsCheckData(): iterable
     {
-        yield 'simple token without branch' => [
+        yield 'regular user without branch' => [
             'branchType' => null,
-            'token' => new StorageApiToken(),
+            'token' => new StorageApiToken(role: 'admin'),
         ];
 
-        yield 'simple token on default branch' => [
+        yield 'regular user on default branch' => [
             'branchType' => BranchType::DEFAULT,
-            'token' => new StorageApiToken(),
+            'token' => new StorageApiToken(role: 'admin'),
         ];
 
-        yield 'simple token on dev branch' => [
+        yield 'regular user on dev branch' => [
             'branchType' => BranchType::DEV,
-            'token' => new StorageApiToken(),
+            'token' => new StorageApiToken(role: 'admin'),
         ];
 
         yield 'developer role on protected dev branch' => [
@@ -76,11 +76,15 @@ class CanModifyVariableTest extends TestCase
 
     public static function provideInvalidPermissionsCheckData(): iterable
     {
+        yield 'no role' => [
+            'branchType' => null,
+            'token' => new StorageApiToken(role: null),
+            'error' => PermissionDeniedException::roleDenied(Role::NONE, 'modify variable'),
+        ];
+
         yield 'readOnly role' => [
             'branchType' => null,
-            'token' => new StorageApiToken(
-                role: 'readOnly',
-            ),
+            'token' => new StorageApiToken(role: 'readOnly'),
             'error' => PermissionDeniedException::roleDenied(Role::READ_ONLY, 'modify variable'),
         ];
 


### PR DESCRIPTION
https://keboola.atlassian.net/browse/SOX-387

Nakonec se to ukazalo jako ne zase tak velky problem, jak jsme se na zacatku bali.

SOX (protected default branch) situace by mely byt v pohode, vude mame "default deny" a jen explicitne vyjmenovane situace, kdy danou akci dovolujeme. Problem byly nektere ne-SOX checky, kde mame "default allow" behaviour + seznam roli, ktery to naopak nesmi delat. Tam jsme se obcas zapomneli zamyslet nad tokeny bez role a pripadne guest, ktery je takova variace na read-only (https://help.keboola.com/management/project/users/#user-roles).

Pri vymysleni jsem si to zkusil trosku zjednodusit a uvazoval jsem, ze token s roli = user (vic/mene clovek co tuka pres UI), token bez role = nejaka automatizace/integrace pres API.