### PR TITLE
Update keboola/coding-standard to 15.x - fix build

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -125,3 +125,7 @@ services:
     <<: *dev
     image: keboola/slicer
     working_dir: /code/libs/slicer
+
+  dev-logging-bundle:
+    <<: *dev
+    working_dir: /code/libs/logging-bundle

--- a/libs/api-bundle/composer.json
+++ b/libs/api-bundle/composer.json
@@ -12,7 +12,7 @@
     },
     "require-dev": {
         "keboola/api-error-control": "^4.1",
-        "keboola/coding-standard": "^14.0",
+        "keboola/coding-standard": "^15.0",
         "keboola/kbc-manage-api-php-client": "^7.0",
         "keboola/storage-api-php-client-branch-wrapper": "^5.1",
         "phpstan/phpstan": "^1.8",

--- a/libs/api-bundle/src/Security/AttributeAuthenticator.php
+++ b/libs/api-bundle/src/Security/AttributeAuthenticator.php
@@ -67,7 +67,7 @@ class AttributeAuthenticator extends AbstractAuthenticator
                     $e->getMessage(),
                     [],
                     Response::HTTP_FORBIDDEN,
-                    $e
+                    $e,
                 );
             }
 
@@ -99,7 +99,7 @@ class AttributeAuthenticator extends AbstractAuthenticator
         return ErrorResponse::fromException(new HttpException(
             $exception->getCode() > 0 ? $exception->getCode() : Response::HTTP_UNAUTHORIZED,
             $errorMessage,
-            $exception
+            $exception,
         ));
     }
 

--- a/libs/api-bundle/src/Security/ManageApiToken/ManageApiClientFactory.php
+++ b/libs/api-bundle/src/Security/ManageApiToken/ManageApiClientFactory.php
@@ -10,7 +10,7 @@ class ManageApiClientFactory
 {
     public function __construct(
         private readonly string $appName,
-        private readonly string $storageApiUrl
+        private readonly string $storageApiUrl,
     ) {
     }
 

--- a/libs/api-bundle/src/Security/ManageApiToken/ManageApiTokenAuthenticator.php
+++ b/libs/api-bundle/src/Security/ManageApiToken/ManageApiTokenAuthenticator.php
@@ -51,7 +51,7 @@ class ManageApiTokenAuthenticator implements TokenAuthenticatorInterface
         if (count($missingScopes) > 0) {
             throw new AccessDeniedException(sprintf(
                 'Authentication token is valid but missing following scopes: %s',
-                implode(', ', $missingScopes)
+                implode(', ', $missingScopes),
             ));
         }
     }

--- a/libs/api-bundle/src/Security/StorageApiToken/StorageApiTokenAuthenticator.php
+++ b/libs/api-bundle/src/Security/StorageApiToken/StorageApiTokenAuthenticator.php
@@ -57,7 +57,7 @@ class StorageApiTokenAuthenticator implements TokenAuthenticatorInterface
         if (count($missingFeatures) > 0) {
             throw new AccessDeniedException(sprintf(
                 'Authentication token is valid but missing following features: %s',
-                implode(', ', $missingFeatures)
+                implode(', ', $missingFeatures),
             ));
         }
     }

--- a/libs/api-bundle/src/ServiceClient.php
+++ b/libs/api-bundle/src/ServiceClient.php
@@ -55,7 +55,7 @@ class ServiceClient
     {
         if (($this->hostnameSuffix !== 'north-europe.azure.keboola.com') && ($serviceName === self::BILLING_SERVICE)) {
             throw new ServiceNotFoundException(
-                sprintf('Billing service is not available on stack "%s".', $this->hostnameSuffix)
+                sprintf('Billing service is not available on stack "%s".', $this->hostnameSuffix),
             );
         }
         if (in_array($serviceName, self::KNOWN_SERVICES, true)) {

--- a/libs/api-bundle/src/Util/ControllerReflector.php
+++ b/libs/api-bundle/src/Util/ControllerReflector.php
@@ -11,7 +11,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 class ControllerReflector
 {
     public function __construct(
-        private readonly ContainerInterface $container
+        private readonly ContainerInterface $container,
     ) {
     }
 

--- a/libs/azure-api-client/composer.json
+++ b/libs/azure-api-client/composer.json
@@ -35,7 +35,7 @@
     },
     "require-dev": {
         "infection/infection": "^0.26.18",
-        "keboola/coding-standard": "^14.0",
+        "keboola/coding-standard": "^15.0",
         "phpstan/phpstan": "^1.9",
         "phpstan/phpstan-phpunit": "^1.3",
         "phpstan/phpstan-webmozart-assert": "^1.2",
@@ -51,6 +51,7 @@
             "@infection"
         ],
         "phpcs": "phpcs -n --ignore=vendor,cache,Kernel.php --extensions=php .",
+        "phpcbf": "phpcbf --extensions=php src tests",
         "phpstan": "phpstan analyse --no-progress -c phpstan.neon",
         "tests": [
             "@putenv XDEBUG_MODE=coverage",

--- a/libs/azure-api-client/src/ApiClient.php
+++ b/libs/azure-api-client/src/ApiClient.php
@@ -53,13 +53,13 @@ class ApiClient
         if ($configuration->backoffMaxTries > 0) {
             $this->requestHandlerStack->push(Middleware::retry(new RetryDecider(
                 $configuration->backoffMaxTries,
-                $configuration->logger
+                $configuration->logger,
             )));
         }
 
         $this->requestHandlerStack->push(Middleware::log($configuration->logger, new MessageFormatter(
             '{hostname} {req_header_User-Agent} - [{ts}] "{method} {resource} {protocol}/{version}"' .
-            ' {code} {res_header_Content-Length}'
+            ' {code} {res_header_Content-Length}',
         )));
 
         $this->httpClient = new GuzzleClient([
@@ -150,7 +150,7 @@ class ApiClient
         return new ClientException(
             trim($error['code'] . ': ' . $error['message']),
             $response->getStatusCode(),
-            $e
+            $e,
         );
     }
 }

--- a/libs/azure-api-client/src/Authentication/Authenticator/ClientCredentialsAuth.php
+++ b/libs/azure-api-client/src/Authentication/Authenticator/ClientCredentialsAuth.php
@@ -39,7 +39,7 @@ class ClientCredentialsAuth implements BearerTokenResolver
         if (!$armUrl) {
             $armUrl = self::DEFAULT_ARM_URL;
             $configuration->logger->debug(
-                self::ENV_AZURE_AD_RESOURCE . ' environment variable is not specified, falling back to default.'
+                self::ENV_AZURE_AD_RESOURCE . ' environment variable is not specified, falling back to default.',
             );
         }
 
@@ -47,7 +47,7 @@ class ClientCredentialsAuth implements BearerTokenResolver
         if (!$this->cloudName) {
             $this->cloudName = self::DEFAULT_PUBLIC_CLOUD_NAME;
             $configuration->logger->debug(
-                self::ENV_AZURE_ENVIRONMENT . ' environment variable is not specified, falling back to default.'
+                self::ENV_AZURE_ENVIRONMENT . ' environment variable is not specified, falling back to default.',
             );
         }
 
@@ -69,7 +69,7 @@ class ClientCredentialsAuth implements BearerTokenResolver
         $token = $this->apiClient->sendRequestAndMapResponse(
             $request,
             TokenResponse::class,
-            ['form_params' => $formData]
+            ['form_params' => $formData],
         );
 
         return new AuthenticationToken(
@@ -85,7 +85,7 @@ class ClientCredentialsAuth implements BearerTokenResolver
                 new Request('GET', ''),
                 MetadataResponse::class,
                 [],
-                true
+                true,
             );
         } catch (ClientException $e) {
             throw new ClientException('Failed to get instance metadata: ' . $e->getMessage(), $e->getCode(), $e);

--- a/libs/azure-api-client/src/Authentication/Authenticator/Internal/SystemAuthenticatorResolver.php
+++ b/libs/azure-api-client/src/Authentication/Authenticator/Internal/SystemAuthenticatorResolver.php
@@ -33,7 +33,7 @@ class SystemAuthenticatorResolver implements BearerTokenResolver
         $clientSecret = (string) getenv('AZURE_CLIENT_SECRET');
         if ($tenantId !== '' && $clientId !== '' && $clientSecret !== '') {
             $this->configuration->logger->debug(
-                'Found Azure client credentials in ENV, using ClientCredentialsAuthenticator'
+                'Found Azure client credentials in ENV, using ClientCredentialsAuthenticator',
             );
 
             return new ClientCredentialsAuth(
@@ -45,7 +45,7 @@ class SystemAuthenticatorResolver implements BearerTokenResolver
         }
 
         $this->configuration->logger->debug(
-            'Azure client credentials not found in ENV, using ManagedCredentialsAuthenticator'
+            'Azure client credentials not found in ENV, using ManagedCredentialsAuthenticator',
         );
         return new ManagedCredentialsAuth($this->configuration);
     }

--- a/libs/azure-api-client/src/Authentication/Authenticator/ManagedCredentialsAuth.php
+++ b/libs/azure-api-client/src/Authentication/Authenticator/ManagedCredentialsAuth.php
@@ -38,13 +38,13 @@ class ManagedCredentialsAuth implements BearerTokenResolver
                         'api-version' => self::API_VERSION,
                         'format' => 'text',
                         'resource' => $resource,
-                    ])
+                    ]),
                 ),
                 [
                     'Metadata' => 'true',
                 ],
             ),
-            TokenResponse::class
+            TokenResponse::class,
         );
 
         return new AuthenticationToken(

--- a/libs/azure-api-client/src/Authentication/Authenticator/StaticBearerTokenAuth.php
+++ b/libs/azure-api-client/src/Authentication/Authenticator/StaticBearerTokenAuth.php
@@ -10,7 +10,7 @@ use Keboola\AzureApiClient\Authentication\Authenticator\Internal\BearerTokenReso
 class StaticBearerTokenAuth implements BearerTokenResolver
 {
     public function __construct(
-        private readonly string $token
+        private readonly string $token,
     ) {
     }
 

--- a/libs/azure-api-client/src/Marketplace/MarketplaceApiClient.php
+++ b/libs/azure-api-client/src/Marketplace/MarketplaceApiClient.php
@@ -61,7 +61,7 @@ class MarketplaceApiClient
                 'POST',
                 sprintf(
                     '/api/saas/subscriptions/%s/activate?api-version=2018-08-31',
-                    urlencode($parameters->subscriptionId)
+                    urlencode($parameters->subscriptionId),
                 ),
                 [
                     'Content-Type' => 'application/json',

--- a/libs/azure-api-client/src/RetryDecider.php
+++ b/libs/azure-api-client/src/RetryDecider.php
@@ -24,7 +24,7 @@ class RetryDecider
         int $retries,
         RequestInterface $request,
         ?ResponseInterface $response = null,
-        mixed $error = null
+        mixed $error = null,
     ): bool {
         if ($retries >= $this->maxRetries) {
             return false;
@@ -52,8 +52,8 @@ class RetryDecider
                         default => 'No error',
                     },
                     $retries,
-                    $this->maxRetries
-                )
+                    $this->maxRetries,
+                ),
             );
             return true;
         }

--- a/libs/azure-api-client/tests/ApiClientFunctionalTest.php
+++ b/libs/azure-api-client/tests/ApiClientFunctionalTest.php
@@ -184,7 +184,7 @@ class ApiClientFunctionalTest extends TestCase
 
         $this->expectException(ClientException::class);
         $this->expectExceptionMessage(
-            "GET http://mockserver:1080/foo/bar` resulted in a `400 Bad Request` response:\nGateway timeout"
+            "GET http://mockserver:1080/foo/bar` resulted in a `400 Bad Request` response:\nGateway timeout",
         );
 
         $apiClient->sendRequest(new Request('GET', 'foo/bar'));
@@ -211,7 +211,7 @@ class ApiClientFunctionalTest extends TestCase
         $this->expectExceptionMessage(
             'Failed to map response data: Keboola\AzureApiClient\Tests\DummyTestResponse::__construct(): ' .
             'Argument #1 ($foo) must be of type string, null given, called in ' .
-            '/code/libs/azure-api-client/tests/DummyTestResponse.php on line'
+            '/code/libs/azure-api-client/tests/DummyTestResponse.php on line',
         );
 
         $apiClient->sendRequestAndMapResponse(new Request('GET', 'foo/bar'), DummyTestResponse::class);
@@ -278,7 +278,7 @@ class ApiClientFunctionalTest extends TestCase
         $this->expectException(ClientException::class);
         $this->expectExceptionMessage(
             'Server error: `GET http://mockserver:1080/foo/bar` resulted in a `500 Internal Server Error` response:
-error occurred'
+error occurred',
         );
 
         $apiClient->sendRequest(new Request('GET', 'foo/bar'));

--- a/libs/azure-api-client/tests/ApiClientTest.php
+++ b/libs/azure-api-client/tests/ApiClientTest.php
@@ -51,7 +51,7 @@ class ApiClientTest extends TestCase
     public function testInvalidOptions(
         ?string $baseUrl,
         ?int $backoffMaxTries,
-        string $expectedError
+        string $expectedError,
     ): void {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage($expectedError);
@@ -59,8 +59,8 @@ class ApiClientTest extends TestCase
         new ApiClient(
             $baseUrl, // @phpstan-ignore-line intentionally passing invalid values
             new ApiClientConfiguration(
-                backoffMaxTries: $backoffMaxTries // @phpstan-ignore-line
-            )
+                backoffMaxTries: $backoffMaxTries, // @phpstan-ignore-line
+            ),
         );
     }
 

--- a/libs/azure-api-client/tests/Authentication/Authenticator/ClientCredentialsAuthTest.php
+++ b/libs/azure-api-client/tests/Authentication/Authenticator/ClientCredentialsAuthTest.php
@@ -44,7 +44,7 @@ class ClientCredentialsAuthTest extends TestCase
             'client-secret',
             new ApiClientConfiguration(
                 logger: $this->logger,
-            )
+            ),
         );
         self::assertCount(0, $this->logsHandler->getRecords());
 
@@ -56,13 +56,13 @@ class ClientCredentialsAuthTest extends TestCase
             'client-secret',
             new ApiClientConfiguration(
                 logger: $this->logger,
-            )
+            ),
         );
         self::assertTrue($this->logsHandler->hasDebug(
-            'AZURE_AD_RESOURCE environment variable is not specified, falling back to default.'
+            'AZURE_AD_RESOURCE environment variable is not specified, falling back to default.',
         ));
         self::assertTrue($this->logsHandler->hasDebug(
-            'AZURE_ENVIRONMENT environment variable is not specified, falling back to default.'
+            'AZURE_ENVIRONMENT environment variable is not specified, falling back to default.',
         ));
     }
 
@@ -74,7 +74,7 @@ class ClientCredentialsAuthTest extends TestCase
             new Response(
                 200,
                 ['Content-Type' => 'application/json'],
-                Json::encodeArray($metadata)
+                Json::encodeArray($metadata),
             ),
             new Response(
                 200,
@@ -84,7 +84,7 @@ class ClientCredentialsAuthTest extends TestCase
                     "expires_in": 3599,
                     "resource": "https://vault.azure.net",
                     "access_token": "ey....ey"
-                }'
+                }',
             ),
         ]);
 
@@ -95,7 +95,7 @@ class ClientCredentialsAuthTest extends TestCase
             new ApiClientConfiguration(
                 requestHandler: $requestHandler(...),
                 logger: $this->logger,
-            )
+            ),
         );
 
         $token = $auth->getAuthenticationToken('resource-id');
@@ -106,7 +106,7 @@ class ClientCredentialsAuthTest extends TestCase
         $request = $requestsHistory[0]['request'];
         self::assertSame(
             'https://management.azure.com/metadata/endpoints?api-version=2020-01-01',
-            $request->getUri()->__toString()
+            $request->getUri()->__toString(),
         );
         self::assertSame('GET', $request->getMethod());
 
@@ -116,7 +116,7 @@ class ClientCredentialsAuthTest extends TestCase
         self::assertSame('application/x-www-form-urlencoded', $request->getHeader('Content-type')[0]);
         self::assertSame(
             'grant_type=client_credentials&client_id=client-id&client_secret=client-secret&resource=resource-id',
-            $request->getBody()->getContents()
+            $request->getBody()->getContents(),
         );
     }
 
@@ -133,7 +133,7 @@ class ClientCredentialsAuthTest extends TestCase
             new Response(
                 200,
                 ['Content-Type' => 'application/json'],
-                Json::encodeArray($metadata)
+                Json::encodeArray($metadata),
             ),
             new Response(
                 200,
@@ -143,7 +143,7 @@ class ClientCredentialsAuthTest extends TestCase
                     "expires_in": 3599,
                     "resource": "https://vault.azure.net",
                     "access_token": "ey....ey"
-                }'
+                }',
             ),
         ]);
 
@@ -154,7 +154,7 @@ class ClientCredentialsAuthTest extends TestCase
             new ApiClientConfiguration(
                 requestHandler: $requestHandler(...),
                 logger: $this->logger,
-            )
+            ),
         );
 
         $token = $auth->getAuthenticationToken('resource-id');
@@ -165,7 +165,7 @@ class ClientCredentialsAuthTest extends TestCase
         $request = $requestsHistory[0]['request'];
         self::assertSame(
             'https://example.com',
-            $request->getUri()->__toString()
+            $request->getUri()->__toString(),
         );
         self::assertSame('GET', $request->getMethod());
 
@@ -175,7 +175,7 @@ class ClientCredentialsAuthTest extends TestCase
         self::assertSame('application/x-www-form-urlencoded', $request->getHeader('Content-type')[0]);
         self::assertSame(
             'grant_type=client_credentials&client_id=client-id&client_secret=client-secret&resource=resource-id',
-            $request->getBody()->getContents()
+            $request->getBody()->getContents(),
         );
     }
 
@@ -187,7 +187,7 @@ class ClientCredentialsAuthTest extends TestCase
             new Response(
                 200,
                 ['Content-Type' => 'application/json'],
-                Json::encodeArray($this->getSampleArmMetadata())
+                Json::encodeArray($this->getSampleArmMetadata()),
             ),
         ]);
 
@@ -198,7 +198,7 @@ class ClientCredentialsAuthTest extends TestCase
             new ApiClientConfiguration(
                 requestHandler: $requestHandler(...),
                 logger: $this->logger,
-            )
+            ),
         );
 
         $this->expectException(ClientException::class);
@@ -213,12 +213,12 @@ class ClientCredentialsAuthTest extends TestCase
             new Response(
                 500,
                 ['Content-Type' => 'application/json'],
-                'boo'
+                'boo',
             ),
             new Response(
                 200,
                 ['Content-Type' => 'application/json'],
-                Json::encodeArray($this->getSampleArmMetadata())
+                Json::encodeArray($this->getSampleArmMetadata()),
             ),
             new Response(
                 200,
@@ -228,7 +228,7 @@ class ClientCredentialsAuthTest extends TestCase
                     "expires_in": 3599,
                     "resource": "https://vault.azure.net",
                     "access_token": "ey....ey"
-                }'
+                }',
             ),
         ]);
 
@@ -239,7 +239,7 @@ class ClientCredentialsAuthTest extends TestCase
             new ApiClientConfiguration(
                 requestHandler: $requestHandler(...),
                 logger: $this->logger,
-            )
+            ),
         );
         $token = $auth->getAuthenticationToken('resource-id');
         self::assertEquals('ey....ey', $token->value);
@@ -252,7 +252,7 @@ class ClientCredentialsAuthTest extends TestCase
             new Response(
                 200,
                 ['Content-Type' => 'application/json'],
-                'boo'
+                'boo',
             ),
         ]);
 
@@ -263,7 +263,7 @@ class ClientCredentialsAuthTest extends TestCase
             new ApiClientConfiguration(
                 requestHandler: $requestHandler(...),
                 logger: $this->logger,
-            )
+            ),
         );
 
         $this->expectException(ClientException::class);
@@ -277,12 +277,12 @@ class ClientCredentialsAuthTest extends TestCase
             new Response(
                 200,
                 ['Content-Type' => 'application/json'],
-                Json::encodeArray($this->getSampleArmMetadata())
+                Json::encodeArray($this->getSampleArmMetadata()),
             ),
             new Response(
                 200,
                 ['Content-Type' => 'application/json'],
-                '{"boo":"bar"}'
+                '{"boo":"bar"}',
             ),
         ]);
 
@@ -293,12 +293,12 @@ class ClientCredentialsAuthTest extends TestCase
             new ApiClientConfiguration(
                 requestHandler: $requestHandler(...),
                 logger: $this->logger,
-            )
+            ),
         );
 
         $this->expectException(ClientException::class);
         $this->expectExceptionMessage(
-            'Failed to map response data: Missing or invalid "access_token" in response: {"boo":"bar"}'
+            'Failed to map response data: Missing or invalid "access_token" in response: {"boo":"bar"}',
         );
         $auth->getAuthenticationToken('resource-id');
     }

--- a/libs/azure-api-client/tests/Authentication/Authenticator/Internal/SystemAuthenticatorResolverTest.php
+++ b/libs/azure-api-client/tests/Authentication/Authenticator/Internal/SystemAuthenticatorResolverTest.php
@@ -48,7 +48,7 @@ class SystemAuthenticatorResolverTest extends TestCase
                     "expires_in": 3599,
                     "resource": "https://vault.azure.net",
                     "access_token": "ey....ey"
-                }'
+                }',
             ),
         ]);
 
@@ -66,7 +66,7 @@ class SystemAuthenticatorResolverTest extends TestCase
         self::assertSame('ey....ey', $token->value);
         self::assertEqualsWithDelta(time() + 3599, $token->expiresAt?->getTimestamp(), 1);
         self::assertTrue($this->logsHandler->hasDebug(
-            'Found Azure client credentials in ENV, using ClientCredentialsAuthenticator'
+            'Found Azure client credentials in ENV, using ClientCredentialsAuthenticator',
         ));
     }
 
@@ -81,7 +81,7 @@ class SystemAuthenticatorResolverTest extends TestCase
                     "expires_in": 3599,
                     "resource": "https://vault.azure.net",
                     "access_token": "ey....ey"
-                }'
+                }',
             ),
         ]);
 
@@ -95,7 +95,7 @@ class SystemAuthenticatorResolverTest extends TestCase
         self::assertSame('ey....ey', $token->value);
         self::assertEqualsWithDelta(time() + 3599, $token->expiresAt?->getTimestamp(), 1);
         self::assertTrue($this->logsHandler->hasDebug(
-            'Azure client credentials not found in ENV, using ManagedCredentialsAuthenticator'
+            'Azure client credentials not found in ENV, using ManagedCredentialsAuthenticator',
         ));
     }
 

--- a/libs/azure-api-client/tests/Authentication/Authenticator/ManagedCredentialsAuthTest.php
+++ b/libs/azure-api-client/tests/Authentication/Authenticator/ManagedCredentialsAuthTest.php
@@ -41,7 +41,7 @@ class ManagedCredentialsAuthTest extends TestCase
                     "expires_in": 3599,
                     "resource": "https://vault.azure.net",
                     "access_token": "ey....ey"
-                }'
+                }',
             ),
         ]);
 
@@ -59,7 +59,7 @@ class ManagedCredentialsAuthTest extends TestCase
         self::assertSame(
             // phpcs:ignore Generic.Files.LineLength
             'http://169.254.169.254/metadata/identity/oauth2/token?api-version=2019-11-01&format=text&resource=resource-id',
-            $request->getUri()->__toString()
+            $request->getUri()->__toString(),
         );
         self::assertSame('GET', $request->getMethod());
         self::assertSame('true', $request->getHeader('Metadata')[0]);
@@ -73,7 +73,7 @@ class ManagedCredentialsAuthTest extends TestCase
                 ['Content-Type' => 'application/json'],
                 '{
                     "foo": "bar"
-                }'
+                }',
             ),
         ]);
 
@@ -84,7 +84,7 @@ class ManagedCredentialsAuthTest extends TestCase
 
         $this->expectException(ClientException::class);
         $this->expectExceptionMessage(
-            'Failed to map response data: Missing or invalid "access_token" in response: {"foo":"bar"}'
+            'Failed to map response data: Missing or invalid "access_token" in response: {"foo":"bar"}',
         );
         $auth->getAuthenticationToken('resource-id');
     }

--- a/libs/azure-api-client/tests/Marketplace/MarketplaceApiClientTest.php
+++ b/libs/azure-api-client/tests/Marketplace/MarketplaceApiClientTest.php
@@ -43,7 +43,7 @@ class MarketplaceApiClientTest extends TestCase
             new Response(
                 200,
                 ['Content-Type' => 'application/json'],
-                Json::encodeArray($subscriptionData)
+                Json::encodeArray($subscriptionData),
             ),
         ]);
 
@@ -55,7 +55,7 @@ class MarketplaceApiClientTest extends TestCase
 
         self::assertEquals(
             ResolveSubscriptionResult::fromResponseData($subscriptionData),
-            $result
+            $result,
         );
 
         self::assertCount(1, $requestsHistory);
@@ -87,7 +87,7 @@ class MarketplaceApiClientTest extends TestCase
             new Response(
                 200,
                 ['Content-Type' => 'application/json'],
-                Json::encodeArray($subscriptionData)
+                Json::encodeArray($subscriptionData),
             ),
         ]);
 
@@ -99,7 +99,7 @@ class MarketplaceApiClientTest extends TestCase
 
         self::assertEquals(
             Subscription::fromResponseData($subscriptionData),
-            $result
+            $result,
         );
 
         self::assertCount(1, $requestsHistory);

--- a/libs/azure-api-client/tests/Marketplace/MeteringServiceApiClientTest.php
+++ b/libs/azure-api-client/tests/Marketplace/MeteringServiceApiClientTest.php
@@ -55,7 +55,7 @@ class MeteringServiceApiClientTest extends TestCase
             new Response(
                 200,
                 ['Content-Type' => 'application/json'],
-                Json::encodeArray($apiResponse)
+                Json::encodeArray($apiResponse),
             ),
         ]);
 

--- a/libs/k8s-client/composer.json
+++ b/libs/k8s-client/composer.json
@@ -26,7 +26,7 @@
         "kubernetes/php-client": "^1.20"
     },
     "require-dev": {
-        "keboola/coding-standard": "^14.0",
+        "keboola/coding-standard": "^15.0",
         "phpstan/phpstan": "^1.9",
         "phpstan/phpstan-phpunit": "^1.1",
         "phpunit/phpunit": "^9.5",
@@ -49,6 +49,7 @@
             "@tests"
         ],
         "phpcs": "phpcs -n --ignore=vendor,cache,Kernel.php --extensions=php .",
+        "phpcbf": "phpcbf --extensions=php src tests",
         "phpstan": "phpstan analyse --no-progress -c phpstan.neon",
         "tests": "phpunit"
     }

--- a/libs/k8s-client/src/ApiClient/BaseClusterApiClient.php
+++ b/libs/k8s-client/src/ApiClient/BaseClusterApiClient.php
@@ -28,7 +28,7 @@ abstract class BaseClusterApiClient implements ApiClientInterface
         protected readonly KubernetesApiClient $apiClient,
         protected readonly AbstractAPI $baseApi,
         protected readonly string $listClass,
-        protected readonly string $itemClass
+        protected readonly string $itemClass,
     ) {
     }
 

--- a/libs/k8s-client/src/ApiClient/BaseNamespaceApiClient.php
+++ b/libs/k8s-client/src/ApiClient/BaseNamespaceApiClient.php
@@ -28,7 +28,7 @@ abstract class BaseNamespaceApiClient implements ApiClientInterface
         protected readonly KubernetesApiClient $apiClient,
         protected readonly AbstractAPI $baseApi,
         protected readonly string $listClass,
-        protected readonly string $itemClass
+        protected readonly string $itemClass,
     ) {
     }
 

--- a/libs/k8s-client/src/ApiClient/PodsApiClient.php
+++ b/libs/k8s-client/src/ApiClient/PodsApiClient.php
@@ -43,7 +43,7 @@ class PodsApiClient extends BaseNamespaceApiClient
         if (!is_string($result)) {
             throw new KubernetesResponseException(
                 sprintf('Unexpected response type: %s', get_debug_type($result)),
-                null
+                null,
             );
         }
 

--- a/libs/k8s-client/src/ClientFacadeFactory/GenericClientFacadeFactory.php
+++ b/libs/k8s-client/src/ClientFacadeFactory/GenericClientFacadeFactory.php
@@ -32,12 +32,12 @@ class GenericClientFacadeFactory
         string $apiUrl,
         string $token,
         string $caCertFile,
-        string $namespace
+        string $namespace,
     ): KubernetesApiClientFacade {
         if (!is_file($caCertFile) || !is_readable($caCertFile)) {
             throw new ConfigurationException(sprintf(
                 'Invalid K8S CA cert path "%s". File does not exist or can\'t be read.',
-                $caCertFile
+                $caCertFile,
             ));
         }
 
@@ -50,7 +50,7 @@ class GenericClientFacadeFactory
             [
                 'connect_timeout' => '30',
                 'timeout' => '60',
-            ]
+            ],
         );
 
         $apiClient = new KubernetesApiClient($this->retryProxy, $namespace);

--- a/libs/k8s-client/src/ClientFacadeFactory/InClusterClientFacadeFactory.php
+++ b/libs/k8s-client/src/ClientFacadeFactory/InClusterClientFacadeFactory.php
@@ -17,7 +17,7 @@ class InClusterClientFacadeFactory
 
     public function __construct(
         GenericClientFacadeFactory $genericFactory,
-        string $credentialsPath = self::IN_CLUSTER_AUTH_PATH
+        string $credentialsPath = self::IN_CLUSTER_AUTH_PATH,
     ) {
         $this->genericFactory = $genericFactory;
         $this->credentialsPath = $credentialsPath;

--- a/libs/k8s-client/src/KubernetesApiClient.php
+++ b/libs/k8s-client/src/KubernetesApiClient.php
@@ -70,7 +70,7 @@ class KubernetesApiClient
             if ($result instanceof Status && $result->code >= 500) {
                 throw new KubernetesResponseException(
                     sprintf('K8S request has failed: %s', $result->message),
-                    $result
+                    $result,
                 );
             }
 
@@ -110,7 +110,7 @@ class KubernetesApiClient
                 $method,
                 get_debug_type($result),
             ),
-            null
+            null,
         );
     }
 }

--- a/libs/k8s-client/src/KubernetesApiClientFacade.php
+++ b/libs/k8s-client/src/KubernetesApiClientFacade.php
@@ -121,7 +121,7 @@ class KubernetesApiClientFacade
             fn($resource) => $this->getApiForResource($resource::class)->delete(
                 $resource->metadata->name,
                 $deleteOptions,
-                $queries
+                $queries,
             ),
             $resources,
         );
@@ -248,7 +248,7 @@ class KubernetesApiClientFacade
 
             default => throw new RuntimeException(sprintf(
                 'Unknown K8S resource type "%s"',
-                get_debug_type($resourceType)
+                get_debug_type($resourceType),
             )),
         };
     }

--- a/libs/k8s-client/src/RetryProxyFactory.php
+++ b/libs/k8s-client/src/RetryProxyFactory.php
@@ -32,9 +32,9 @@ class RetryProxyFactory
             new ExponentialBackOffPolicy(
                 self::KUBERNETES_INITIAL_DELAY_MS,
                 self::RETRY_MULTIPLIER,
-                self::KUBERNETES_MAX_DELAY_MS
+                self::KUBERNETES_MAX_DELAY_MS,
             ),
-            $this->logger
+            $this->logger,
         );
     }
 }

--- a/libs/k8s-client/tests/ApiClient/BaseNamespaceApiClientTestCase.php
+++ b/libs/k8s-client/tests/ApiClient/BaseNamespaceApiClientTestCase.php
@@ -72,7 +72,7 @@ trait BaseNamespaceApiClientTestCase
                 'gracePeriodSeconds' => 0,
                 'propagationPolicy' => 'Foreground',
             ]),
-            $queries
+            $queries,
         );
 
         while ($startTime + $timeout > microtime(true)) {
@@ -140,9 +140,9 @@ trait BaseNamespaceApiClientTestCase
         $this->assertResultItems(
             array_merge(
                 $originalItemNames,
-                ['test-resource-1', 'test-resource-2']
+                ['test-resource-1', 'test-resource-2'],
             ),
-            $result->items
+            $result->items,
         );
 
         // list using labelSelector
@@ -152,13 +152,13 @@ trait BaseNamespaceApiClientTestCase
                 [
                     'app=test-1',
                     sprintf('%s=%s', self::getTestResourcesLabelName(), (string) getenv('K8S_NAMESPACE')),
-                ]
+                ],
             ),
         ]);
         self::assertCount(1, $result->items);
         self::assertSame(
             ['test-resource-1'],
-            array_map(fn($resource) => $resource->metadata->name, $result->items)
+            array_map(fn($resource) => $resource->metadata->name, $result->items),
         );
     }
 
@@ -295,7 +295,7 @@ trait BaseNamespaceApiClientTestCase
                 [
                     'app=test-1',
                     sprintf('%s=%s', self::getTestResourcesLabelName(), (string) getenv('K8S_NAMESPACE')),
-                ]
+                ],
             ),
         ]);
 

--- a/libs/k8s-client/tests/ApiClient/ConfigMapsApiClientFunctionalTest.php
+++ b/libs/k8s-client/tests/ApiClient/ConfigMapsApiClientFunctionalTest.php
@@ -21,7 +21,7 @@ class ConfigMapsApiClientFunctionalTest extends TestCase
         parent::setUp();
         $this->setUpBaseNamespaceApiClientTest(
             ConfigMapsApi::class,
-            ConfigMapsApiClient::class
+            ConfigMapsApiClient::class,
         );
     }
 

--- a/libs/k8s-client/tests/ApiClient/EventsApiClientTest.php
+++ b/libs/k8s-client/tests/ApiClient/EventsApiClientTest.php
@@ -17,7 +17,7 @@ class EventsApiClientTest extends TestCase
     {
         Client::configure(
             'dummy',
-            []
+            [],
         );
 
         $k8sClientMock = $this->createMock(KubernetesApiClient::class);
@@ -27,7 +27,7 @@ class EventsApiClientTest extends TestCase
                 $this->isInstanceOf(EventsApi::class),
                 'listForAllNamespaces',
                 EventList::class,
-                ['fieldSelector' => 'involvedObject.kind=ConfigMap']
+                ['fieldSelector' => 'involvedObject.kind=ConfigMap'],
             )
             ->willReturn(new EventList())
         ;

--- a/libs/k8s-client/tests/ApiClient/SecretsApiClientFunctionalTest.php
+++ b/libs/k8s-client/tests/ApiClient/SecretsApiClientFunctionalTest.php
@@ -21,7 +21,7 @@ class SecretsApiClientFunctionalTest extends TestCase
         parent::setUp();
         $this->setUpBaseNamespaceApiClientTest(
             SecretsApi::class,
-            SecretsApiClient::class
+            SecretsApiClient::class,
         );
     }
 

--- a/libs/k8s-client/tests/KubernetesApiClientFacadeFunctionalTest.php
+++ b/libs/k8s-client/tests/KubernetesApiClientFacadeFunctionalTest.php
@@ -35,7 +35,7 @@ class KubernetesApiClientFacadeFunctionalTest extends TestCase
 
         $this->apiClient = (new GenericClientFacadeFactory(
             (new RetryProxyFactory($logger))->createRetryProxy(),
-            $logger
+            $logger,
         ))->createClusterClient(
             (string) getenv('K8S_HOST'),
             (string) getenv('K8S_TOKEN'),
@@ -64,10 +64,10 @@ class KubernetesApiClientFacadeFunctionalTest extends TestCase
                         [
                             'kube-root-ca.crt', // secret automatically created by K8S
                             'k8s-client', // service account used by the client
-                        ]
-                    )
+                        ],
+                    ),
                 ),
-            ]
+            ],
         );
     }
 

--- a/libs/k8s-client/tests/KubernetesApiClientTest.php
+++ b/libs/k8s-client/tests/KubernetesApiClientTest.php
@@ -24,7 +24,7 @@ class KubernetesApiClientTest extends TestCase
     {
         $client = new KubernetesApiClient(
             $this->createMock(RetryProxy::class),
-            self::TEST_NAMESPACE
+            self::TEST_NAMESPACE,
         );
 
         self::assertSame(self::TEST_NAMESPACE, $client->getK8sNamespace());
@@ -34,7 +34,7 @@ class KubernetesApiClientTest extends TestCase
     {
         $client = new KubernetesApiClient(
             $this->createRetryProxyMock(),
-            self::TEST_NAMESPACE
+            self::TEST_NAMESPACE,
         );
 
         $event = new Event(['name' => 'test-event']);
@@ -51,7 +51,7 @@ class KubernetesApiClientTest extends TestCase
             'read',
             Event::class,
             self::TEST_NAMESPACE,
-            'event-name'
+            'event-name',
         );
 
         self::assertSame($event, $result);
@@ -131,11 +131,11 @@ class KubernetesApiClientTest extends TestCase
         array $methodArguments,
         Status $status,
         string $expectedErrorMessage,
-        string $expectetErrorClassName
+        string $expectetErrorClassName,
     ): void {
         $client = new KubernetesApiClient(
             $this->createRetryProxyMock(),
-            self::TEST_NAMESPACE
+            self::TEST_NAMESPACE,
         );
 
         $eventsApiMock = $this->createMock(EventsApi::class);
@@ -150,7 +150,7 @@ class KubernetesApiClientTest extends TestCase
                 $eventsApiMock,
                 $method,
                 EventList::class,
-                ...$methodArguments
+                ...$methodArguments,
             );
 
             $this->fail('Cluster request should throw KubernetesResponseException');
@@ -165,7 +165,7 @@ class KubernetesApiClientTest extends TestCase
     {
         $client = new KubernetesApiClient(
             $this->createRetryProxyMock(),
-            self::TEST_NAMESPACE
+            self::TEST_NAMESPACE,
         );
 
         $resultMock = $this->createMock(EventList::class);
@@ -183,7 +183,7 @@ class KubernetesApiClientTest extends TestCase
                 'read',
                 Event::class,
                 self::TEST_NAMESPACE,
-                'event-name'
+                'event-name',
             );
 
             $this->fail('Cluster request should throw KubernetesResponseException');
@@ -194,9 +194,9 @@ class KubernetesApiClientTest extends TestCase
                     'Expected response class %s for request %s::read, found %s',
                     Event::class,
                     get_class($eventsApiMock),
-                    get_debug_type($resultMock)
+                    get_debug_type($resultMock),
                 ),
-                $e->getMessage()
+                $e->getMessage(),
             );
         }
     }
@@ -234,7 +234,7 @@ class KubernetesApiClientTest extends TestCase
                 Event::class,
                 self::TEST_NAMESPACE,
                 'dummy-name',
-                ['test']
+                ['test'],
             )
         ;
 
@@ -243,7 +243,7 @@ class KubernetesApiClientTest extends TestCase
             'read',
             Event::class,
             'dummy-name',
-            ['test']
+            ['test'],
         );
     }
 }

--- a/libs/logging-bundle/composer.json
+++ b/libs/logging-bundle/composer.json
@@ -8,7 +8,7 @@
         "symfony/monolog-bundle": "^3.8"
     },
     "require-dev": {
-        "keboola/coding-standard": "^14.0",
+        "keboola/coding-standard": "^15.0",
         "phpstan/phpstan": "^1.8",
         "phpstan/phpstan-phpunit": "^1.1",
         "phpunit/phpunit": "^9.5",

--- a/libs/logging-bundle/tests/KeboolaLoggingBundleFunctionalTest.php
+++ b/libs/logging-bundle/tests/KeboolaLoggingBundleFunctionalTest.php
@@ -19,7 +19,7 @@ class KeboolaLoggingBundleFunctionalTest extends KernelTestCase
 
         $datadogProcessors = array_filter(
             $logger->getProcessors(),
-            fn (callable $processor) => $processor instanceof DataDogContextProcessor
+            fn (callable $processor) => $processor instanceof DataDogContextProcessor,
         );
         self::assertCount(1, $datadogProcessors);
     }

--- a/libs/permission-checker/composer.json
+++ b/libs/permission-checker/composer.json
@@ -31,7 +31,7 @@
     },
     "require-dev": {
         "infection/infection": "^0.27.0",
-        "keboola/coding-standard": "^14.0",
+        "keboola/coding-standard": "^15.0",
         "keboola/storage-api-php-client-branch-wrapper": "^5.1",
         "phpstan/phpstan": "^1.9",
         "phpstan/phpstan-phpunit": "^1.1",
@@ -57,6 +57,7 @@
             "@infection"
         ],
         "phpcs": "phpcs -n --ignore=vendor,cache,Kernel.php --extensions=php .",
+        "phpcbf": "phpcbf --extensions=php src tests",
         "phpstan": "phpstan analyse --no-progress -c phpstan.neon",
         "phpunit": [
             "@putenv XDEBUG_MODE=coverage",

--- a/libs/permission-checker/src/Check/RunnerSyncApi/CanResolveConfigVariables.php
+++ b/libs/permission-checker/src/Check/RunnerSyncApi/CanResolveConfigVariables.php
@@ -21,7 +21,7 @@ class CanResolveConfigVariables implements PermissionCheckInterface
             if (!$token->hasAllowedComponent($componentId)) {
                 throw new PermissionDeniedException(sprintf(
                     'You do not have permission to read configurations of "%s" component',
-                    $componentId
+                    $componentId,
                 ));
             }
         }

--- a/libs/permission-checker/src/Check/Scheduler/CanModifySchedules.php
+++ b/libs/permission-checker/src/Check/Scheduler/CanModifySchedules.php
@@ -32,7 +32,7 @@ class CanModifySchedules implements PermissionCheckInterface
             if (!$isAllowed) {
                 throw new PermissionDeniedException(sprintf(
                     'Role "%s" is insufficient for this operation.',
-                    $role->value
+                    $role->value,
                 ));
             }
         }
@@ -48,7 +48,7 @@ class CanModifySchedules implements PermissionCheckInterface
         if (!$isAllowed) {
             throw new PermissionDeniedException(sprintf(
                 'Role "%s" is insufficient for this operation.',
-                $role->value
+                $role->value,
             ));
         }
     }

--- a/libs/permission-checker/src/StorageApiToken.php
+++ b/libs/permission-checker/src/StorageApiToken.php
@@ -64,11 +64,11 @@ class StorageApiToken
                 function (string $value) {
                     return TokenPermission::tryFrom($value);
                 },
-                $this->permissions
+                $this->permissions,
             ),
             function (?TokenPermission $permission) {
                 return $permission !== null;
-            }
+            },
         );
     }
 

--- a/libs/permission-checker/tests/Check/JobQueue/CanRunJobTest.php
+++ b/libs/permission-checker/tests/Check/JobQueue/CanRunJobTest.php
@@ -29,7 +29,7 @@ class CanRunJobTest extends TestCase
             'componentId' => 'keboola.component',
             'token' => new StorageApiToken(
                 features: ['queuev2'],
-                allowedComponents: ['keboola.component']
+                allowedComponents: ['keboola.component'],
             ),
         ];
 
@@ -161,7 +161,7 @@ class CanRunJobTest extends TestCase
                 features: ['queuev2', 'protected-default-branch'],
             ),
             'error' => new PermissionDeniedException(
-                'Role "none" without "canCreateJobs" permission is not allowed to run jobs on default branch'
+                'Role "none" without "canCreateJobs" permission is not allowed to run jobs on default branch',
             ),
         ];
 
@@ -172,7 +172,7 @@ class CanRunJobTest extends TestCase
                 features: ['queuev2', 'protected-default-branch'],
             ),
             'error' => new PermissionDeniedException(
-                'Role "none" without "canCreateJobs" permission is not allowed to run jobs on dev branch'
+                'Role "none" without "canCreateJobs" permission is not allowed to run jobs on dev branch',
             ),
         ];
 

--- a/libs/permission-checker/tests/Check/RunnerSyncApi/CanResolveConfigVariablesTest.php
+++ b/libs/permission-checker/tests/Check/RunnerSyncApi/CanResolveConfigVariablesTest.php
@@ -20,7 +20,7 @@ class CanResolveConfigVariablesTest extends TestCase
             allowedComponents: [
                 'keboola.shared-code',
                 'keboola.variables',
-            ]
+            ],
         );
 
         $checker = new CanResolveConfigVariables();

--- a/libs/permission-checker/tests/Check/RunnerSyncApi/CanRunActionTest.php
+++ b/libs/permission-checker/tests/Check/RunnerSyncApi/CanRunActionTest.php
@@ -28,7 +28,7 @@ class CanRunActionTest extends TestCase
     public function testPermissionCheckForTokensWithoutPermissionToComponent(BranchType $branchType): void
     {
         $token = new StorageApiToken(
-            allowedComponents: []
+            allowedComponents: [],
         );
 
         $this->expectException(PermissionDeniedException::class);
@@ -45,7 +45,7 @@ class CanRunActionTest extends TestCase
     {
         $token = new StorageApiToken(
             role: Role::READ_ONLY->value,
-            allowedComponents: ['dummy-component']
+            allowedComponents: ['dummy-component'],
         );
 
         $this->expectException(PermissionDeniedException::class);
@@ -68,7 +68,7 @@ class CanRunActionTest extends TestCase
                     'expectedErrorMessage' => sprintf(
                         'Role "%s" is not allowed to run actions on %s branch',
                         $role->value,
-                        $branchType->value
+                        $branchType->value,
                     ),
                 ];
             }
@@ -84,7 +84,7 @@ class CanRunActionTest extends TestCase
 
         $token = new StorageApiToken(
             role: $role !== Role::NONE ? $role->value : null,
-            allowedComponents: ['dummy-component']
+            allowedComponents: ['dummy-component'],
         );
 
         $checker = new CanRunAction($branchType, 'dummy-component');
@@ -111,7 +111,7 @@ class CanRunActionTest extends TestCase
                     'expectedErrorMessage' => sprintf(
                         'Role "%s" is not allowed to run actions on %s branch',
                         $role->value,
-                        $branchType->value
+                        $branchType->value,
                     ),
                 ];
             }
@@ -124,12 +124,12 @@ class CanRunActionTest extends TestCase
     public function testPermissionCheckFailOnSoxProjects(
         Role $role,
         BranchType $branchType,
-        string $expectedErrorMessage
+        string $expectedErrorMessage,
     ): void {
         $token = new StorageApiToken(
             features: [Feature::PROTECTED_DEFAULT_BRANCH->value],
             role: $role !== Role::NONE ? $role->value : null,
-            allowedComponents: ['dummy-component']
+            allowedComponents: ['dummy-component'],
         );
 
         $this->expectException(PermissionDeniedException::class);
@@ -165,7 +165,7 @@ class CanRunActionTest extends TestCase
         $token = new StorageApiToken(
             features: [Feature::PROTECTED_DEFAULT_BRANCH->value],
             role: $role !== Role::NONE ? $role->value : null,
-            allowedComponents: ['dummy-component']
+            allowedComponents: ['dummy-component'],
         );
 
         $checker = new CanRunAction($branchType, 'dummy-component');

--- a/libs/permission-checker/tests/Check/Scheduler/CanModifySchedulesTest.php
+++ b/libs/permission-checker/tests/Check/Scheduler/CanModifySchedulesTest.php
@@ -47,7 +47,7 @@ class CanModifySchedulesTest extends TestCase
     /** @dataProvider provideValidPermissionsCheckData */
     public function testValidPermissionsCheck(
         StorageApiToken $token,
-        ?BranchType $branchType
+        ?BranchType $branchType,
     ): void {
         $this->expectNotToPerformAssertions();
 

--- a/libs/vault-api-client/composer.json
+++ b/libs/vault-api-client/composer.json
@@ -35,7 +35,7 @@
     },
     "require-dev": {
         "infection/infection": "^0.27",
-        "keboola/coding-standard": "^14.0",
+        "keboola/coding-standard": "^15.0",
         "phpstan/phpstan": "^1.10",
         "phpstan/phpstan-phpunit": "^1.3",
         "phpstan/phpstan-webmozart-assert": "^1.2",
@@ -52,6 +52,7 @@
             "@infection"
         ],
         "phpcs": "phpcs -n --ignore=vendor,cache,Kernel.php --extensions=php .",
+        "phpcbf": "phpcbf --extensions=php src tests",
         "phpstan": "phpstan analyse --no-progress -c phpstan.neon",
         "phpunit": [
             "@putenv XDEBUG_MODE=coverage",

--- a/libs/vault-api-client/src/ApiClient.php
+++ b/libs/vault-api-client/src/ApiClient.php
@@ -44,13 +44,13 @@ class ApiClient
         if ($configuration->backoffMaxTries > 0) {
             $this->requestHandlerStack->push(Middleware::retry(new RetryDecider(
                 $configuration->backoffMaxTries,
-                $configuration->logger
+                $configuration->logger,
             )));
         }
 
         $this->requestHandlerStack->push(Middleware::log($configuration->logger, new MessageFormatter(
             '{hostname} {req_header_User-Agent} - [{ts}] "{method} {resource} {protocol}/{version}"' .
-            ' {code} {res_header_Content-Length}'
+            ' {code} {res_header_Content-Length}',
         )));
 
         $userAgent = self::USER_AGENT;
@@ -136,7 +136,7 @@ class ApiClient
         return new ClientException(
             trim($data['code'] . ': ' . $data['error']),
             $response->getStatusCode(),
-            $e
+            $e,
         );
     }
 }

--- a/libs/vault-api-client/src/RetryDecider.php
+++ b/libs/vault-api-client/src/RetryDecider.php
@@ -22,7 +22,7 @@ class RetryDecider
         int $retries,
         RequestInterface $request,
         ?ResponseInterface $response = null,
-        mixed $error = null
+        mixed $error = null,
     ): bool {
         if ($retries >= $this->maxRetries) {
             return false;
@@ -50,8 +50,8 @@ class RetryDecider
                         default => 'No error',
                     },
                     $retries,
-                    $this->maxRetries
-                )
+                    $this->maxRetries,
+                ),
             );
             return true;
         }

--- a/libs/vault-api-client/src/Variables/VariablesApiClient.php
+++ b/libs/vault-api-client/src/Variables/VariablesApiClient.php
@@ -49,7 +49,7 @@ class VariablesApiClient
                     'value' => $value,
                     'flags' => $flags,
                     'attributes' => $attributes,
-                ])
+                ]),
             ),
             Variable::class,
         );

--- a/libs/vault-api-client/tests/ApiClientTest.php
+++ b/libs/vault-api-client/tests/ApiClientTest.php
@@ -62,7 +62,7 @@ class ApiClientTest extends TestCase
         string $baseUrl,
         string $token,
         ?int $backoffMaxTries,
-        string $expectedError
+        string $expectedError,
     ): void {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage($expectedError);
@@ -71,8 +71,8 @@ class ApiClientTest extends TestCase
             $baseUrl,
             $token,
             new ApiClientConfiguration(
-                backoffMaxTries: $backoffMaxTries // @phpstan-ignore-line
-            )
+                backoffMaxTries: $backoffMaxTries, // @phpstan-ignore-line
+            ),
         );
     }
 
@@ -127,8 +127,8 @@ class ApiClientTest extends TestCase
             self::BASE_URL,
             self::API_TOKEN,
             new ApiClientConfiguration(
-                requestHandler: $requestHandler(...)
-            )
+                requestHandler: $requestHandler(...),
+            ),
         );
         $apiClient->sendRequest(new Request('DELETE', 'foo/bar'));
 
@@ -159,8 +159,8 @@ class ApiClientTest extends TestCase
             self::BASE_URL,
             self::API_TOKEN,
             new ApiClientConfiguration(
-                requestHandler: $requestHandler(...)
-            )
+                requestHandler: $requestHandler(...),
+            ),
         );
         $result = $apiClient->sendRequestAndMapResponse(
             new Request('GET', 'foo/bar'),
@@ -197,8 +197,8 @@ class ApiClientTest extends TestCase
             self::BASE_URL,
             self::API_TOKEN,
             new ApiClientConfiguration(
-                requestHandler: $requestHandler(...)
-            )
+                requestHandler: $requestHandler(...),
+            ),
         );
 
         $this->expectException(ClientException::class);
@@ -223,13 +223,13 @@ class ApiClientTest extends TestCase
             self::BASE_URL,
             self::API_TOKEN,
             new ApiClientConfiguration(
-                requestHandler: $requestHandler(...)
-            )
+                requestHandler: $requestHandler(...),
+            ),
         );
 
         $this->expectException(ClientException::class);
         $this->expectExceptionMessage(
-            'Client error: `DELETE https://vault.keboola.com/foo/bar` resulted in a `400 Bad Request` response'
+            'Client error: `DELETE https://vault.keboola.com/foo/bar` resulted in a `400 Bad Request` response',
         );
 
         $apiClient->sendRequest(new Request('DELETE', 'foo/bar'));
@@ -252,8 +252,8 @@ class ApiClientTest extends TestCase
             self::BASE_URL,
             self::API_TOKEN,
             new ApiClientConfiguration(
-                requestHandler: $requestHandler(...)
-            )
+                requestHandler: $requestHandler(...),
+            ),
         );
 
         $apiClient->sendRequest(new Request('DELETE', 'foo/bar'));
@@ -300,8 +300,8 @@ class ApiClientTest extends TestCase
             self::API_TOKEN,
             new ApiClientConfiguration(
                 backoffMaxTries: 2,
-                requestHandler: $requestHandler(...)
-            )
+                requestHandler: $requestHandler(...),
+            ),
         );
 
         $this->expectException(ClientException::class);
@@ -330,8 +330,8 @@ class ApiClientTest extends TestCase
             self::API_TOKEN,
             new ApiClientConfiguration(
                 backoffMaxTries: 0,
-                requestHandler: $requestHandler(...)
-            )
+                requestHandler: $requestHandler(...),
+            ),
         );
 
         $this->expectException(ClientException::class);
@@ -351,7 +351,7 @@ class ApiClientTest extends TestCase
             new Response(
                 200,
                 ['Content-Type' => 'application/json'],
-                '{"foo":'
+                '{"foo":',
             ),
         ]);
 
@@ -359,8 +359,8 @@ class ApiClientTest extends TestCase
             self::BASE_URL,
             self::API_TOKEN,
             new ApiClientConfiguration(
-                requestHandler: $requestHandler(...)
-            )
+                requestHandler: $requestHandler(...),
+            ),
         );
 
         $this->expectException(ClientException::class);

--- a/libs/vault-api-client/tests/Variables/VariablesApiClientTest.php
+++ b/libs/vault-api-client/tests/Variables/VariablesApiClientTest.php
@@ -36,7 +36,7 @@ class VariablesApiClientTest extends TestCase
                     'attributes' => [
                         'branchId' => '123',
                     ],
-                ])
+                ]),
             ),
         ]);
 
@@ -127,7 +127,7 @@ class VariablesApiClientTest extends TestCase
                 Json::encodeArray([
                     ['hash' => 'hash1', 'key' => 'key1', 'value' => 'val1', 'flags' => [], 'attributes' => []],
                     ['hash' => 'hash2', 'key' => 'key2', 'value' => 'val2', 'flags' => [], 'attributes' => []],
-                ])
+                ]),
             ),
         ]);
 
@@ -186,7 +186,7 @@ class VariablesApiClientTest extends TestCase
                 Json::encodeArray([
                     ['hash' => 'hash1', 'key' => 'key1', 'value' => 'val1', 'flags' => [], 'attributes' => []],
                     ['hash' => 'hash2', 'key' => 'key2', 'value' => 'val2', 'flags' => [], 'attributes' => []],
-                ])
+                ]),
             ),
         ]);
 


### PR DESCRIPTION
Failnul mi build v mainu: https://github.com/keboola/platform-libraries/runs/19642996038

V keboola codestyle jsme meli neplatnou konfiguraci nekterych pravidel. PHPCS driv jen vypisoval warning, nova verze hazi error. 
Je potreba updatnout vsechno kde to jeste neni na fixnuty KB CS 

 