### PR TITLE
fix[service-client]: Fix switched namespace of billing & buffer services

### DIFF
--- a/libs/service-client/src/Service.php
+++ b/libs/service-client/src/Service.php
@@ -51,8 +51,8 @@ enum Service
     {
         return match ($this) {
             self::AI => 'ai-service-api.default',
-            self::BILLING => 'billing-api.buffer',
-            self::BUFFER => 'buffer-api.default',
+            self::BILLING => 'billing-api.default',
+            self::BUFFER => 'buffer-api.buffer',
             self::CONNECTION => 'connection-api.connection',
             self::ENCRYPTION => 'encryption-api.default',
             self::IMPORT => 'sapi-importer.default',

--- a/libs/service-client/tests/ServiceClientTest.php
+++ b/libs/service-client/tests/ServiceClientTest.php
@@ -28,8 +28,8 @@ class ServiceClientTest extends TestCase
     private const PUBLIC_VAULT = 'https://vault.north-europe.azure.keboola.com';
 
     private const INTERNAL_AI_SERVICE = 'http://ai-service-api.default.svc.cluster.local';
-    private const INTERNAL_BILLING_SERVICE = 'http://billing-api.buffer.svc.cluster.local';
-    private const INTERNAL_BUFFER_SERVICE = 'http://buffer-api.default.svc.cluster.local';
+    private const INTERNAL_BILLING_SERVICE = 'http://billing-api.default.svc.cluster.local';
+    private const INTERNAL_BUFFER_SERVICE = 'http://buffer-api.buffer.svc.cluster.local';
     private const INTERNAL_CONNECTION_SERVICE = 'http://connection-api.connection.svc.cluster.local';
     private const INTERNAL_DATA_SCIENCE_SERVICE = 'http://sandboxes-service-api.default.svc.cluster.local';
     private const INTERNAL_ENCRYPTION_SERVICE = 'http://encryption-api.default.svc.cluster.local';

--- a/libs/service-client/tests/ServiceTest.php
+++ b/libs/service-client/tests/ServiceTest.php
@@ -52,8 +52,8 @@ class ServiceTest extends TestCase
     public function provideInternalServiceNames(): iterable
     {
         yield 'ai' => [Service::AI, 'ai-service-api.default'];
-        yield 'billing' => [Service::BILLING, 'billing-api.buffer']; // <-- custom namespace
-        yield 'buffer' => [Service::BUFFER, 'buffer-api.default'];
+        yield 'billing' => [Service::BILLING, 'billing-api.default'];
+        yield 'buffer' => [Service::BUFFER, 'buffer-api.buffer']; // <-- custom namespace
         yield 'connection' => [Service::CONNECTION, 'connection-api.connection']; // <-- custom namespace
         yield 'data-science' => [Service::SANDBOXES_SERVICE, 'sandboxes-service-api.default'];
         yield 'encryption' => [Service::ENCRYPTION, 'encryption-api.default'];


### PR DESCRIPTION
Nahodou jsem narazil na to, ze mame prohozeny namespace u `billing` a `buffer` servis (`billing` bezi v `default` NS, `buffer` ve svym NS).

![image](https://github.com/user-attachments/assets/7c569d0d-0d1f-4dd3-bb0a-269384f1c583)

![image](https://github.com/user-attachments/assets/021bde11-3b64-4cf2-b4d4-7bb33bdab20a)
