### PR TITLE
[output-mapping] phpunit - table structure modifier tests added to na…

### DIFF
--- a/libs/output-mapping/src/Storage/TableStructureModifier.php
+++ b/libs/output-mapping/src/Storage/TableStructureModifier.php
@@ -5,12 +5,14 @@ declare(strict_types=1);
 namespace Keboola\OutputMapping\Storage;
 
 use Keboola\Datatype\Definition\BaseType;
+use Keboola\OutputMapping\Exception\InvalidOutputException;
 use Keboola\OutputMapping\Exception\PrimaryKeyNotChangedException;
 use Keboola\OutputMapping\Mapping\MappingColumnMetadata;
 use Keboola\OutputMapping\Mapping\MappingFromProcessedConfiguration;
 use Keboola\OutputMapping\Writer\Helper\PrimaryKeyHelper;
 use Keboola\OutputMapping\Writer\Table\MappingDestination;
 use Keboola\OutputMapping\Writer\Table\TableDefinition\TableDefinitionColumnFactory;
+use Keboola\StorageApi\ClientException;
 
 class TableStructureModifier extends AbstractTableStructureModifier
 {
@@ -99,14 +101,18 @@ class TableStructureModifier extends AbstractTableStructureModifier
             ];
         }
 
-        foreach ($missingColumnsData as $missingColumnData) {
-            [$columnName, $columnDefinition, $columnBasetype] = $missingColumnData;
-            $this->client->addTableColumn(
-                $currentTableInfo->getId(),
-                $columnName,
-                $columnDefinition,
-                $columnBasetype,
-            );
+        try {
+            foreach ($missingColumnsData as $missingColumnData) {
+                [$columnName, $columnDefinition, $columnBasetype] = $missingColumnData;
+                $this->client->addTableColumn(
+                    $currentTableInfo->getId(),
+                    $columnName,
+                    $columnDefinition,
+                    $columnBasetype,
+                );
+            }
+        } catch (ClientException $e) {
+            throw new InvalidOutputException($e->getMessage(), $e->getCode(), $e);
         }
     }
 


### PR DESCRIPTION
…tive types suites

Fixes: https://keboola.atlassian.net/browse/PST-2101


Konverze Storage API erroru na InvalidtOutputException pri pridavani novych sloupcu.

Pro OM se schema, to neni potreba resit, tam uz je to osetrene https://github.com/keboola/platform-libraries/blob/8ebcb710b74d744f62d10c10c4c5fa4382585ce9/libs/output-mapping/src/Storage/TableStructureModifierFromSchema.php#L59
