### PR TITLE
[api-bundle] Allow setting `default_service_dns_type` using ENV vars

### DIFF
--- a/libs/api-bundle/README.md
+++ b/libs/api-bundle/README.md
@@ -27,6 +27,19 @@ keboola_api:
   default_service_dns_type: internal
 ```
 
+#### Using ENV variables
+
+If you need to use ENV variable to configure the `default_service_dns_type`, make sure you provide some default value,
+otherwise the validation will fail with error `The value "" is not allowed for path "keboola_api.default_service_dns_type".`
+
+```yaml
+parameters:
+  env(API_DNS_TYPE): internal
+
+keboola_api:
+  default_service_dns_type: '%env(API_DNS_TYPE)%'
+```
+
 ### Controller authentication using attributes
 To use authentication using attributes, configure firewall to use the `keboola.api_bundle.security.attribute_authenticator`:
 ```yaml 

--- a/libs/api-bundle/src/DependencyInjection/KeboolaApiExtension.php
+++ b/libs/api-bundle/src/DependencyInjection/KeboolaApiExtension.php
@@ -31,6 +31,10 @@ class KeboolaApiExtension extends Extension
 
         $config['app_name'] = $container->resolveEnvPlaceholders($config['app_name'], true);
 
+        $defaultServiceDnsType = $container->resolveEnvPlaceholders($config['default_service_dns_type'], true);
+        assert(is_string($defaultServiceDnsType) || $defaultServiceDnsType instanceof ServiceDnsType);
+        $container->setParameter('keboola_api_bundle.default_service_dns_type', $defaultServiceDnsType);
+
         $authenticators = [];
         $this->setupStorageApiAuthenticator($container, $authenticators);
         $this->setupManageApiAuthenticator($container, $config, $authenticators);
@@ -40,8 +44,6 @@ class KeboolaApiExtension extends Extension
                 $authenticators,
             ])
         ;
-
-        $this->setupServiceClient($container, $config);
     }
 
     private function setupStorageApiAuthenticator(ContainerBuilder $container, array &$authenticators): void
@@ -77,12 +79,5 @@ class KeboolaApiExtension extends Extension
         ;
 
         $authenticators[ManageApiTokenAuth::class] = new Reference(ManageApiTokenAuthenticator::class);
-    }
-
-    private function setupServiceClient(ContainerBuilder $container, array $config): void
-    {
-        $container->getDefinition(ServiceClient::class)
-            ->setArgument('$defaultDnsType', ServiceDnsType::from($config['default_service_dns_type']))
-        ;
     }
 }

--- a/libs/api-bundle/src/Resources/config/api_bundle.php
+++ b/libs/api-bundle/src/Resources/config/api_bundle.php
@@ -8,8 +8,8 @@ use Keboola\PermissionChecker\PermissionChecker;
 use Keboola\ServiceClient\ServiceClient;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 use Symfony\Component\DependencyInjection\ServiceLocator;
-use function Symfony\Component\DependencyInjection\Loader\Configurator\abstract_arg;
 use function Symfony\Component\DependencyInjection\Loader\Configurator\env;
+use function Symfony\Component\DependencyInjection\Loader\Configurator\param;
 use function Symfony\Component\DependencyInjection\Loader\Configurator\service;
 
 return static function (ContainerConfigurator $container): void {
@@ -33,7 +33,7 @@ return static function (ContainerConfigurator $container): void {
 
         ->set(ServiceClient::class)
             ->arg('$hostnameSuffix', env('HOSTNAME_SUFFIX'))
-            ->arg('$defaultDnsType', abstract_arg('should be configured by extension'))
+            ->arg('$defaultDnsType', param('keboola_api_bundle.default_service_dns_type'))
         ->alias('keboola.api_bundle.service_client', ServiceClient::class)
     ;
 };


### PR DESCRIPTION
Podpora ENV variables v configu neni bohuzel v Symfony uplne idealni a obcas vyzaduje nejake workaroundy. Tady byly nakonec 2 moznosti jak vyresit, aby `default_service_dns_type` sel nastavit pres ENV:
* odebrat z configu `cannotBeEmpty`
* vzdycky poskytnout nejakou validni default hodnotu

Pokud bysme povolili prazdnou hodnotu, musel by se pro to upravit konstruktor `ServiceClient`, coz mi neprislo spravny, protoze neco, co jde zvalidovat uz pri startu appky by se validovalo az za behu. Takze jsem radeji sel druhou cestou a zdokumentoval, ze pri pouziti ENV je potreba poskytnout default.