### PR TITLE
[api-bundle] Fix support for multiple auth attributes on single controller

### DIFF
--- a/libs/api-bundle/README.md
+++ b/libs/api-bundle/README.md
@@ -1,15 +1,33 @@
 # Keboola API Bundle
 Symfony bundle providing common functionality for Keboola API applications.
 
-Features:
-* authentication using Storage and Manage API tokens
-
 ## Installation
 Install the package with Composer:
 ```shell
 composer require keboola/api-bundle
 ```
 
+## Configuration
+The bundle expects having `%app_name%` parameter defined in your Symfony configuration.
+
+### Default configuration
+```yaml
+keboola_api:
+  app_name: '%app_name%'           # application name to use in user agent
+  default_service_dns_type: public # default service DNS type to use in ServiceClient, can be 'public' or 'private'
+```
+
+## Features
+### Preconfigured ServiceClient
+The bundle provides a preconfigured `ServiceClient` that can be used to resolve Keboola API URLs. By default, it is
+configured to use public hostnames, but it can be reconfigured to use internal ones.
+
+```yaml
+keboola_api:
+  default_service_dns_type: internal
+```
+
+### Controller authentication using attributes
 To use authentication using attributes, configure firewall to use the `keboola.api_bundle.security.attribute_authenticator`:
 ```yaml 
 security:
@@ -21,16 +39,55 @@ security:
           - keboola.api_bundle.security.attribute_authenticator
 ```
 
-## Configuration
-The default configuration is:
+Then add any combination of authentication attributes to your controller:
+```php
+use Keboola\ApiBundle\Attribute\StorageApiTokenAuth;
+use Keboola\ApiBundle\Security\StorageApiToken\SecurityApiToken;
+use Symfony\Component\Security\Http\Attribute\CurrentUser;
 
-```yaml
-keboola_api:
-  app_name: '%app_name%'             # application name to use in user agent
-  default_service_dns_type: 'public' # default service DNS type to use in ServiceClient, can be 'public' or 'private'
+#[StorageApiTokenAuth]
+class Controller {
+  public function __invoke(#[CurrentUser] StorageApiToken $token) 
+  {
+    // only requests with valid X-StorageApi-Token will be allowed
+  }
+}
+
+#[StorageApiTokenAuth(features: ['feat-a', 'feat-b'])]
+class Controller {
+  public function __invoke(#[CurrentUser] StorageApiToken $token) 
+  {
+    // only requests with valid X-StorageApi-Token and project features 'feat-a' AND 'feat-b' is allowed
+  }
+}
+
+#[StorageApiTokenAuth(features: ['feat-a'])]
+#[StorageApiTokenAuth(features: ['feat-b'])]
+class Controller {
+  public function __invoke(#[CurrentUser] StorageApiToken $token) 
+  {
+    // only requests with valid X-StorageApi-Token and any of project features 'feat-a' OR 'feat-b' ise allowed
+  }
+}
+
+#[ManageApiTokenAuth(scopes: ['something:manage'])]
+#[StorageApiTokenAuth]
+class Controller {
+  public function __invoke(
+    string $entityId,
+    #[CurrentUser] TokenInterface $token,
+  ) {
+    // allows request with either valid X-KBC-ManageApiToken with 'something:manage' scope OR any valid X-StorageApi-Token
+    // but with additional checks in controller
+    $entity = $this->fetchEntity($entityId);
+    if ($token instanceof StorageApiToken && $token->getProjectId() !== $entity->getProjectId()) {
+      throw new AccessDeniedHttpException('...');
+    }
+  }
+}
 ```
 
-Authentication attributes are configured automatically based on API clients installed:
+To use individual authentication attributes, you need to install appropriate client package:
 * to use `StorageApiTokenAuth`, install `keboola/storage-api-client`
 * to use `ManageApiTokenAuth`, install `keboola/kbc-manage-api-php-client`
 

--- a/libs/api-bundle/tests/Security/AttributeAuthenticatorTest.php
+++ b/libs/api-bundle/tests/Security/AttributeAuthenticatorTest.php
@@ -1,0 +1,377 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Keboola\ApiBundle\Tests\Security;
+
+use Keboola\ApiBundle\Attribute\ManageApiTokenAuth;
+use Keboola\ApiBundle\Attribute\StorageApiTokenAuth;
+use Keboola\ApiBundle\Security\AttributeAuthenticator;
+use Keboola\ApiBundle\Security\TokenAuthenticatorInterface;
+use Keboola\ApiBundle\Security\TokenInterface;
+use Keboola\ApiBundle\Util\ControllerReflector;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\DependencyInjection\Container;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Security\Core\Exception\AccessDeniedException;
+use Symfony\Component\Security\Core\Exception\AuthenticationException;
+use Symfony\Component\Security\Core\Exception\CustomUserMessageAuthenticationException;
+
+// disable some PHPCS rules to make the anonymous controller class more readable
+// phpcs:disable Squiz.Functions.MultiLineFunctionDeclaration.BraceOnSameLine
+// phpcs:disable Squiz.WhiteSpace.ScopeClosingBrace.ContentBefore
+// phpcs:disable Generic.WhiteSpace.ScopeIndent.IncorrectExact
+class AttributeAuthenticatorTest extends TestCase
+{
+    public static function provideSupportsRequestTestData(): iterable
+    {
+        yield 'no auth attribute' => [
+            'controller' => new
+                class {
+                    public function __invoke(): void {}
+                },
+            'supports' => false,
+        ];
+
+        yield 'single auth attribute' => [
+            'controller' => new
+                #[StorageApiTokenAuth(['foo-feature'])]
+                class {
+                    public function __invoke(): void {}
+                },
+            'supports' => true,
+        ];
+
+        yield 'multiple auth attributes' => [
+            'controller' => new
+                #[StorageApiTokenAuth(['foo-feature'])]
+                #[ManageApiTokenAuth(['bar-feature'])]
+                class {
+                    public function __invoke(): void {}
+                },
+            'supports' => true,
+        ];
+    }
+
+    /** @dataProvider provideSupportsRequestTestData */
+    public function testSupportsRequest(object $controller, bool $supports): void
+    {
+        $authenticators = [];
+
+        $request = $this->createControllerRequest($controller, []);
+
+        $authenticator = $this->createAuthenticator($controller, $authenticators);
+        $this->assertSame($supports, $authenticator->supports($request));
+    }
+
+    public function testAuthenticateRequest(): void
+    {
+        $controller = new
+            #[StorageApiTokenAuth(['foo-feature'])]
+            class {
+                public function __invoke(): void {}
+            };
+
+        $request = $this->createControllerRequest($controller, [
+            'X-Auth-Token' => 'token',
+        ]);
+
+        $token = $this->createToken('user-id');
+
+        $authenticator = $this->createAuthenticator(
+            $controller,
+            [
+                StorageApiTokenAuth::class => $this->createSuccessAuthenticator($token),
+            ],
+        );
+        $passport = $authenticator->authenticate($request);
+
+        self::assertSame($token, $passport->getUser());
+    }
+
+    public function testAuthenticateRequestWithNoTokenHeader(): void
+    {
+        $controller = new
+            #[StorageApiTokenAuth(['foo-feature'])]
+            class {
+                public function __invoke(): void {}
+            };
+
+        $request = $this->createControllerRequest($controller, []);
+
+        $token = $this->createToken('user-id');
+
+        $tokenAuthenticator = $this->createMock(TokenAuthenticatorInterface::class);
+        $tokenAuthenticator->expects(self::once())
+            ->method('getTokenHeader')
+            ->willReturn('X-Auth-Token')
+        ;
+
+        $authenticator = $this->createAuthenticator(
+            $controller,
+            [
+                StorageApiTokenAuth::class => $tokenAuthenticator,
+            ],
+        );
+
+        $this->expectException(CustomUserMessageAuthenticationException::class);
+        $this->expectExceptionMessage('Authentication header "X-Auth-Token" is missing');
+
+        $authenticator->authenticate($request);
+    }
+
+    public function testAuthenticateRequestWithFailingAuthentication(): void
+    {
+        $controller = new
+            #[StorageApiTokenAuth(['foo-feature'])]
+            class {
+                public function __invoke(): void {}
+            };
+
+        $request = $this->createControllerRequest($controller, [
+            'X-Auth-Token' => 'token',
+        ]);
+
+        $authenticator = $this->createAuthenticator(
+            $controller,
+            [
+                StorageApiTokenAuth::class => $this->createAuthenticatorWithFailingAuthentication('X-Auth-Token'),
+            ],
+        );
+
+        $this->expectException(AuthenticationException::class);
+        $this->expectExceptionMessage('Token is not valid');
+
+        $authenticator->authenticate($request);
+    }
+
+    public function testAuthenticateRequestWithFailingAuthorization(): void
+    {
+        $controller = new
+            #[StorageApiTokenAuth(['foo-feature'])]
+            class {
+                public function __invoke(): void {}
+            };
+
+        $request = $this->createControllerRequest($controller, [
+            'X-Auth-Token' => 'token',
+        ]);
+
+        $token = $this->createToken('user-id');
+
+        $authenticator = $this->createAuthenticator(
+            $controller,
+            [
+                StorageApiTokenAuth::class => $this->createAuthenticatorWithFailingAuthorization(
+                    'X-Auth-Token',
+                    $token,
+                ),
+            ],
+        );
+
+        $this->expectException(CustomUserMessageAuthenticationException::class);
+        $this->expectExceptionMessage('Token is not authorized');
+
+        $authenticator->authenticate($request);
+    }
+
+    public function testAuthenticateRequestWithMultipleDifferentAuthenticatorsWithDifferentTokenHeader(): void
+    {
+        $controller = new
+            #[ManageApiTokenAuth]
+            #[StorageApiTokenAuth]
+            class {
+                public function __invoke(): void {}
+            };
+
+        $request = $this->createControllerRequest($controller, [
+            'X-Auth-Token' => 'token',
+        ]);
+
+        $token = $this->createToken('user-id');
+
+        $failingAuthenticator = $this->createMock(TokenAuthenticatorInterface::class);
+        $failingAuthenticator->expects(self::once())
+            ->method('getTokenHeader')
+            ->willReturn('X-Other-Token')
+        ;
+
+        $authenticator = $this->createAuthenticator(
+            $controller,
+            [
+                ManageApiTokenAuth::class => $failingAuthenticator,
+                StorageApiTokenAuth::class => $this->createSuccessAuthenticator($token),
+            ],
+        );
+        $passport = $authenticator->authenticate($request);
+
+        self::assertSame($token, $passport->getUser());
+    }
+
+    public function testAuthenticateRequestWithMultipleDifferentAuthenticatorsWithFailingAuthentication(): void
+    {
+        $controller = new
+            #[ManageApiTokenAuth]
+            #[StorageApiTokenAuth]
+            class {
+                public function __invoke(): void {}
+            };
+
+        $request = $this->createControllerRequest($controller, [
+            'X-Other-Token' => 'other-token',
+            'X-Auth-Token' => 'token',
+        ]);
+
+        $token = $this->createToken('user-id');
+
+        $authenticator = $this->createAuthenticator(
+            $controller,
+            [
+                ManageApiTokenAuth::class => $this->createAuthenticatorWithFailingAuthentication('X-Other-Token'),
+                StorageApiTokenAuth::class => $this->createSuccessAuthenticator($token),
+            ],
+        );
+        $passport = $authenticator->authenticate($request);
+
+        self::assertSame($token, $passport->getUser());
+    }
+
+    public function testAuthenticateRequestWithMultipleDifferentAuthenticatorsWithFailingAuthorization(): void
+    {
+        $controller = new
+            #[ManageApiTokenAuth]
+            #[StorageApiTokenAuth]
+            class {
+                public function __invoke(): void {}
+            };
+
+        $request = $this->createControllerRequest($controller, [
+            'X-Other-Token' => 'other-token',
+            'X-Auth-Token' => 'token',
+        ]);
+
+        $otherToken = $this->createToken('other-user-id');
+        $token = $this->createToken('user-id');
+
+        $authenticator = $this->createAuthenticator(
+            $controller,
+            [
+                ManageApiTokenAuth::class => $this->createAuthenticatorWithFailingAuthorization(
+                    'X-Other-Token',
+                    $otherToken,
+                ),
+                StorageApiTokenAuth::class => $this->createSuccessAuthenticator($token),
+            ],
+        );
+        $passport = $authenticator->authenticate($request);
+
+        self::assertSame($token, $passport->getUser());
+    }
+
+    private function createAuthenticator(object $controller, array $authenticators): AttributeAuthenticator
+    {
+        $controllersContainer = new Container();
+        $controllersContainer->set(get_class($controller), $controller);
+
+        $authenticatorsContainer = new Container();
+        foreach ($authenticators as $attribute => $authenticator) {
+            $authenticatorsContainer->set($attribute, $authenticator);
+        }
+
+        return new AttributeAuthenticator(
+            new ControllerReflector($controllersContainer),
+            $authenticatorsContainer,
+        );
+    }
+
+    private function createControllerRequest(object $controller, array $authHeaders): Request
+    {
+        $request = new Request();
+        $request->attributes->set('_controller', get_class($controller));
+        $request->headers->replace($authHeaders);
+
+        return $request;
+    }
+
+    private function createToken(string $userIdentifier): TokenInterface
+    {
+        $token = $this->createMock(TokenInterface::class);
+        $token->method('getUserIdentifier')->willReturn($userIdentifier);
+
+        return $token;
+    }
+
+    /**
+     * @return TokenAuthenticatorInterface<TokenInterface>
+     */
+    private function createSuccessAuthenticator(TokenInterface $token): TokenAuthenticatorInterface
+    {
+        $authenticator = $this->createMock(TokenAuthenticatorInterface::class);
+        $authenticator->expects(self::once())
+            ->method('getTokenHeader')
+            ->willReturn('X-Auth-Token')
+        ;
+
+        $authenticator->expects(self::once())
+            ->method('authenticateToken')
+            ->with(
+                $this->isInstanceOf(StorageApiTokenAuth::class),
+                'token',
+            )
+            ->willReturn($token)
+        ;
+
+        $authenticator->expects(self::once())
+            ->method('authorizeToken')
+            ->with(
+                $this->isInstanceOf(StorageApiTokenAuth::class),
+                $token,
+            )
+        ;
+
+        return $authenticator;
+    }
+
+    /**
+     * @return TokenAuthenticatorInterface<TokenInterface>
+     */
+    private function createAuthenticatorWithFailingAuthentication(string $tokenHeader): TokenAuthenticatorInterface
+    {
+        $authenticator = $this->createMock(TokenAuthenticatorInterface::class);
+        $authenticator->expects(self::once())
+            ->method('getTokenHeader')
+            ->willReturn($tokenHeader)
+        ;
+        $authenticator->expects(self::once())
+            ->method('authenticateToken')
+            ->willThrowException(new AuthenticationException('Token is not valid'))
+        ;
+        $authenticator->expects(self::never())->method('authorizeToken');
+
+        return $authenticator;
+    }
+
+    /**
+     * @return TokenAuthenticatorInterface<TokenInterface>
+     */
+    private function createAuthenticatorWithFailingAuthorization(
+        string $tokenHeader,
+        TokenInterface $authenticatedToken,
+    ): TokenAuthenticatorInterface {
+        $authenticator = $this->createMock(TokenAuthenticatorInterface::class);
+        $authenticator->expects(self::once())
+            ->method('getTokenHeader')
+            ->willReturn($tokenHeader)
+        ;
+        $authenticator->expects(self::once())
+            ->method('authenticateToken')
+            ->willReturn($authenticatedToken)
+        ;
+        $authenticator->expects(self::once())
+            ->method('authorizeToken')
+            ->willThrowException(new AccessDeniedException('Token is not authorized'))
+        ;
+
+        return $authenticator;
+    }
+}


### PR DESCRIPTION
Opravuje podporu vice auth attributu na jednom controlleru. `AttributeAuthenticator` na to byl od zacatku designovany, ale evidentne jsem to zapomnel otestovat :facepalm:

```
#[StorageApiTokenAuth(features: ['feat-a'])]
#[StorageApiTokenAuth(isAdmin: true)] // tohle realne nemame implementovany, ale tak pro ilustraci
class Controller {
  public function __invoke() {
    // povoli token, ktery ma `feat-a` NEBO je admin token
  }
}

#[ManageApiTokenAuth(scopes: ['something:manage'])]
#[StorageApiTokenAuth]
class Controller {
  public function __invoke(
    string $entityId,
    #[CurrentUser] TokenInterface $token,
  ) {
    // povoli manage token se scope `something:manage` NEBO libovolny storage token a controller si pak muze doresit detaily
    $entity = $this->fetchEntity($entityId);
    if ($token instanceof StorageApiToken && $token->getProjectId() !== $entity->getProjectId()) {
      throw new AccessDeniedHttpException('...');
    }
  }
}
class Controller {
}
```

Ten test mi dal trosku zabrat, protoze attributy nejdou snadno mockovat (nastetsi jdou aspon nahodit na anonymni class) a neslo pouzit data providery (protoze v data provideru nejde vytvorit mock/nastavit expectation), tak jsem to musel obratit, udelat separatni test cases a udelat si nejaky helpery na setup testu.