### PR TITLE
[api-bundle] Add option to allow permissive types

### DIFF
--- a/libs/api-bundle/src/RequestMapper/ArgumentResolver.php
+++ b/libs/api-bundle/src/RequestMapper/ArgumentResolver.php
@@ -119,6 +119,7 @@ class ArgumentResolver implements ValueResolverInterface
             Response::HTTP_BAD_REQUEST,
             enableFlexibleCasting: true,
             enableExtraKeys: $attribute->allowExtraKeys,
+            allowPermissiveTypes: $attribute->allowPermissiveTypes,
         );
     }
 }

--- a/libs/api-bundle/src/RequestMapper/Attribute/RequestQueryObject.php
+++ b/libs/api-bundle/src/RequestMapper/Attribute/RequestQueryObject.php
@@ -11,6 +11,7 @@ class RequestQueryObject implements RequestMapperAttributeInterface
 {
     public function __construct(
         public readonly bool $allowExtraKeys = true,
+        public readonly bool $allowPermissiveTypes = false,
     ) {
     }
 }

--- a/libs/api-bundle/src/RequestMapper/DataMapper.php
+++ b/libs/api-bundle/src/RequestMapper/DataMapper.php
@@ -33,6 +33,7 @@ class DataMapper
         int $errorCode,
         bool $enableFlexibleCasting = false,
         bool $enableExtraKeys = false,
+        bool $allowPermissiveTypes = false,
     ): object {
         $mapperBuilder = $this->mapperBuilder;
         if ($enableFlexibleCasting) {
@@ -40,6 +41,9 @@ class DataMapper
         }
         if ($enableExtraKeys) {
             $mapperBuilder = $mapperBuilder->allowSuperfluousKeys();
+        }
+        if ($allowPermissiveTypes) {
+            $mapperBuilder = $mapperBuilder->allowPermissiveTypes();
         }
 
         try {

--- a/libs/api-bundle/tests/RequestMapper/ArgumentResolverTest.php
+++ b/libs/api-bundle/tests/RequestMapper/ArgumentResolverTest.php
@@ -223,6 +223,7 @@ class ArgumentResolverTest extends TestCase
                 }
             },
             'extraKeysEnabled' => true,
+            'allowPermissiveTypes' => false,
         ];
 
         yield 'disallow extra keys' => [
@@ -233,12 +234,27 @@ class ArgumentResolverTest extends TestCase
                 }
             },
             'extraKeysEnabled' => false,
+            'allowPermissiveTypes' => false,
+        ];
+
+        yield 'allow permissive types' => [
+            'controller' => new class {
+                public function __invoke(
+                    #[RequestQueryObject(allowPermissiveTypes: true)] RequestData $data,
+                ): void {
+                }
+            },
+            'extraKeysEnabled' => true,
+            'allowPermissiveTypes' => true,
         ];
     }
 
     /** @dataProvider provideValidQueryAttributesTestData */
-    public function testValidQueryRequest(object $controller, bool $extraKeysEnabled): void
-    {
+    public function testValidQueryRequest(
+        object $controller,
+        bool $extraKeysEnabled,
+        bool $allowPermissiveTypes,
+    ): void {
         $request = new Request(
             query: [
                 'foo' => 'bar',
@@ -257,6 +273,7 @@ class ArgumentResolverTest extends TestCase
                 Response::HTTP_BAD_REQUEST,
                 true,
                 $extraKeysEnabled,
+                $allowPermissiveTypes,
             )
             ->willReturn($data)
         ;


### PR DESCRIPTION
Potřebujeme možnost povolit volnější typování kvůli internal api a např. mappingu string|array, kdy se může předávat jen scalar.