### PR TITLE
[output-mapping] TableDefinitionColumnFactory without NATIVE_BACKEND_…

### DIFF
--- a/libs/output-mapping/src/Writer/Table/TableDefinition/TableDefinitionColumnFactory.php
+++ b/libs/output-mapping/src/Writer/Table/TableDefinition/TableDefinitionColumnFactory.php
@@ -6,19 +6,10 @@ namespace Keboola\OutputMapping\Writer\Table\TableDefinition;
 
 use Keboola\Datatype\Definition\Common;
 use Keboola\Datatype\Definition\DefinitionInterface;
-use Keboola\Datatype\Definition\Exasol;
-use Keboola\Datatype\Definition\Snowflake;
-use Keboola\Datatype\Definition\Synapse;
 
 class TableDefinitionColumnFactory
 {
     public const NATIVE_TYPE_METADATA_KEY = 'KBC.datatype.backend';
-
-    public const NATIVE_BACKEND_TYPE_CLASS_MAP = [
-        'snowflake' => Snowflake::class,
-        'synapse' => Synapse::class,
-        'exasol' => Exasol::class,
-    ];
 
     /**
      * @var class-string<DefinitionInterface>|null
@@ -87,11 +78,14 @@ class TableDefinitionColumnFactory
      */
     private function getNativeDatatypeClass(array $tableMetadata, string $backend): ?string
     {
+        $columnDefinitionClassName = 'Keboola\\Datatype\\Definition\\' . ucfirst(strtolower($backend));
+
         $dataTypeBackend = $this->getDatatypeBackendFromMetadata($tableMetadata);
         if ($dataTypeBackend === $backend &&
-            array_key_exists($dataTypeBackend, self::NATIVE_BACKEND_TYPE_CLASS_MAP)
+            class_exists($columnDefinitionClassName) &&
+                is_subclass_of($columnDefinitionClassName, DefinitionInterface::class)
         ) {
-            return self::NATIVE_BACKEND_TYPE_CLASS_MAP[$backend];
+            return $columnDefinitionClassName;
         }
         return null;
     }

--- a/libs/output-mapping/tests/Writer/Table/TableDefinition/TableDefinitionColumnFactoryTest.php
+++ b/libs/output-mapping/tests/Writer/Table/TableDefinition/TableDefinitionColumnFactoryTest.php
@@ -5,23 +5,34 @@ declare(strict_types=1);
 namespace Keboola\OutputMapping\Tests\Writer\Table\TableDefinition;
 
 use Generator;
+use Keboola\Datatype\Definition\Bigquery;
+use Keboola\Datatype\Definition\Common;
+use Keboola\Datatype\Definition\Exasol;
 use Keboola\Datatype\Definition\GenericStorage;
 use Keboola\Datatype\Definition\Snowflake;
+use Keboola\OutputMapping\Writer\Table\TableDefinition\BaseTypeTableDefinitionColumn;
+use Keboola\OutputMapping\Writer\Table\TableDefinition\NativeTableDefinitionColumn;
 use Keboola\OutputMapping\Writer\Table\TableDefinition\TableDefinitionColumnFactory;
+use Keboola\OutputMapping\Writer\Table\TableDefinition\TableDefinitionColumnInterface;
 use PHPUnit\Framework\TestCase;
 
 class TableDefinitionColumnFactoryTest extends TestCase
 {
-    /** @dataProvider createTableDefinitionColumnProvider */
+    /**
+     * @dataProvider createTableDefinitionColumnProvider
+     * @param  class-string<TableDefinitionColumnInterface> $expectedTabeDefinitionColumnClass
+     */
     public function testFactoryCreateTableDefinitionColumn(
         string $columnName,
         array $columnMetadata,
         array $tableMetadata,
         string $backendType,
         array $expectedSerialisation,
+        string $expectedTabeDefinitionColumnClass,
     ): void {
         $columnFactory = new TableDefinitionColumnFactory($tableMetadata, $backendType);
         $column = $columnFactory->createTableDefinitionColumn($columnName, $columnMetadata);
+        self::assertInstanceOf($expectedTabeDefinitionColumnClass, $column);
         self::assertSame($expectedSerialisation, $column->toArray());
     }
 
@@ -36,6 +47,7 @@ class TableDefinitionColumnFactoryTest extends TestCase
                 'name' => 'testNoDefinitionUseBaseType',
                 'basetype' => 'STRING',
             ],
+            'expectedTabeDefinitionColumnClass' => BaseTypeTableDefinitionColumn::class,
         ];
 
         yield 'snowflake native' => [
@@ -56,6 +68,7 @@ class TableDefinitionColumnFactoryTest extends TestCase
                     'nullable' => true,
                 ],
             ],
+            'expectedTabeDefinitionColumnClass' => NativeTableDefinitionColumn::class,
         ];
 
         yield 'snowflake native missing tableMetadata' => [
@@ -67,6 +80,7 @@ class TableDefinitionColumnFactoryTest extends TestCase
                 'name' => 'testNativeToBaseType',
                 'basetype' => 'STRING',
             ],
+            'expectedTabeDefinitionColumnClass' => BaseTypeTableDefinitionColumn::class,
         ];
 
         yield 'full native type definition' => [
@@ -87,13 +101,14 @@ class TableDefinitionColumnFactoryTest extends TestCase
                     'nullable' => false,
                 ],
             ],
+            'expectedTabeDefinitionColumnClass' => NativeTableDefinitionColumn::class,
         ];
 
         yield 'native type without basetype' => [
             'columnName' => 'testDecimalWithLength',
             'columnMetadata' => [
                 [
-                    'key' => Snowflake::KBC_METADATA_KEY_NULLABLE,
+                    'key' => Common::KBC_METADATA_KEY_NULLABLE,
                     'value' => false,
                 ],
             ],
@@ -102,6 +117,66 @@ class TableDefinitionColumnFactoryTest extends TestCase
             'expectedSerialisation' => [
                 'name' => 'testDecimalWithLength',
             ],
+            'expectedTabeDefinitionColumnClass' => BaseTypeTableDefinitionColumn::class,
+        ];
+
+        yield 'different backend' => [
+            'columnName' => 'testTime',
+            'columnMetadata' => (new Bigquery('TIME'))->toMetadata(),
+            'tableMetadata' => [
+                [
+                    'key' => 'KBC.datatype.backend',
+                    'value' => 'bigquery',
+                ],
+            ],
+            'backendType' => 'snowflake',
+            'expectedSerialisation' => [
+                'name' => 'testTime',
+                'basetype' => 'TIMESTAMP',
+            ],
+            'expectedTabeDefinitionColumnClass' => BaseTypeTableDefinitionColumn::class,
+        ];
+
+        yield 'bigquery native' => [
+            'columnName' => 'testTime',
+            'columnMetadata' => (new Bigquery('TIME'))->toMetadata(),
+            'tableMetadata' => [
+                [
+                    'key' => 'KBC.datatype.backend',
+                    'value' => 'bigquery',
+                ],
+            ],
+            'backendType' => 'bigquery',
+            'expectedSerialisation' => [
+                'name' => 'testTime',
+                'definition' => [
+                    'type' => 'TIME',
+                    'length' => null,
+                    'nullable' => true,
+                ],
+            ],
+            'expectedTabeDefinitionColumnClass' => NativeTableDefinitionColumn::class,
+        ];
+
+        yield 'exasol native' => [
+            'columnName' => 'testTime',
+            'columnMetadata' => (new Exasol('TIMESTAMP'))->toMetadata(),
+            'tableMetadata' => [
+                [
+                    'key' => 'KBC.datatype.backend',
+                    'value' => 'exasol',
+                ],
+            ],
+            'backendType' => 'exasol',
+            'expectedSerialisation' => [
+                'name' => 'testTime',
+                'definition' => [
+                    'type' => 'TIMESTAMP',
+                    'length' => null,
+                    'nullable' => true,
+                ],
+            ],
+            'expectedTabeDefinitionColumnClass' => NativeTableDefinitionColumn::class,
         ];
     }
 }


### PR DESCRIPTION
…TYPE_CLASS_MAP

Fixes: https://keboola.atlassian.net/browse/PST-2051

Dělá se to kvůli tomu, že tam chybělo bigquery = BQ + native types všechno zakládalo s basetypes

Imho podle tohoto https://keboola.atlassian.net/browse/PST-2051?focusedCommentId=125202 by to nemělo failovat na existujících tabulkách. (Někdo už používá BQ se starýma native types.)