### PR TITLE
PST-1967: feat (input-mapping): add ADAPTIVE_INPUT_MAPPING_VALUE option to WS load

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Prerequisites:
 * configured `az` CLI tools (run `az login`)
 * existing Azure Synapse Analytics
 
-#### Prepare resoruces
+#### Prepare resources
 
 ```shell
 cat <<EOF > ./provisioning/ci/synapse-auto-stop/terraform.tfvars

--- a/libs/input-mapping/src/Table/Options/InputTableOptions.php
+++ b/libs/input-mapping/src/Table/Options/InputTableOptions.php
@@ -152,9 +152,13 @@ class InputTableOptions
         }
         if (!empty($this->definition['changed_since'])) {
             if ($this->definition['changed_since'] === self::ADAPTIVE_INPUT_MAPPING_VALUE) {
-                throw new InvalidInputException(
-                    'Adaptive input mapping is not supported on input mapping to workspace.',
-                );
+                try {
+                    $exportOptions['changedSince'] = $states
+                        ->getTable($this->getSource())
+                        ->getLastImportDate();
+                } catch (TableNotFoundException) {
+                    // intentionally blank
+                }
             } else {
                 if (strtotime($this->definition['changed_since']) === false) {
                     throw new InvalidInputException(

--- a/libs/input-mapping/src/Table/Options/InputTableOptions.php
+++ b/libs/input-mapping/src/Table/Options/InputTableOptions.php
@@ -153,9 +153,12 @@ class InputTableOptions
         if (!empty($this->definition['changed_since'])) {
             if ($this->definition['changed_since'] === self::ADAPTIVE_INPUT_MAPPING_VALUE) {
                 try {
-                    $exportOptions['changedSince'] = $states
+                    $lastImportDateString = $states
                         ->getTable($this->getSource())
                         ->getLastImportDate();
+
+                    // converting to unix timestamp https://keboolaglobal.slack.com/archives/C054VSPFVST/p1723555870048739?thread_ts=1723531121.814779&cid=C054VSPFVST
+                    $exportOptions['changedSince'] = strtotime($lastImportDateString);
                 } catch (TableNotFoundException) {
                     // intentionally blank
                 }
@@ -168,6 +171,7 @@ class InputTableOptions
                 $exportOptions['seconds'] = time() - strtotime($this->definition['changed_since']);
             }
         }
+
         if (isset($this->definition['where_column']) && count($this->definition['where_values'])) {
             $exportOptions['whereColumn'] = $this->definition['where_column'];
             $exportOptions['whereValues'] = $this->definition['where_values'];

--- a/libs/input-mapping/src/Table/Strategy/S3.php
+++ b/libs/input-mapping/src/Table/Strategy/S3.php
@@ -15,7 +15,6 @@ class S3 extends AbstractStrategy
     {
         $exportOptions = $table->getStorageApiExportOptions($this->tablesState);
         $exportOptions['gzip'] = true;
-
         $jobId = $this->clientWrapper->getTableAndFileStorageClient()->queueTableExport(
             $table->getSource(),
             $exportOptions,

--- a/libs/input-mapping/src/Table/Strategy/S3.php
+++ b/libs/input-mapping/src/Table/Strategy/S3.php
@@ -15,6 +15,7 @@ class S3 extends AbstractStrategy
     {
         $exportOptions = $table->getStorageApiExportOptions($this->tablesState);
         $exportOptions['gzip'] = true;
+
         $jobId = $this->clientWrapper->getTableAndFileStorageClient()->queueTableExport(
             $table->getSource(),
             $exportOptions,

--- a/libs/input-mapping/tests/Functional/DownloadTablesWorkspaceSnowflakeAdaptiveTest.php
+++ b/libs/input-mapping/tests/Functional/DownloadTablesWorkspaceSnowflakeAdaptiveTest.php
@@ -1,0 +1,155 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Keboola\InputMapping\Tests\Functional;
+
+use Keboola\Csv\CsvFile;
+use Keboola\InputMapping\Configuration\Table\Manifest\Adapter;
+use Keboola\InputMapping\Reader;
+use Keboola\InputMapping\Staging\AbstractStrategyFactory;
+use Keboola\InputMapping\State\InputTableStateList;
+use Keboola\InputMapping\Table\Options\InputTableOptions;
+use Keboola\InputMapping\Table\Options\InputTableOptionsList;
+use Keboola\InputMapping\Table\Options\ReaderOptions;
+use Keboola\InputMapping\Tests\AbstractTestCase;
+use Keboola\InputMapping\Tests\Needs\NeedsEmptyOutputBucket;
+use Keboola\InputMapping\Tests\Needs\NeedsTestTables;
+use Keboola\StorageApi\ClientException;
+
+class DownloadTablesWorkspaceSnowflakeAdaptiveTest extends AbstractTestCase
+{
+    #[NeedsTestTables, NeedsEmptyOutputBucket]
+    public function testDownloadTablesDownloadsEmptyTable(): void
+    {
+        $reader = new Reader($this->getWorkspaceStagingFactory(logger: $this->testLogger));
+        $configuration = new InputTableOptionsList([
+            [
+                'source' => $this->firstTableId,
+                'destination' => 'test1',
+                'changed_since' => InputTableOptions::ADAPTIVE_INPUT_MAPPING_VALUE,
+            ],
+        ]);
+
+        $testTableInfo = $this->clientWrapper->getTableAndFileStorageClient()->getTable($this->firstTableId);
+        $inputTablesState = new InputTableStateList([
+            [
+                'source' => $this->firstTableId,
+                'lastImportDate' => $testTableInfo['lastImportDate'],
+            ],
+        ]);
+        $tablesResult = $reader->downloadTables(
+            $configuration,
+            $inputTablesState,
+            'download',
+            AbstractStrategyFactory::WORKSPACE_SNOWFLAKE,
+            new ReaderOptions(true),
+        );
+
+        self::assertEquals(
+            $testTableInfo['lastImportDate'],
+            $tablesResult->getInputTableStateList()->getTable($this->firstTableId)->getLastImportDate(),
+        );
+
+        $adapter = new Adapter();
+        $manifest = $adapter->readFromFile($this->temp->getTmpFolder() . '/download/test1.manifest');
+        self::assertEquals($this->firstTableId, $manifest['id']);
+
+        // check that the table exists in the workspace
+        $this->clientWrapper->getTableAndFileStorageClient()->createTableAsyncDirect(
+            $this->emptyOutputBucketId,
+            ['dataWorkspaceId' => $this->workspaceId, 'dataTableName' => 'test1', 'name' => 'test1'],
+        );
+
+        self::assertCount(1, $tablesResult->getInputTableStateList()->jsonSerialize());
+
+        self::assertTrue($this->testHandler->hasInfoThatContains('Using "workspace-snowflake" table input staging.'));
+        self::assertTrue(
+            $this->testHandler->hasInfoThatContains(sprintf('Table "%s" will be copied.', $this->firstTableId)),
+        );
+        self::assertTrue($this->testHandler->hasInfoThatContains('Copying 1 tables to workspace.'));
+        self::assertTrue($this->testHandler->hasInfoThatContains('Processed 1 workspace exports.'));
+    }
+
+    #[NeedsTestTables]
+    public function testDownloadTablesDownloadsOnlyNewRows(): void
+    {
+        $reader = new Reader($this->getWorkspaceStagingFactory(logger: $this->testLogger));
+        $configuration = new InputTableOptionsList([
+            [
+                'source' => $this->firstTableId,
+                'destination' => 'test1',
+                'changed_since' => InputTableOptions::ADAPTIVE_INPUT_MAPPING_VALUE,
+            ],
+        ]);
+        $firstTablesResult = $reader->downloadTables(
+            $configuration,
+            new InputTableStateList([]),
+            'download',
+            AbstractStrategyFactory::WORKSPACE_SNOWFLAKE,
+            new ReaderOptions(true),
+        );
+
+        // Update table
+        $csv = new CsvFile($this->temp->getTmpFolder() . DIRECTORY_SEPARATOR . 'upload.csv');
+        $csv->writeRow(['Id', 'Name', 'foo', 'bar']);
+        $csv->writeRow(['id4', 'name4', 'foo4', 'bar4']);
+        $this->clientWrapper->getTableAndFileStorageClient()->writeTableAsync(
+            $this->firstTableId,
+            $csv,
+            ['incremental' => true],
+        );
+
+        $configuration = new InputTableOptionsList([
+            [
+                'source' => $this->firstTableId,
+                'destination' => 'test1',
+                'changed_since' => InputTableOptions::ADAPTIVE_INPUT_MAPPING_VALUE,
+                'overwrite' => true,
+            ],
+        ]);
+        $updatedTestTableInfo = $this->clientWrapper->getTableAndFileStorageClient()->getTable($this->firstTableId);
+        $secondTablesResult = $reader->downloadTables(
+            $configuration,
+            $firstTablesResult->getInputTableStateList(),
+            'data/in/tables/',
+            AbstractStrategyFactory::WORKSPACE_SNOWFLAKE,
+            new ReaderOptions(true),
+        );
+
+        self::assertEquals(
+            $updatedTestTableInfo['lastImportDate'],
+            $secondTablesResult->getInputTableStateList()->getTable($this->firstTableId)->getLastImportDate(),
+        );
+        self::assertCount(1, $secondTablesResult->getInputTableStateList()->jsonSerialize());
+    }
+
+    #[NeedsTestTables]
+    public function testDownloadTablesInvalidDate(): void
+    {
+        $reader = new Reader($this->getWorkspaceStagingFactory(logger: $this->testLogger));
+        $configuration = new InputTableOptionsList([
+            [
+                'source' => $this->firstTableId,
+                'destination' => 'test1',
+                'changed_since' => InputTableOptions::ADAPTIVE_INPUT_MAPPING_VALUE,
+            ],
+        ]);
+        $inputTablesState = new InputTableStateList([
+            [
+                'source' => $this->firstTableId,
+                'lastImportDate' => 'nonsense',
+            ],
+        ]);
+
+        $this->expectException(ClientException::class);
+        $this->expectExceptionMessage('Invalid column definition: Invalid "changedSince" parameter');
+        $reader->downloadTables(
+            $configuration,
+            $inputTablesState,
+            'download',
+            AbstractStrategyFactory::WORKSPACE_SNOWFLAKE,
+            new ReaderOptions(true),
+        );
+    }
+}

--- a/libs/input-mapping/tests/Functional/DownloadTablesWorkspaceSnowflakeTest.php
+++ b/libs/input-mapping/tests/Functional/DownloadTablesWorkspaceSnowflakeTest.php
@@ -155,7 +155,7 @@ class DownloadTablesWorkspaceSnowflakeTest extends AbstractTestCase
     #[NeedsTestTables(2), NeedsEmptyOutputBucket]
     public function testTablesAdaptiveChangedSince(): void
     {
-        $reader = new Reader($this->getWorkspaceStagingFactory());
+        $reader = new Reader($this->getWorkspaceStagingFactory(logger: $this->testLogger));
         $configuration = new InputTableOptionsList([
             [
                 'source' => $this->firstTableId,
@@ -192,7 +192,7 @@ class DownloadTablesWorkspaceSnowflakeTest extends AbstractTestCase
         $manifest = $adapter->readFromFile($this->temp->getTmpFolder() . '/download/test1.manifest');
         self::assertEquals($this->firstTableId, $manifest['id']);
         self::assertEquals(
-            ['Id'],
+            ['Id', 'Name', 'foo', 'bar'],
             $manifest['columns'],
         );
         // check that the table exists in the workspace
@@ -201,7 +201,7 @@ class DownloadTablesWorkspaceSnowflakeTest extends AbstractTestCase
             [
                 'dataWorkspaceId' => $this->workspaceId,
                 'dataTableName' => 'test1',
-                'name' => 'test1'
+                'name' => 'test1',
             ],
         );
 
@@ -209,10 +209,12 @@ class DownloadTablesWorkspaceSnowflakeTest extends AbstractTestCase
         self::assertTrue(
             $this->testHandler->hasInfoThatContains(sprintf('Table "%s" will be copied.', $this->firstTableId)),
         );
+        self::assertTrue(
+            $this->testHandler->hasInfoThatContains(sprintf('Table "%s" will be cloned.', $this->secondTableId)),
+        );
         self::assertTrue($this->testHandler->hasInfoThatContains('Copying 1 tables to workspace.'));
-        self::assertTrue($this->testHandler->hasInfoThatContains('Processed 1 workspace exports.'));
-
-        var_dump($this->testHandler->getRecords());
+        self::assertTrue($this->testHandler->hasInfoThatContains('Cloning 1 tables to workspace.'));
+        self::assertTrue($this->testHandler->hasInfoThatContains('Processed 2 workspace exports.'));
     }
 
     #[NeedsTestTables, NeedsEmptyOutputBucket]

--- a/libs/input-mapping/tests/Table/Options/InputTableOptionsTest.php
+++ b/libs/input-mapping/tests/Table/Options/InputTableOptionsTest.php
@@ -8,6 +8,7 @@ use Generator;
 use Keboola\InputMapping\Exception\InvalidInputException;
 use Keboola\InputMapping\State\InputTableStateList;
 use Keboola\InputMapping\Table\Options\InputTableOptions;
+use Keboola\InputMapping\Table\Options\RewrittenInputTableOptions;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
 
@@ -276,9 +277,33 @@ class InputTableOptionsTest extends TestCase
             'source' => 'test',
             'changed_since' => InputTableOptions::ADAPTIVE_INPUT_MAPPING_VALUE,
         ]);
-        $this->expectExceptionMessage('Adaptive input mapping is not supported on input mapping to workspace.');
-        $this->expectException(InvalidInputException::class);
-        $definition->getStorageApiLoadOptions(new InputTableStateList([]));
+        $tablesState = new InputTableStateList([[
+            'source' => 'test',
+            'lastImportDate' => '1989-11-17T21:00:00+0200',
+        ]]);
+        self::assertEquals(
+            [
+                'changedSince' => '1989-11-17T21:00:00+0200',
+                'overwrite' => false,
+                'sourceBranchId' => 12345,
+            ],
+            $definition->getStorageApiLoadOptions($tablesState),
+        );
+    }
+
+    public function testGetExportOptionsAdaptiveInputMappingMissingTable(): void
+    {
+        $definition = new InputTableOptions([
+            'source' => 'test',
+            'changed_since' => InputTableOptions::ADAPTIVE_INPUT_MAPPING_VALUE,
+        ]);
+        $tablesState = new InputTableStateList([]);
+        self::assertEquals(
+            [
+                'overwrite' => false,
+            ],
+            $definition->getStorageApiLoadOptions($tablesState),
+        );
     }
 
     public function testGetLoadOptionsDaysMapping(): void

--- a/libs/input-mapping/tests/Table/Options/InputTableOptionsTest.php
+++ b/libs/input-mapping/tests/Table/Options/InputTableOptionsTest.php
@@ -283,9 +283,8 @@ class InputTableOptionsTest extends TestCase
         ]]);
         self::assertEquals(
             [
-                'changedSince' => '1989-11-17T21:00:00+0200',
+                'changedSince' => '627332400',
                 'overwrite' => false,
-                'sourceBranchId' => 12345,
             ],
             $definition->getStorageApiLoadOptions($tablesState),
         );


### PR DESCRIPTION
- WS load nove uz podporuje i adaptivni `changed_since`

V runneru by se ten state mel updatnout normalne, neni potreba doimplementovat:
https://github.com/keboola/docker-bundle/blob/main/src/Docker/Runner.php#L505