### PR TITLE
PST-1629 Add support for job queue internal API

### DIFF
--- a/libs/service-client/src/Service.php
+++ b/libs/service-client/src/Service.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Keboola\ServiceClient;
 
+use RuntimeException;
+
 enum Service
 {
     case AI;
@@ -15,6 +17,7 @@ enum Service
     case NOTIFICATION;
     case OAUTH;
     case QUEUE;
+    case QUEUE_INTERNAL_API;
     case SANDBOXES_API;
     case SANDBOXES_SERVICE;
     case SCHEDULER;
@@ -34,6 +37,7 @@ enum Service
             self::NOTIFICATION => 'notification',
             self::OAUTH => 'oauth',
             self::QUEUE => 'queue',
+            self::QUEUE_INTERNAL_API => throw new RuntimeException('Job queue internal API does not have public DNS'),
             self::SANDBOXES_API => 'sandboxes',
             self::SANDBOXES_SERVICE => 'data-science',
             self::SCHEDULER => 'scheduler',
@@ -55,6 +59,7 @@ enum Service
             self::NOTIFICATION => 'notification-api.default',
             self::OAUTH => 'oauth-api.default',
             self::QUEUE => 'job-queue-api.default',
+            self::QUEUE_INTERNAL_API => 'job-queue-internal-api.default',
             self::SANDBOXES_API => 'sandboxes-api.sandboxes',
             self::SANDBOXES_SERVICE => 'sandboxes-service-api.default',
             self::SCHEDULER => 'scheduler-api.default',

--- a/libs/service-client/src/ServiceClient.php
+++ b/libs/service-client/src/ServiceClient.php
@@ -142,6 +142,14 @@ class ServiceClient
     /**
      * @return non-empty-string
      */
+    public function getQueueInternalApiUrl(?ServiceDnsType $dnsType = null): string
+    {
+        return $this->getServiceUrl(Service::QUEUE_INTERNAL_API, $dnsType);
+    }
+
+    /**
+     * @return non-empty-string
+     */
     public function getTemplatesUrl(?ServiceDnsType $dnsType = null): string
     {
         return $this->getServiceUrl(Service::TEMPLATES, $dnsType);

--- a/libs/service-client/tests/ServiceClientTest.php
+++ b/libs/service-client/tests/ServiceClientTest.php
@@ -7,6 +7,7 @@ namespace Keboola\ServiceClient\Tests;
 use Keboola\ServiceClient\ServiceClient;
 use Keboola\ServiceClient\ServiceDnsType;
 use PHPUnit\Framework\TestCase;
+use RuntimeException;
 
 class ServiceClientTest extends TestCase
 {
@@ -36,6 +37,7 @@ class ServiceClientTest extends TestCase
     private const INTERNAL_NOTIFICATION_SERVICE = 'http://notification-api.default.svc.cluster.local';
     private const INTERNAL_OAUTH = 'http://oauth-api.default.svc.cluster.local';
     private const INTERNAL_QUEUE = 'http://job-queue-api.default.svc.cluster.local';
+    private const INTERNAL_QUEUE_INTERNAL_API = 'http://job-queue-internal-api.default.svc.cluster.local';
     private const INTERNAL_SANDBOXES_SERVICE = 'http://sandboxes-api.sandboxes.svc.cluster.local';
     private const INTERNAL_SCHEDULER_SERVICE = 'http://scheduler-api.default.svc.cluster.local';
     private const INTERNAL_SYNC_ACTIONS_SERVICE = 'http://runner-sync-api.default.svc.cluster.local';
@@ -85,6 +87,27 @@ class ServiceClientTest extends TestCase
         self::assertSame(self::PUBLIC_VAULT, $client->getVaultUrl());
     }
 
+    public function testGetExplicitPublicUrlOfServiceWithoutPublicDns(): void
+    {
+        // configure for default INTERNAL dns and test that PUBLIC is properly passed from the method
+        $client = new ServiceClient('north-europe.azure.keboola.com', ServiceDnsType::INTERNAL);
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Job queue internal API does not have public DNS');
+
+        $client->getQueueInternalApiUrl(ServiceDnsType::PUBLIC);
+    }
+
+    public function testGetDefaultPublicUrlOfServiceWithoutPublicDns(): void
+    {
+        $client = new ServiceClient('north-europe.azure.keboola.com', ServiceDnsType::PUBLIC);
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Job queue internal API does not have public DNS');
+
+        $client->getQueueInternalApiUrl();
+    }
+
     public function testGetExplicitInternalUrlMethods(): void
     {
         // configure for default PUBLIC dns and test that INTERNAL is properly passed from the method
@@ -101,6 +124,7 @@ class ServiceClientTest extends TestCase
         self::assertSame(self::INTERNAL_NOTIFICATION_SERVICE, $client->getNotificationServiceUrl(ServiceDnsType::INTERNAL));
         self::assertSame(self::INTERNAL_OAUTH, $client->getOauthUrl(ServiceDnsType::INTERNAL));
         self::assertSame(self::INTERNAL_QUEUE, $client->getQueueUrl(ServiceDnsType::INTERNAL));
+        self::assertSame(self::INTERNAL_QUEUE_INTERNAL_API, $client->getQueueInternalApiUrl(ServiceDnsType::INTERNAL));
         self::assertSame(self::INTERNAL_SANDBOXES_SERVICE, $client->getSandboxesApiUrl(ServiceDnsType::INTERNAL));
         self::assertSame(self::INTERNAL_SCHEDULER_SERVICE, $client->getSchedulerServiceUrl(ServiceDnsType::INTERNAL));
         self::assertSame(self::INTERNAL_SYNC_ACTIONS_SERVICE, $client->getSyncActionsServiceUrl(ServiceDnsType::INTERNAL));
@@ -123,6 +147,7 @@ class ServiceClientTest extends TestCase
         self::assertSame(self::INTERNAL_NOTIFICATION_SERVICE, $client->getNotificationServiceUrl());
         self::assertSame(self::INTERNAL_OAUTH, $client->getOauthUrl());
         self::assertSame(self::INTERNAL_QUEUE, $client->getQueueUrl());
+        self::assertSame(self::INTERNAL_QUEUE_INTERNAL_API, $client->getQueueInternalApiUrl());
         self::assertSame(self::INTERNAL_SANDBOXES_SERVICE, $client->getSandboxesApiUrl());
         self::assertSame(self::INTERNAL_SCHEDULER_SERVICE, $client->getSchedulerServiceUrl());
         self::assertSame(self::INTERNAL_SYNC_ACTIONS_SERVICE, $client->getSyncActionsServiceUrl());

--- a/libs/service-client/tests/ServiceTest.php
+++ b/libs/service-client/tests/ServiceTest.php
@@ -6,6 +6,7 @@ namespace Keboola\ServiceClient\Tests;
 
 use Keboola\ServiceClient\Service;
 use PHPUnit\Framework\TestCase;
+use RuntimeException;
 
 class ServiceTest extends TestCase
 {
@@ -32,6 +33,22 @@ class ServiceTest extends TestCase
         self::assertSame($expectedValue, $service->getPublicSubdomain());
     }
 
+    public function provideServicesWithoutPublicDns(): iterable
+    {
+        yield 'queue internal api' => [Service::QUEUE_INTERNAL_API, 'Job queue internal API does not have public DNS'];
+    }
+
+    /** @dataProvider provideServicesWithoutPublicDns */
+    public function testGetPublicSubdomainThrowsExceptionForServiceWithoutPublicDns(
+        Service $service,
+        string $expectedError,
+    ): void {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage($expectedError);
+
+        $service->getPublicSubdomain();
+    }
+
     public function provideInternalServiceNames(): iterable
     {
         yield 'ai' => [Service::AI, 'ai-service-api.default'];
@@ -44,6 +61,7 @@ class ServiceTest extends TestCase
         yield 'notification' => [Service::NOTIFICATION, 'notification-api.default'];
         yield 'oauth' => [Service::OAUTH, 'oauth-api.default'];
         yield 'queue' => [Service::QUEUE, 'job-queue-api.default'];
+        yield 'queue internal api' => [Service::QUEUE_INTERNAL_API, 'job-queue-internal-api.default'];
         yield 'sandboxes' => [Service::SANDBOXES_API, 'sandboxes-api.sandboxes']; // <-- custom namespace
         yield 'scheduler' => [Service::SCHEDULER, 'scheduler-api.default'];
         yield 'sync-actions' => [Service::SYNC_ACTIONS, 'runner-sync-api.default'];


### PR DESCRIPTION
https://keboola.atlassian.net/browse/PST-1629

Pridani podpory pro Job Queue Internal API.

K8S service je v `default` namespace, jmenuje se `job-queue-internal-api`, public DNS to nema.
![image](https://github.com/keboola/platform-libraries/assets/271753/76fb6e50-d6f2-40ba-a0b8-1f0b99dc2df5)
