### PR TITLE
[output-mapping] composer: storage-api-client 14.12

### DIFF
--- a/libs/output-mapping/composer.json
+++ b/libs/output-mapping/composer.json
@@ -33,7 +33,7 @@
         "keboola/php-file-storage-utils": "^0.2",
         "keboola/sanitizer": "^0.1",
         "keboola/slicer": "*@dev",
-        "keboola/storage-api-client": "^14.11.2",
+        "keboola/storage-api-client": "^14.12",
         "keboola/storage-api-php-client-branch-wrapper": "^5.1",
         "microsoft/azure-storage-blob": "^1.5",
         "monolog/monolog": "^1.25.5|^2.0",


### PR DESCRIPTION
Min version updated to 14.12 _(has fixed re-upload of files on GCS)_ https://github.com/keboola/storage-api-php-client/releases/tag/v14.12.0