### PR TITLE
fix(permission-checker): Use integer for app id

### DIFF
--- a/libs/permission-checker/src/Check/SandboxesService/CanManageApp.php
+++ b/libs/permission-checker/src/Check/SandboxesService/CanManageApp.php
@@ -11,7 +11,7 @@ use Keboola\PermissionChecker\StorageApiToken;
 class CanManageApp implements PermissionCheckInterface
 {
     public function __construct(
-        private readonly string $appId,
+        private readonly int $appId,
         private readonly string $appProjectId,
     ) {
     }

--- a/libs/permission-checker/tests/Check/SandboxesService/CanManageAppTest.php
+++ b/libs/permission-checker/tests/Check/SandboxesService/CanManageAppTest.php
@@ -15,7 +15,7 @@ class CanManageAppTest extends TestCase
     {
         $this->expectNotToPerformAssertions();
 
-        $appId = '1';
+        $appId = 1;
         $projectId = '123'; // app project id is the same as token project id
 
         $checker = new CanManageApp($appId, $projectId);
@@ -24,7 +24,7 @@ class CanManageAppTest extends TestCase
 
     public function testDenyManageApp(): void
     {
-        $appId = '1';
+        $appId = 1;
         $appProjectId = '456';
         $tokenProjectId = '123';
 


### PR DESCRIPTION
App id je vždy integer - https://github.com/keboola/sandboxes-service/pull/237#discussion_r1747377381