### PR TITLE
[api-bundle] Allow requiring admin token or specific role on Storage token

### DIFF
--- a/libs/api-bundle/src/Attribute/StorageApiTokenAuth.php
+++ b/libs/api-bundle/src/Attribute/StorageApiTokenAuth.php
@@ -5,12 +5,28 @@ declare(strict_types=1);
 namespace Keboola\ApiBundle\Attribute;
 
 use Attribute;
+use InvalidArgumentException;
 
 #[Attribute(Attribute::TARGET_CLASS | Attribute::TARGET_METHOD | Attribute::IS_REPEATABLE)]
 class StorageApiTokenAuth implements AuthAttributeInterface
 {
+    /**
+     * @param array $features Require project to have all these features
+     * @param null|bool $isAdmin If set to true, token must be admin, if set to false, token must not be admin
+     * @param null|int-mask-of<StorageApiTokenRole::ROLE_*> $role Require token to have role matching the mash
+     *     * StorageApiTokenRole::ROLE_ADMIN - token must have "admin" role
+     *     * StorageApiTokenRole::ROLE_ADMIN | StorageApiTokenRole::ROLE_GUEST - token must have "admin" OR "guest" role
+     *     * StorageApiTokenRole::ROLE_ANY & ~StorageApiTokenRole::ROLE_READ_ONLY - token must not have "readonly" role
+     */
     public function __construct(
         public readonly array $features = [],
+        public readonly ?bool $isAdmin = null,
+        public readonly ?int $role = null,
     ) {
+        if ($this->role !== null && $this->isAdmin === false) {
+            throw new InvalidArgumentException(
+                'Invalid combination of role AND isAdmin=false. Only admin tokens has roles',
+            );
+        }
     }
 }

--- a/libs/api-bundle/src/Attribute/StorageApiTokenRole.php
+++ b/libs/api-bundle/src/Attribute/StorageApiTokenRole.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Keboola\ApiBundle\Attribute;
+
+class StorageApiTokenRole
+{
+    public const ROLE_ADMIN = 1;
+    public const ROLE_GUEST = 2;
+    public const ROLE_READ_ONLY = 4;
+    public const ROLE_SHARE = 8;
+    public const ROLE_DEVELOPER = 16;
+    public const ROLE_REVIEWER = 32;
+    public const ROLE_PRODUCTION_MANAGER = 64;
+
+    public const ANY =
+        self::ROLE_ADMIN |
+        self::ROLE_GUEST |
+        self::ROLE_READ_ONLY |
+        self::ROLE_SHARE |
+        self::ROLE_DEVELOPER |
+        self::ROLE_REVIEWER |
+        self::ROLE_PRODUCTION_MANAGER
+    ;
+
+    private const MAP = [
+        'admin' => self::ROLE_ADMIN,
+        'guest' => self::ROLE_GUEST,
+        'readonly' => self::ROLE_READ_ONLY,
+        'share' => self::ROLE_SHARE,
+        'developer' => self::ROLE_DEVELOPER,
+        'reviewer' => self::ROLE_REVIEWER,
+        'production-manager' => self::ROLE_PRODUCTION_MANAGER,
+    ];
+
+    public static function rolesToMask(array $roles): int
+    {
+        return array_reduce(
+            $roles,
+            fn(int $sum, string $role) => $sum + (self::MAP[$role] ?? 0),
+            0,
+        );
+    }
+
+    public static function maskToRoles(int $sum): array
+    {
+        $roles = [];
+        foreach (self::MAP as $role => $value) {
+            if (($sum & $value) === $value) {
+                $roles[] = $role;
+            }
+        }
+
+        return $roles;
+    }
+}

--- a/libs/api-bundle/tests/Attribute/StorageApiTokenAuthTest.php
+++ b/libs/api-bundle/tests/Attribute/StorageApiTokenAuthTest.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Keboola\ApiBundle\Tests\Attribute;
+
+use InvalidArgumentException;
+use Keboola\ApiBundle\Attribute\StorageApiTokenAuth;
+use PHPUnit\Framework\TestCase;
+
+class StorageApiTokenAuthTest extends TestCase
+{
+    public function testInvalidNonAdminTokenWithRoleFails(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid combination of role AND isAdmin=false. Only admin tokens has roles');
+
+        new StorageApiTokenAuth(isAdmin: false, role: 1);
+    }
+}

--- a/libs/api-bundle/tests/Attribute/StorageApiTokenRoleTest.php
+++ b/libs/api-bundle/tests/Attribute/StorageApiTokenRoleTest.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Keboola\ApiBundle\Tests\Attribute;
+
+use Keboola\ApiBundle\Attribute\StorageApiTokenRole;
+use PHPUnit\Framework\TestCase;
+
+class StorageApiTokenRoleTest extends TestCase
+{
+    private const ALL_KNOWN_ROLES = [
+        'admin',
+        'guest',
+        'readonly',
+        'share',
+        'developer',
+        'reviewer',
+        'production-manager',
+    ];
+
+    public function provideRolesMasks(): iterable
+    {
+        yield 'no role' => [
+            'mask' => 0,
+            'roles' => [],
+        ];
+
+        yield 'single role' => [
+            'mask' => StorageApiTokenRole::ROLE_ADMIN,
+            'roles' => ['admin'],
+        ];
+
+        yield 'multiple roles' => [
+            'mask' => StorageApiTokenRole::ROLE_ADMIN | StorageApiTokenRole::ROLE_DEVELOPER,
+            'roles' => ['admin', 'developer'],
+        ];
+
+        yield 'any role' => [
+            'mask' => StorageApiTokenRole::ANY,
+            'roles' => self::ALL_KNOWN_ROLES,
+        ];
+
+        yield 'any role except one' => [
+            'mask' => StorageApiTokenRole::ANY & ~StorageApiTokenRole::ROLE_ADMIN,
+            'roles' => array_diff(self::ALL_KNOWN_ROLES, ['admin']),
+        ];
+
+        yield 'any role except some' => [
+            'mask' => StorageApiTokenRole::ANY & ~StorageApiTokenRole::ROLE_ADMIN & ~StorageApiTokenRole::ROLE_GUEST,
+            'roles' => array_diff(self::ALL_KNOWN_ROLES, ['admin', 'guest']),
+        ];
+    }
+
+    /** @dataProvider provideRolesMasks */
+    public function testRolesToMask(int $mask, array $roles): void
+    {
+        self::assertSame($mask, StorageApiTokenRole::rolesToMask($roles));
+    }
+
+    /** @dataProvider provideRolesMasks */
+    public function testMaskToRoles(int $mask, array $roles): void
+    {
+        self::assertSame(array_values($roles), StorageApiTokenRole::maskToRoles($mask));
+    }
+
+    public function testInvalidRoleToMask(): void
+    {
+        self::assertSame(0, StorageApiTokenRole::rolesToMask(['invalid']));
+    }
+}


### PR DESCRIPTION
Podpora pro check, ze Storage token je admin token nebo ma konkretni roli.

Pro https://github.com/keboola/sandboxes-service/pull/168 je teoreticky potreba jen ten `isAdmin` check, ale nejak jsem zacal s tim, ze chces checkovat `admin` roli a az pozdeji mi doslo, ze vlastne staci asi jen obecne admin token (neni admin jako admin :slightly_smiling_face:)

Check na role jsem udelal jako bit-mask, protoze vim, ze obcas delame i negativni check (nesmi byt `readonly` atp.). Jen aby to hezky prochazelo PHPstanem, je to takovy dost ukecany.