### PR TITLE
Hints tables - fix nullable if column has primary key

### DIFF
--- a/libs/output-mapping/src/Writer/Table/TableHintsConfigurationSchemaResolver.php
+++ b/libs/output-mapping/src/Writer/Table/TableHintsConfigurationSchemaResolver.php
@@ -41,6 +41,9 @@ class TableHintsConfigurationSchemaResolver
                 $item['metadata']['KBC.datatype.distribution_key'] = $item['distribution_key'];
                 unset($item['distribution_key']);
             }
+            if (array_key_exists('primary_key', $item) && $item['primary_key'] === true) {
+                $item['nullable'] = false;
+            }
             $convertedSchemaConfig[] = $item;
         }
 

--- a/libs/output-mapping/tests/Writer/Table/TableHintsConfigurationSchemaResolverTest.php
+++ b/libs/output-mapping/tests/Writer/Table/TableHintsConfigurationSchemaResolverTest.php
@@ -154,6 +154,7 @@ class TableHintsConfigurationSchemaResolverTest extends TestCase
                     [
                         'name' => 'col1',
                         'primary_key' => true,
+                        'nullable' => false,
                     ],
                 ],
             ],
@@ -199,6 +200,7 @@ class TableHintsConfigurationSchemaResolverTest extends TestCase
                             'KBC.datatype.distribution_key' => 1,
                         ],
                         'primary_key' => true,
+                        'nullable' => false,
                         'description' => 'description value',
                     ],
                 ],


### PR DESCRIPTION
Další věc - narazil jsem na to u Hints data types
1/ když založím tabulku s hints data types tak se všechny parametry přesouvají do metadat
2/ connection založí ale sloupečky s PK jako nullable false
3/ tím nesedí naše výchozí hodnoty kde máme nullable = true
4/ takže při druhém loadu do tabulky neprojde check tabulky (nullable je false ale posíláme true)
5/ takže pro Hints data types pro PK sloupečky nastavím vždy nullable na false