### PR TITLE
Output Mapping - PK in TableChangesStore only if changed

### DIFF
--- a/libs/output-mapping/src/Storage/AbstractTableStructureModifier.php
+++ b/libs/output-mapping/src/Storage/AbstractTableStructureModifier.php
@@ -22,44 +22,6 @@ abstract class AbstractTableStructureModifier
         $this->client = $clientWrapper->getTableAndFileStorageClient();
     }
 
-    /**
-     * @param array $keys
-     * @return array
-     */
-    protected function normalizeKeyArray(array $keys)
-    {
-        $logger = $this->logger;
-        return array_map(
-            function ($key) {
-                return trim($key);
-            },
-            array_unique(
-                array_filter($keys, function ($col) use ($logger) {
-                    if ($col !== '') {
-                        return true;
-                    }
-                    $logger->warning('Found empty column name in key array.');
-                    return false;
-                }),
-            ),
-        );
-    }
-
-    protected function modifyPrimaryKeyDecider(
-        array $currentTablePrimaryKey,
-        array $newTableConfigurationPrimaryKey,
-    ): bool {
-        $configPK = $this->normalizeKeyArray($newTableConfigurationPrimaryKey);
-        if (count($currentTablePrimaryKey) !== count($configPK)) {
-            return true;
-        }
-        $currentTablePkColumnsCount = count($currentTablePrimaryKey);
-        if (count(array_intersect($currentTablePrimaryKey, $configPK)) !== $currentTablePkColumnsCount) {
-            return true;
-        }
-        return false;
-    }
-
     protected function modifyPrimaryKey(
         string $tableId,
         array $tablePrimaryKey,

--- a/libs/output-mapping/src/Storage/TableStructureModifier.php
+++ b/libs/output-mapping/src/Storage/TableStructureModifier.php
@@ -7,6 +7,7 @@ namespace Keboola\OutputMapping\Storage;
 use Keboola\Datatype\Definition\BaseType;
 use Keboola\OutputMapping\Exception\PrimaryKeyNotChangedException;
 use Keboola\OutputMapping\Mapping\MappingFromProcessedConfiguration;
+use Keboola\OutputMapping\Writer\Helper\PrimaryKeyHelper;
 use Keboola\OutputMapping\Writer\Table\MappingDestination;
 use Keboola\OutputMapping\Writer\Table\TableDefinition\TableDefinitionColumnFactory;
 
@@ -24,7 +25,11 @@ class TableStructureModifier extends AbstractTableStructureModifier
             $destinationBucket->backend,
         );
 
-        if ($this->modifyPrimaryKeyDecider($destinationTableInfo->getPrimaryKey(), $source->getPrimaryKey(),)) {
+        if (PrimaryKeyHelper::modifyPrimaryKeyDecider(
+            $this->logger,
+            $destinationTableInfo->getPrimaryKey(),
+            $source->getPrimaryKey(),
+        )) {
             try {
                 $this->modifyPrimaryKey(
                     $destination->getTableId(),

--- a/libs/output-mapping/src/Storage/TableStructureModifierFromSchema.php
+++ b/libs/output-mapping/src/Storage/TableStructureModifierFromSchema.php
@@ -19,19 +19,14 @@ class TableStructureModifierFromSchema extends AbstractTableStructureModifier
         }
 
         if ($changesStore->getPrimaryKey() !== null) {
-            if ($this->modifyPrimaryKeyDecider(
-                $table->getPrimaryKey(),
-                $changesStore->getPrimaryKey()->getPrimaryKeyColumnNames(),
-            )) {
-                try {
-                    $this->modifyPrimaryKey(
-                        $table->getId(),
-                        $table->getPrimaryKey(),
-                        $changesStore->getPrimaryKey()->getPrimaryKeyColumnNames(),
-                    );
-                } catch (PrimaryKeyNotChangedException $e) {
-                    throw new InvalidOutputException($e->getMessage(), $e->getCode(), $e);
-                }
+            try {
+                $this->modifyPrimaryKey(
+                    $table->getId(),
+                    $table->getPrimaryKey(),
+                    $changesStore->getPrimaryKey()->getPrimaryKeyColumnNames(),
+                );
+            } catch (PrimaryKeyNotChangedException $e) {
+                throw new InvalidOutputException($e->getMessage(), $e->getCode(), $e);
             }
         }
 

--- a/libs/output-mapping/src/Writer/Helper/PrimaryKeyHelper.php
+++ b/libs/output-mapping/src/Writer/Helper/PrimaryKeyHelper.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace Keboola\OutputMapping\Writer\Helper;
 
+use Keboola\StorageApi\Client;
 use Psr\Log\LoggerInterface;
+use Throwable;
 
 class PrimaryKeyHelper
 {
@@ -29,5 +31,72 @@ class PrimaryKeyHelper
                 }),
             ),
         );
+    }
+
+    public static function modifyPrimaryKeyDecider(
+        LoggerInterface $logger,
+        array $currentTablePrimaryKey,
+        array $newTableConfigurationPrimaryKey,
+    ): bool {
+        $configPK = self::normalizeKeyArray($logger, $newTableConfigurationPrimaryKey);
+        if (count($currentTablePrimaryKey) !== count($configPK)) {
+            return true;
+        }
+        $currentTablePkColumnsCount = count($currentTablePrimaryKey);
+        if (count(array_intersect($currentTablePrimaryKey, $configPK)) !== $currentTablePkColumnsCount) {
+            return true;
+        }
+        return false;
+    }
+
+    public static function modifyPrimaryKey(
+        LoggerInterface $logger,
+        Client $client,
+        string $tableId,
+        array $tablePrimaryKey,
+        array $configPrimaryKey,
+    ): void {
+        $logger->warning(sprintf(
+            'Modifying primary key of table "%s" from "%s" to "%s".',
+            $tableId,
+            join(', ', $tablePrimaryKey),
+            join(', ', $configPrimaryKey),
+        ));
+        if (self::removePrimaryKey($logger, $client, $tableId, $tablePrimaryKey)) {
+            // modify primary key
+            try {
+                if (count($configPrimaryKey)) {
+                    $client->createTablePrimaryKey($tableId, $configPrimaryKey);
+                }
+            } catch (Throwable $e) {
+                // warn and try to rollback to original state
+                $logger->warning(
+                    "Error changing primary key of table {$tableId}: " . $e->getMessage(),
+                );
+                if (count($tablePrimaryKey) > 0) {
+                    $client->createTablePrimaryKey($tableId, $tablePrimaryKey);
+                }
+            }
+        }
+    }
+
+    private static function removePrimaryKey(
+        LoggerInterface $logger,
+        Client $client,
+        string $tableId,
+        array $tablePrimaryKey,
+    ): bool {
+        if (count($tablePrimaryKey) > 0) {
+            try {
+                $client->removeTablePrimaryKey($tableId);
+            } catch (Throwable $e) {
+                // warn and go on
+                $logger->warning(
+                    "Error deleting primary key of table {$tableId}: " . $e->getMessage(),
+                );
+                return false;
+            }
+        }
+        return true;
     }
 }

--- a/libs/output-mapping/src/Writer/Helper/PrimaryKeyHelper.php
+++ b/libs/output-mapping/src/Writer/Helper/PrimaryKeyHelper.php
@@ -4,18 +4,11 @@ declare(strict_types=1);
 
 namespace Keboola\OutputMapping\Writer\Helper;
 
-use Keboola\StorageApi\Client;
 use Psr\Log\LoggerInterface;
-use Throwable;
 
 class PrimaryKeyHelper
 {
-    /**
-     * @param array $keys
-     * @param LoggerInterface $logger
-     * @return array
-     */
-    public static function normalizeKeyArray(LoggerInterface $logger, array $keys)
+    public static function normalizeKeyArray(LoggerInterface $logger, array $keys): array
     {
         return array_map(
             function ($key) {
@@ -47,56 +40,5 @@ class PrimaryKeyHelper
             return true;
         }
         return false;
-    }
-
-    public static function modifyPrimaryKey(
-        LoggerInterface $logger,
-        Client $client,
-        string $tableId,
-        array $tablePrimaryKey,
-        array $configPrimaryKey,
-    ): void {
-        $logger->warning(sprintf(
-            'Modifying primary key of table "%s" from "%s" to "%s".',
-            $tableId,
-            join(', ', $tablePrimaryKey),
-            join(', ', $configPrimaryKey),
-        ));
-        if (self::removePrimaryKey($logger, $client, $tableId, $tablePrimaryKey)) {
-            // modify primary key
-            try {
-                if (count($configPrimaryKey)) {
-                    $client->createTablePrimaryKey($tableId, $configPrimaryKey);
-                }
-            } catch (Throwable $e) {
-                // warn and try to rollback to original state
-                $logger->warning(
-                    "Error changing primary key of table {$tableId}: " . $e->getMessage(),
-                );
-                if (count($tablePrimaryKey) > 0) {
-                    $client->createTablePrimaryKey($tableId, $tablePrimaryKey);
-                }
-            }
-        }
-    }
-
-    private static function removePrimaryKey(
-        LoggerInterface $logger,
-        Client $client,
-        string $tableId,
-        array $tablePrimaryKey,
-    ): bool {
-        if (count($tablePrimaryKey) > 0) {
-            try {
-                $client->removeTablePrimaryKey($tableId);
-            } catch (Throwable $e) {
-                // warn and go on
-                $logger->warning(
-                    "Error deleting primary key of table {$tableId}: " . $e->getMessage(),
-                );
-                return false;
-            }
-        }
-        return true;
     }
 }

--- a/libs/output-mapping/tests/Storage/TableStructureValidatorTest.php
+++ b/libs/output-mapping/tests/Storage/TableStructureValidatorTest.php
@@ -617,7 +617,7 @@ class TableStructureValidatorTest extends AbstractTestCase
                     'nullable' => true,
                 ]),
             ],
-            'expectedPrimaryKeyColumns' => [$primaryKeyColumn1],
+            'expectedPrimaryKeyColumns' => null,
         ];
 
         yield 'primary key reset' => [
@@ -663,59 +663,21 @@ class TableStructureValidatorTest extends AbstractTestCase
     /**
      * @dataProvider typedTableWithPkDataProvider
      */
-    public function testTypedTableWithPk(array $schemaColumns, array $expectedPrimaryKeyColumns): void
+    public function testTypedTableWithPk(array $schemaColumns, ?array $expectedPrimaryKeyColumns): void
     {
-        $primaryKeyColumn1 = new MappingFromConfigurationSchemaColumn([
-            'name' => 'col1',
-            'data_type' => [
-                'base' => [
-                    'type' => 'STRING',
-                ],
-                'snowflake' => [
-                    'type' => 'VARCHAR',
-                ],
-            ],
-            'nullable' => false,
-            'primary_key' => true,
-        ]);
-
-        $primaryKeyColumn2 = new MappingFromConfigurationSchemaColumn([
-            'name' => 'col2',
-            'data_type' => [
-                'base' => [
-                    'type' => 'NUMERIC',
-                ],
-            ],
-            'nullable' => false,
-            'primary_key' => true,
-        ]);
-
-        $schema = [
-            $primaryKeyColumn1,
-            $primaryKeyColumn2,
-            new MappingFromConfigurationSchemaColumn([
-                'name' => 'col3',
-                'data_type' => [
-                    'base' => [
-                        'type' => 'NUMERIC',
-                    ],
-                    'snowflake' => [
-                        'type' => 'INT',
-                    ],
-                ],
-                'nullable' => true,
-            ]),
-        ];
-
         $validator = new TableStructureValidator(true, new NullLogger(), $this->getClientMockTypedTable());
 
         $tableChangesStore = $validator->validateTable('in.c-main.table', $schemaColumns);
 
-        self::assertNotNull($tableChangesStore->getPrimaryKey());
-        self::assertSame(
-            $expectedPrimaryKeyColumns,
-            $tableChangesStore->getPrimaryKey()->getColumns(),
-        );
+        if ($expectedPrimaryKeyColumns === null) {
+            self::assertNull($tableChangesStore->getPrimaryKey());
+        } else {
+            self::assertNotNull($tableChangesStore->getPrimaryKey());
+            self::assertSame(
+                $expectedPrimaryKeyColumns,
+                $tableChangesStore->getPrimaryKey()->getColumns(),
+            );
+        }
     }
 
     public function testValidateNonTypedTableStructure(): void

--- a/libs/output-mapping/tests/Writer/Helper/PrimaryKeyHelperTest.php
+++ b/libs/output-mapping/tests/Writer/Helper/PrimaryKeyHelperTest.php
@@ -4,12 +4,26 @@ declare(strict_types=1);
 
 namespace Keboola\OutputMapping\Tests\Writer\Helper;
 
+use Keboola\Csv\CsvFile;
 use Keboola\OutputMapping\Tests\AbstractTestCase;
+use Keboola\OutputMapping\Tests\Needs\NeedsEmptyOutputBucket;
 use Keboola\OutputMapping\Writer\Helper\PrimaryKeyHelper;
 use Psr\Log\NullLogger;
 
 class PrimaryKeyHelperTest extends AbstractTestCase
 {
+    private function createTable(array $columns, string $primaryKey): string
+    {
+        $csv = new CsvFile($this->temp->getTmpFolder() . '/import.csv');
+        $csv->writeRow($columns);
+        return $this->clientWrapper->getTableAndFileStorageClient()->createTableAsync(
+            $this->emptyOutputBucketId,
+            'test-table',
+            $csv,
+            ['primaryKey' => $primaryKey],
+        );
+    }
+
     /**
      * @dataProvider normalizePrimaryKeyProvider
      * @param array $pkey
@@ -36,5 +50,200 @@ class PrimaryKeyHelperTest extends AbstractTestCase
                 ['Id', 'Name'],
             ],
         ];
+    }
+
+    /**
+     * @dataProvider modifyPrimaryKeyDeciderOptionsProvider
+     */
+    public function testModifyPrimaryKeyDecider(
+        array $currentTableInfo,
+        array $newTableConfiguration,
+        bool $result,
+    ): void {
+        self::assertEquals($result, PrimaryKeyHelper::modifyPrimaryKeyDecider(
+            new NullLogger(),
+            $currentTableInfo['primaryKey'],
+            $newTableConfiguration['primary_key'],
+        ));
+    }
+
+    public function modifyPrimaryKeyDeciderOptionsProvider(): array
+    {
+        return [
+            [
+                [
+                    'primaryKey' => [],
+                ],
+                [
+                    'primary_key' => [],
+                ],
+                false,
+            ],
+            [
+                [
+                    'primaryKey' => [],
+                ],
+                [
+                    'primary_key' => ['Id'],
+                ],
+                true,
+            ],
+            [
+                [
+                    'primaryKey' => ['Id'],
+                ],
+                [
+                    'primary_key' => [],
+                ],
+                true,
+            ],
+            [
+                [
+                    'primaryKey' => ['Id'],
+                ],
+                [
+                    'primary_key' => ['Id'],
+                ],
+                false,
+            ],
+            [
+                [
+                    'primaryKey' => ['Id'],
+                ],
+                [
+                    'primary_key' => ['Name'],
+                ],
+                true,
+            ],
+            [
+                [
+                    'primaryKey' => ['Id'],
+                ],
+                [
+                    'primary_key' => ['Id', 'Name'],
+                ],
+                true,
+            ],
+        ];
+    }
+
+    #[NeedsEmptyOutputBucket]
+    public function testModifyPrimaryKeyChange(): void
+    {
+        $tableId = $this->createTable(['id', 'name', 'foo'], 'id,name');
+        $tableInfo = $this->clientWrapper->getTableAndFileStorageClient()->getTable($tableId);
+        self::assertEquals(['id', 'name'], $tableInfo['primaryKey']);
+
+        PrimaryKeyHelper::modifyPrimaryKey(
+            $this->testLogger,
+            $this->clientWrapper->getTableAndFileStorageClient(),
+            $tableId,
+            ['id', 'name'],
+            ['id', 'foo'],
+        );
+        self::assertTrue($this->testHandler->hasWarningThatContains(
+            sprintf('Modifying primary key of table "%s" from "id, name" to "id, foo".', $tableId),
+        ));
+        $tableInfo = $this->clientWrapper->getTableAndFileStorageClient()->getTable($tableId);
+        self::assertEquals(['id', 'foo'], $tableInfo['primaryKey']);
+    }
+
+    #[NeedsEmptyOutputBucket]
+    public function testModifyPrimaryKeyChangeFromEmpty(): void
+    {
+        $tableId = $this->createTable(['id', 'name', 'foo'], '');
+        $tableInfo = $this->clientWrapper->getTableAndFileStorageClient()->getTable($tableId);
+        self::assertEquals([], $tableInfo['primaryKey']);
+
+        PrimaryKeyHelper::modifyPrimaryKey(
+            $this->testLogger,
+            $this->clientWrapper->getTableAndFileStorageClient(),
+            $tableId,
+            [ ],
+            ['id', 'foo'],
+        );
+        self::assertTrue($this->testHandler->hasWarningThatContains(
+            sprintf('Modifying primary key of table "%s" from "" to "id, foo".', $tableId),
+        ));
+        $tableInfo = $this->clientWrapper->getTableAndFileStorageClient()->getTable($tableId);
+        self::assertEquals(['id', 'foo'], $tableInfo['primaryKey']);
+    }
+
+    #[NeedsEmptyOutputBucket]
+    public function testModifyPrimaryKeyChangeToEmpty(): void
+    {
+        $tableId = $this->createTable(['id', 'name', 'foo'], 'id,foo');
+        $tableInfo = $this->clientWrapper->getTableAndFileStorageClient()->getTable($tableId);
+        self::assertEquals(['id', 'foo'], $tableInfo['primaryKey']);
+
+        PrimaryKeyHelper::modifyPrimaryKey(
+            $this->testLogger,
+            $this->clientWrapper->getTableAndFileStorageClient(),
+            $tableId,
+            $tableInfo['primaryKey'],
+            [],
+        );
+        self::assertTrue($this->testHandler->hasWarningThatContains(
+            sprintf('Modifying primary key of table "%s" from "id, foo" to "".', $tableId),
+        ));
+        $tableInfo = $this->clientWrapper->getTableAndFileStorageClient()->getTable($tableId);
+        self::assertEquals([], $tableInfo['primaryKey']);
+    }
+
+    #[NeedsEmptyOutputBucket]
+    public function testModifyPrimaryKeyErrorRemove(): void
+    {
+        $tableId = $this->createTable(['id', 'name', 'foo'], 'id,name');
+        $tableInfo = $this->clientWrapper->getTableAndFileStorageClient()->getTable($tableId);
+        self::assertEquals(['id', 'name'], $tableInfo['primaryKey']);
+        $invalidTableId = $tableId . '-non-existent';
+
+        PrimaryKeyHelper::modifyPrimaryKey(
+            $this->testLogger,
+            $this->clientWrapper->getTableAndFileStorageClient(),
+            $invalidTableId,
+            ['id', 'name'],
+            ['id', 'foo'],
+        );
+        self::assertTrue($this->testHandler->hasWarningThatContains(
+            sprintf('Modifying primary key of table "%s" from "id, name" to "id, foo".', $invalidTableId),
+        ));
+        self::assertTrue($this->testHandler->hasWarningThatContains(
+            sprintf(
+                'Error deleting primary key of table %s: The table "test-table-non-existent" ' .
+                'was not found in the bucket "%s" in the project',
+                $invalidTableId,
+                $this->emptyOutputBucketId,
+            ),
+        ));
+        $tableInfo = $this->clientWrapper->getTableAndFileStorageClient()->getTable($tableId);
+        self::assertEquals(['id', 'name'], $tableInfo['primaryKey']);
+    }
+
+    #[NeedsEmptyOutputBucket]
+    public function testModifyPrimaryKeyErrorCreate(): void
+    {
+        $tableId = $this->createTable(['id', 'name', 'foo'], 'id,name');
+        $tableInfo = $this->clientWrapper->getTableAndFileStorageClient()->getTable($tableId);
+        self::assertEquals(['id', 'name'], $tableInfo['primaryKey']);
+
+        PrimaryKeyHelper::modifyPrimaryKey(
+            $this->testLogger,
+            $this->clientWrapper->getTableAndFileStorageClient(),
+            $tableId,
+            ['id', 'name'],
+            ['id', 'bar'],
+        );
+        self::assertTrue($this->testHandler->hasWarningThatContains(
+            sprintf('Modifying primary key of table "%s" from "id, name" to "id, bar".', $tableId),
+        ));
+        self::assertTrue($this->testHandler->hasWarningThatContains(
+            sprintf(
+                'Error changing primary key of table %s: Primary key columns "bar" not found in "id, name, foo"',
+                $tableId,
+            ),
+        ));
+        $tableInfo = $this->clientWrapper->getTableAndFileStorageClient()->getTable($tableId);
+        self::assertEquals(['id', 'name'], $tableInfo['primaryKey']);
     }
 }

--- a/libs/output-mapping/tests/Writer/Helper/PrimaryKeyHelperTest.php
+++ b/libs/output-mapping/tests/Writer/Helper/PrimaryKeyHelperTest.php
@@ -4,30 +4,14 @@ declare(strict_types=1);
 
 namespace Keboola\OutputMapping\Tests\Writer\Helper;
 
-use Keboola\Csv\CsvFile;
 use Keboola\OutputMapping\Tests\AbstractTestCase;
-use Keboola\OutputMapping\Tests\Needs\NeedsEmptyOutputBucket;
 use Keboola\OutputMapping\Writer\Helper\PrimaryKeyHelper;
 use Psr\Log\NullLogger;
 
 class PrimaryKeyHelperTest extends AbstractTestCase
 {
-    private function createTable(array $columns, string $primaryKey): string
-    {
-        $csv = new CsvFile($this->temp->getTmpFolder() . '/import.csv');
-        $csv->writeRow($columns);
-        return $this->clientWrapper->getTableAndFileStorageClient()->createTableAsync(
-            $this->emptyOutputBucketId,
-            'test-table',
-            $csv,
-            ['primaryKey' => $primaryKey],
-        );
-    }
-
     /**
      * @dataProvider normalizePrimaryKeyProvider
-     * @param array $pkey
-     * @param array $result
      */
     public function testNormalizePrimaryKey(array $pkey, array $result): void
     {
@@ -125,125 +109,5 @@ class PrimaryKeyHelperTest extends AbstractTestCase
                 true,
             ],
         ];
-    }
-
-    #[NeedsEmptyOutputBucket]
-    public function testModifyPrimaryKeyChange(): void
-    {
-        $tableId = $this->createTable(['id', 'name', 'foo'], 'id,name');
-        $tableInfo = $this->clientWrapper->getTableAndFileStorageClient()->getTable($tableId);
-        self::assertEquals(['id', 'name'], $tableInfo['primaryKey']);
-
-        PrimaryKeyHelper::modifyPrimaryKey(
-            $this->testLogger,
-            $this->clientWrapper->getTableAndFileStorageClient(),
-            $tableId,
-            ['id', 'name'],
-            ['id', 'foo'],
-        );
-        self::assertTrue($this->testHandler->hasWarningThatContains(
-            sprintf('Modifying primary key of table "%s" from "id, name" to "id, foo".', $tableId),
-        ));
-        $tableInfo = $this->clientWrapper->getTableAndFileStorageClient()->getTable($tableId);
-        self::assertEquals(['id', 'foo'], $tableInfo['primaryKey']);
-    }
-
-    #[NeedsEmptyOutputBucket]
-    public function testModifyPrimaryKeyChangeFromEmpty(): void
-    {
-        $tableId = $this->createTable(['id', 'name', 'foo'], '');
-        $tableInfo = $this->clientWrapper->getTableAndFileStorageClient()->getTable($tableId);
-        self::assertEquals([], $tableInfo['primaryKey']);
-
-        PrimaryKeyHelper::modifyPrimaryKey(
-            $this->testLogger,
-            $this->clientWrapper->getTableAndFileStorageClient(),
-            $tableId,
-            [ ],
-            ['id', 'foo'],
-        );
-        self::assertTrue($this->testHandler->hasWarningThatContains(
-            sprintf('Modifying primary key of table "%s" from "" to "id, foo".', $tableId),
-        ));
-        $tableInfo = $this->clientWrapper->getTableAndFileStorageClient()->getTable($tableId);
-        self::assertEquals(['id', 'foo'], $tableInfo['primaryKey']);
-    }
-
-    #[NeedsEmptyOutputBucket]
-    public function testModifyPrimaryKeyChangeToEmpty(): void
-    {
-        $tableId = $this->createTable(['id', 'name', 'foo'], 'id,foo');
-        $tableInfo = $this->clientWrapper->getTableAndFileStorageClient()->getTable($tableId);
-        self::assertEquals(['id', 'foo'], $tableInfo['primaryKey']);
-
-        PrimaryKeyHelper::modifyPrimaryKey(
-            $this->testLogger,
-            $this->clientWrapper->getTableAndFileStorageClient(),
-            $tableId,
-            $tableInfo['primaryKey'],
-            [],
-        );
-        self::assertTrue($this->testHandler->hasWarningThatContains(
-            sprintf('Modifying primary key of table "%s" from "id, foo" to "".', $tableId),
-        ));
-        $tableInfo = $this->clientWrapper->getTableAndFileStorageClient()->getTable($tableId);
-        self::assertEquals([], $tableInfo['primaryKey']);
-    }
-
-    #[NeedsEmptyOutputBucket]
-    public function testModifyPrimaryKeyErrorRemove(): void
-    {
-        $tableId = $this->createTable(['id', 'name', 'foo'], 'id,name');
-        $tableInfo = $this->clientWrapper->getTableAndFileStorageClient()->getTable($tableId);
-        self::assertEquals(['id', 'name'], $tableInfo['primaryKey']);
-        $invalidTableId = $tableId . '-non-existent';
-
-        PrimaryKeyHelper::modifyPrimaryKey(
-            $this->testLogger,
-            $this->clientWrapper->getTableAndFileStorageClient(),
-            $invalidTableId,
-            ['id', 'name'],
-            ['id', 'foo'],
-        );
-        self::assertTrue($this->testHandler->hasWarningThatContains(
-            sprintf('Modifying primary key of table "%s" from "id, name" to "id, foo".', $invalidTableId),
-        ));
-        self::assertTrue($this->testHandler->hasWarningThatContains(
-            sprintf(
-                'Error deleting primary key of table %s: The table "test-table-non-existent" ' .
-                'was not found in the bucket "%s" in the project',
-                $invalidTableId,
-                $this->emptyOutputBucketId,
-            ),
-        ));
-        $tableInfo = $this->clientWrapper->getTableAndFileStorageClient()->getTable($tableId);
-        self::assertEquals(['id', 'name'], $tableInfo['primaryKey']);
-    }
-
-    #[NeedsEmptyOutputBucket]
-    public function testModifyPrimaryKeyErrorCreate(): void
-    {
-        $tableId = $this->createTable(['id', 'name', 'foo'], 'id,name');
-        $tableInfo = $this->clientWrapper->getTableAndFileStorageClient()->getTable($tableId);
-        self::assertEquals(['id', 'name'], $tableInfo['primaryKey']);
-
-        PrimaryKeyHelper::modifyPrimaryKey(
-            $this->testLogger,
-            $this->clientWrapper->getTableAndFileStorageClient(),
-            $tableId,
-            ['id', 'name'],
-            ['id', 'bar'],
-        );
-        self::assertTrue($this->testHandler->hasWarningThatContains(
-            sprintf('Modifying primary key of table "%s" from "id, name" to "id, bar".', $tableId),
-        ));
-        self::assertTrue($this->testHandler->hasWarningThatContains(
-            sprintf(
-                'Error changing primary key of table %s: Primary key columns "bar" not found in "id, name, foo"',
-                $tableId,
-            ),
-        ));
-        $tableInfo = $this->clientWrapper->getTableAndFileStorageClient()->getTable($tableId);
-        self::assertEquals(['id', 'name'], $tableInfo['primaryKey']);
     }
 }


### PR DESCRIPTION
Fixes: https://keboola.atlassian.net/browse/PST-1910

Change store nově má nastavený PK jen při změně. Tak jak jsme se bavili v pátek. Pak by se případně mohlo vrátit i to `hasChanges` pokud je k něčemu potřeba.