### PR TITLE
SOX-451 Add Doctrine ping middleware

### DIFF
--- a/libs/messenger-bundle/tests/DependencyInjection/KeboolaMessengerExtensionTest.php
+++ b/libs/messenger-bundle/tests/DependencyInjection/KeboolaMessengerExtensionTest.php
@@ -185,6 +185,27 @@ class KeboolaMessengerExtensionTest extends KernelTestCase
         }
     }
 
+    public function testDoctrinePingIsConfiguredWhenDoctrineBundleIsInstalled(): void
+    {
+        require_once __DIR__ . '/../FakeDoctrineBundle.php';
+
+        $containerBuilder = $this->createContainerBuilder([
+            'platform' => 'aws',
+            'connection_events_queue_dsn' => 'http://example.com',
+        ]);
+
+        $extension = new KeboolaMessengerExtension();
+        $extension->prepend($containerBuilder);
+
+        $frameworkConfigs = $containerBuilder->getExtensionConfig('framework');
+        $frameworkConfig = array_merge_recursive(...$frameworkConfigs);
+
+        self::assertSame(
+            ['doctrine_ping_connection'],
+            $frameworkConfig['messenger']['buses']['messenger.bus.events']['middleware'] ?? [],
+        );
+    }
+
     private function createContainerBuilder(array $bundleConfig): ContainerBuilder
     {
         $containerBuilder = new ContainerBuilder(new ParameterBag([

--- a/libs/messenger-bundle/tests/FakeDoctrineBundle.php
+++ b/libs/messenger-bundle/tests/FakeDoctrineBundle.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symfony\Bridge\Doctrine\Messenger;
+
+class DoctrinePingConnectionMiddleware
+{
+
+}


### PR DESCRIPTION
https://keboola.atlassian.net/browse/SOX-451

MySQL automaticky zavira spojeni po nejake dobe neaktivity. Jelikoz consumer muze celkem dlouho cekat, nez prijde nova message, je potreba to mit osetrene. Je to bezna situace, takze na to existuje oficialni reseni v podobe middleware https://symfony.com/doc/current/messenger.html#middleware-for-doctrine