### PR TITLE
Remove storage-api-client lock on v14.16

### DIFF
--- a/libs/input-mapping/composer.json
+++ b/libs/input-mapping/composer.json
@@ -13,7 +13,7 @@
         "php": ">=8.1",
         "ext-json": "*",
         "keboola/php-file-storage-utils": "^0.2",
-        "keboola/storage-api-client": "14.16.*",
+        "keboola/storage-api-client": "^14.18",
         "keboola/storage-api-php-client-branch-wrapper": "^5.0.1",
         "symfony/config": "^5.4|^6.0",
         "symfony/finder": "^5.4|^6.0",

--- a/libs/output-mapping/composer.json
+++ b/libs/output-mapping/composer.json
@@ -33,7 +33,7 @@
         "keboola/php-file-storage-utils": "^0.2",
         "keboola/sanitizer": "^0.1",
         "keboola/slicer": "*@dev",
-        "keboola/storage-api-client": "14.16.*",
+        "keboola/storage-api-client": "^14.18",
         "keboola/storage-api-php-client-branch-wrapper": "^5.1",
         "microsoft/azure-storage-blob": "^1.5",
         "monolog/monolog": "^1.25.5|^2.0",


### PR DESCRIPTION
Remove temporary workaround for publish pipeline

(Rollback of this issue: https://keboolaglobal.slack.com/archives/C055HSMKX51/p1712323408026709?thread_ts=1712322947.986839&cid=C055HSMKX51)