### PR TITLE
[input-mapping] Table/Result::getTables() return type phpdoc

### DIFF
--- a/libs/input-mapping/src/Table/Result.php
+++ b/libs/input-mapping/src/Table/Result.php
@@ -22,6 +22,9 @@ class Result
         $this->tables[] = $table;
     }
 
+    /**
+     * @return Generator<TableInfo>
+     */
     public function getTables(): Generator
     {
         foreach ($this->tables as $table) {


### PR DESCRIPTION
Part of https://keboola.atlassian.net/browse/PST-1689

Abych v job runneru nemel phpstan errory

```
Parameter #1 $tableInfo of static method App\Helper\TableInfoConverter::convertTableInfoToTableResult() expects Keboola\InputMapping\Table\Result\TableInfo,  
         mixed given. 
```