### PR TITLE
[output-mapping] abs tests moved to own suite for azure

### DIFF
--- a/azure-pipelines/jobs/run-tests.yml
+++ b/azure-pipelines/jobs/run-tests.yml
@@ -34,8 +34,13 @@ parameters:
     type: string
     default: docker-images.tar
 
+  - name: condition
+    type: string
+    default: 'always()'
+
 jobs:
   - job: ${{ parameters.jobName }}
+    condition: ${{ parameters.condition }}
     dependsOn: ${{ parameters.dependsOn }}
     displayName: ${{ parameters.displayName }}
     variables: ${{ parameters.variables }}

--- a/libs/output-mapping/azure-pipelines.tests.yml
+++ b/libs/output-mapping/azure-pipelines.tests.yml
@@ -101,11 +101,10 @@ jobs:
       testCommand: 'composer install && vendor/bin/phpunit --testsuite synapse-writer-tests'
       variables:
         STORAGE_API_URL: $(STORAGE_API_URL_AZURE)
-        RUN_SYNAPSE_TESTS: $(RUN_SYNAPSE_TESTS)
+        SYNAPSE_STORAGE_API_URL: $(STORAGE_API_URL_AZURE)
       secrets:
         STORAGE_API_TOKEN: $(OUTPUT_MAPPING__STORAGE_API_TOKEN_AZURE)
         STORAGE_API_TOKEN_MASTER: $(OUTPUT_MAPPING__STORAGE_API_TOKEN_MASTER_AZURE)
-        SYNAPSE_STORAGE_API_URL: $(STORAGE_API_URL_AZURE)
         SYNAPSE_STORAGE_API_TOKEN: $(OUTPUT_MAPPING__SYNAPSE_STORAGE_API_TOKEN)
 
   - template: ../../azure-pipelines/jobs/run-tests.yml

--- a/libs/output-mapping/azure-pipelines.tests.yml
+++ b/libs/output-mapping/azure-pipelines.tests.yml
@@ -94,13 +94,14 @@ jobs:
   - template: ../../azure-pipelines/jobs/run-tests.yml
     parameters:
       jobName: tests_php81_tableWriter_synapse
+      condition: eq(variables.RUN_SYNAPSE_TESTS, '1')
       dependsOn: [cs]
       displayName: Synapse Writer Tests
       serviceName: dev-output-mapping
       testCommand: 'composer install && vendor/bin/phpunit --testsuite synapse-writer-tests'
       variables:
         STORAGE_API_URL: $(STORAGE_API_URL_AZURE)
-        RUN_SYNAPSE_TESTS: 0
+        RUN_SYNAPSE_TESTS: $(RUN_SYNAPSE_TESTS)
       secrets:
         STORAGE_API_TOKEN: $(OUTPUT_MAPPING__STORAGE_API_TOKEN_AZURE)
         STORAGE_API_TOKEN_MASTER: $(OUTPUT_MAPPING__STORAGE_API_TOKEN_MASTER_AZURE)

--- a/libs/output-mapping/azure-pipelines.tests.yml
+++ b/libs/output-mapping/azure-pipelines.tests.yml
@@ -93,6 +93,22 @@ jobs:
 
   - template: ../../azure-pipelines/jobs/run-tests.yml
     parameters:
+      jobName: tests_php81_tableWriter_synapse
+      dependsOn: [cs]
+      displayName: Synapse Writer Tests
+      serviceName: dev-output-mapping
+      testCommand: 'composer install && vendor/bin/phpunit --testsuite synapse-writer-tests'
+      variables:
+        STORAGE_API_URL: $(STORAGE_API_URL_AZURE)
+        RUN_SYNAPSE_TESTS: 0
+      secrets:
+        STORAGE_API_TOKEN: $(OUTPUT_MAPPING__STORAGE_API_TOKEN_AZURE)
+        STORAGE_API_TOKEN_MASTER: $(OUTPUT_MAPPING__STORAGE_API_TOKEN_MASTER_AZURE)
+        SYNAPSE_STORAGE_API_URL: $(STORAGE_API_URL_AZURE)
+        SYNAPSE_STORAGE_API_TOKEN: $(OUTPUT_MAPPING__SYNAPSE_STORAGE_API_TOKEN)
+
+  - template: ../../azure-pipelines/jobs/run-tests.yml
+    parameters:
       jobName: tests_php81_tableWriter_nativeTypes
       dependsOn: [ cs ]
       displayName: Native types tests

--- a/libs/output-mapping/phpunit.xml.dist
+++ b/libs/output-mapping/phpunit.xml.dist
@@ -21,6 +21,9 @@
             <exclude>tests/Writer/TableDefinitionV2Test.php</exclude>
             <exclude>tests/Writer/StorageApiLocalTableWriterTest.php</exclude>
             <exclude>tests/Writer/StorageApiHeadlessWriterTest.php</exclude>
+            <exclude>tests/Writer/File/Strategy/ABSWorkspaceTest.php</exclude>
+            <exclude>tests/Writer/Table/Source/AbsWorkspaceItemSourceFactoryTest.php</exclude>
+            <exclude>tests/Writer/Table/Strategy/AbsWorkspaceTableStrategyTest.php</exclude>
         </testsuite>
         <testsuite name="main-writer-tests-1">
             <file>tests/Writer/StorageApiLocalTableWriterTest.php</file>
@@ -43,6 +46,7 @@
         </testsuite>
         <testsuite name="workspace-writer-tests">
             <directory>tests/Writer/Workspace</directory>
+            <exclude>tests/Writer/Workspace/AbsWriterWorkspaceTest.php</exclude>
         </testsuite>
         <testsuite name="native-types">
             <file>tests/Writer/TableDefinitionTest.php</file>
@@ -54,6 +58,14 @@
             <directory>tests/Writer/Table</directory>
             <file>tests/Writer/StorageApiLocalTableWriterTest.php</file>
             <file>tests/Writer/StorageApiSlicedWriterTest.php</file>
+            <exclude>tests/Writer/Table/Source/AbsWorkspaceItemSourceFactoryTest.php</exclude>
+            <exclude>tests/Writer/Table/Strategy/AbsWorkspaceTableStrategyTest.php</exclude>
+        </testsuite>
+        <testsuite name="synapse-writer-tests">
+            <file>tests/Writer/File/Strategy/ABSWorkspaceTest.php</file>
+            <file>tests/Writer/Table/Source/AbsWorkspaceItemSourceFactoryTest.php</file>
+            <file>tests/Writer/Table/Strategy/AbsWorkspaceTableStrategyTest.php</file>
+            <file>tests/Writer/Workspace/AbsWriterWorkspaceTest.php</file>
         </testsuite>
     </testsuites>
     <coverage processUncoveredFiles="true">

--- a/libs/output-mapping/phpunit.xml.dist
+++ b/libs/output-mapping/phpunit.xml.dist
@@ -47,6 +47,7 @@
         <testsuite name="workspace-writer-tests">
             <directory>tests/Writer/Workspace</directory>
             <exclude>tests/Writer/Workspace/AbsWriterWorkspaceTest.php</exclude>
+            <exclude>tests/Writer/Workspace/SynapseWriterWorkspaceTest.php</exclude>
         </testsuite>
         <testsuite name="native-types">
             <file>tests/Writer/TableDefinitionTest.php</file>
@@ -66,6 +67,7 @@
             <file>tests/Writer/Table/Source/AbsWorkspaceItemSourceFactoryTest.php</file>
             <file>tests/Writer/Table/Strategy/AbsWorkspaceTableStrategyTest.php</file>
             <file>tests/Writer/Workspace/AbsWriterWorkspaceTest.php</file>
+            <file>tests/Writer/Workspace/SynapseWriterWorkspaceTest.php</file>
         </testsuite>
     </testsuites>
     <coverage processUncoveredFiles="true">

--- a/libs/output-mapping/tests/InitSynapseStorageClientTrait.php
+++ b/libs/output-mapping/tests/InitSynapseStorageClientTrait.php
@@ -4,26 +4,11 @@ declare(strict_types=1);
 
 namespace Keboola\OutputMapping\Tests;
 
-use Keboola\StorageApi\Exception;
 use Keboola\StorageApiBranch\ClientWrapper;
 use Keboola\StorageApiBranch\Factory\ClientOptions;
 
 trait InitSynapseStorageClientTrait
 {
-    protected function checkSynapseTests(): bool
-    {
-        if (!getenv('RUN_SYNAPSE_TESTS')) {
-            return false;
-        }
-        if (getenv('SYNAPSE_STORAGE_API_TOKEN') === false) {
-            throw new Exception('SYNAPSE_STORAGE_API_TOKEN must be set for synapse tests');
-        }
-        if (getenv('SYNAPSE_STORAGE_API_URL') === false) {
-            throw new Exception('SYNAPSE_STORAGE_API_URL must be set for synapse tests');
-        }
-        return true;
-    }
-
     protected function getSynapseClientWrapper(): ClientWrapper
     {
         $clientOptions = (new ClientOptions())

--- a/libs/output-mapping/tests/Writer/File/Strategy/ABSWorkspaceTest.php
+++ b/libs/output-mapping/tests/Writer/File/Strategy/ABSWorkspaceTest.php
@@ -26,14 +26,6 @@ class ABSWorkspaceTest extends AbstractTestCase
         $this->clientWrapper = $this->getSynapseClientWrapper();
     }
 
-    public function setUp(): void
-    {
-        if (!$this->checkSynapseTests()) {
-            self::markTestSkipped('Synapse tests disabled.');
-        }
-        parent::setUp();
-    }
-
     private function getProvider(array $data = []): ProviderInterface
     {
         $mock = self::getMockBuilder(NullProvider::class)

--- a/libs/output-mapping/tests/Writer/Table/Source/AbsWorkspaceItemSourceFactoryTest.php
+++ b/libs/output-mapping/tests/Writer/Table/Source/AbsWorkspaceItemSourceFactoryTest.php
@@ -24,14 +24,6 @@ class AbsWorkspaceItemSourceFactoryTest extends AbstractTestCase
         $this->clientWrapper = $this->getSynapseClientWrapper();
     }
 
-    public function setUp(): void
-    {
-        if (!$this->checkSynapseTests()) {
-            self::markTestSkipped('Synapse tests disabled.');
-        }
-        parent::setUp();
-    }
-
     public function testCreateSource(): void
     {
         $workspaces = new Workspaces($this->clientWrapper->getBranchClient());

--- a/libs/output-mapping/tests/Writer/Workspace/AbsWriterWorkspaceTest.php
+++ b/libs/output-mapping/tests/Writer/Workspace/AbsWriterWorkspaceTest.php
@@ -25,9 +25,6 @@ class AbsWriterWorkspaceTest extends AbstractTestCase
 
     public function setUp(): void
     {
-        if (!$this->checkSynapseTests()) {
-            self::markTestSkipped('Synapse tests disabled.');
-        }
         parent::setUp();
         $this->clearFileUploads([self::FILE_TAG]);
     }

--- a/libs/output-mapping/tests/Writer/Workspace/SynapseWriterWorkspaceTest.php
+++ b/libs/output-mapping/tests/Writer/Workspace/SynapseWriterWorkspaceTest.php
@@ -20,14 +20,6 @@ class SynapseWriterWorkspaceTest extends AbstractTestCase
 {
     use InitSynapseStorageClientTrait;
 
-    public function setUp(): void
-    {
-        if (!$this->checkSynapseTests()) {
-            self::markTestSkipped('Synapse tests disabled.');
-        }
-        parent::setUp();
-    }
-
     protected function initClient(?string $branchId = null): void
     {
         $this->clientWrapper = $this->getSynapseClientWrapper();

--- a/libs/output-mapping/tests/Writer/Workspace/SynapseWriterWorkspaceTest.php
+++ b/libs/output-mapping/tests/Writer/Workspace/SynapseWriterWorkspaceTest.php
@@ -10,11 +10,7 @@ use Keboola\OutputMapping\Tests\AbstractTestCase;
 use Keboola\OutputMapping\Tests\InitSynapseStorageClientTrait;
 use Keboola\OutputMapping\Tests\Needs\NeedsEmptyInputBucket;
 use Keboola\OutputMapping\Tests\Needs\NeedsEmptyOutputBucket;
-use Keboola\OutputMapping\Tests\Needs\NeedsTestTables;
-use Keboola\OutputMapping\Tests\Needs\TestSatisfyer;
 use Keboola\OutputMapping\Writer\TableWriter;
-use Keboola\StorageApi\Client;
-use Keboola\StorageApi\TableExporter;
 
 class SynapseWriterWorkspaceTest extends AbstractTestCase
 {
@@ -26,39 +22,10 @@ class SynapseWriterWorkspaceTest extends AbstractTestCase
     }
 
     #[NeedsEmptyOutputBucket]
+    #[NeedsEmptyInputBucket]
     public function testSynapseTableOutputMapping(): void
     {
         // snowflake bucket does not work - https://keboola.atlassian.net/browse/KBC-228
-        $bucketName = 'testSynapseTableOutputMapping';
-
-        $outBucketId = TestSatisfyer::getBucketIdByDisplayName($this->clientWrapper, $bucketName, Client::STAGE_OUT);
-        if ($outBucketId !== null) {
-            $tables = $this->clientWrapper->getTableAndFileStorageClient()->listTables($outBucketId, ['include' => '']);
-            foreach ($tables as $table) {
-                $this->clientWrapper->getTableAndFileStorageClient()->dropTable($table['id']);
-            }
-        } else {
-            $outBucketId  = $this->clientWrapper->getTableAndFileStorageClient()->createBucket(
-                name: $bucketName,
-                stage: Client::STAGE_OUT,
-                backend: 'synapse',
-            );
-        }
-
-        $bucketId = TestSatisfyer::getBucketIdByDisplayName($this->clientWrapper, $bucketName, Client::STAGE_IN);
-        if ($bucketId !== null) {
-            $tables = $this->clientWrapper->getTableAndFileStorageClient()->listTables($bucketId, ['include' => '']);
-            foreach ($tables as $table) {
-                $this->clientWrapper->getTableAndFileStorageClient()->dropTable($table['id']);
-            }
-        } else {
-            $bucketId  = $this->clientWrapper->getTableAndFileStorageClient()->createBucket(
-                name: $bucketName,
-                stage: Client::STAGE_IN,
-                backend: 'synapse',
-            );
-        }
-
         $csv = new CsvFile($this->temp->getTmpFolder() . DIRECTORY_SEPARATOR . 'upload.csv');
         $csv->writeRow(['Id', 'Name', 'foo', 'bar']);
         $csv->writeRow(['id1', 'name1', 'foo1', 'bar1']);
@@ -69,7 +36,7 @@ class SynapseWriterWorkspaceTest extends AbstractTestCase
         // Create table
         for ($i = 0; $i < 2; $i++) {
             $tableIds[$i] = $this->clientWrapper->getTableAndFileStorageClient()->createTableAsync(
-                $bucketId,
+                $this->emptyInputBucketId,
                 'test' . ($i + 1),
                 $csv,
             );
@@ -85,16 +52,16 @@ class SynapseWriterWorkspaceTest extends AbstractTestCase
         $factory->getTableOutputStrategy(AbstractStrategyFactory::WORKSPACE_SYNAPSE)
             ->getDataStorage()->getWorkspaceId();
         $root = $this->temp->getTmpFolder();
-        $this->prepareWorkspaceWithTables($bucketId);
+        $this->prepareWorkspaceWithTables($this->emptyInputBucketId);
         $configs = [
             [
                 'source' => 'table1a',
-                'destination' => $outBucketId . '.table1a',
+                'destination' => $this->emptyOutputBucketId . '.table1a',
                 'distribution_key' => [],
             ],
             [
                 'source' => 'table2a',
-                'destination' => $outBucketId . '.table2a',
+                'destination' => $this->emptyOutputBucketId . '.table2a',
                 'distribution_key' => ['Id'],
             ],
         ];
@@ -123,21 +90,21 @@ class SynapseWriterWorkspaceTest extends AbstractTestCase
         $jobIds = $tableQueue->waitForAll();
         self::assertCount(2, $jobIds);
 
-        $tables = $this->clientWrapper->getTableAndFileStorageClient()->listTables($outBucketId);
+        $tables = $this->clientWrapper->getTableAndFileStorageClient()->listTables($this->emptyOutputBucketId);
         self::assertCount(2, $tables);
         $sortedTables = [$tables[0]['id'] => $tables[0], $tables[1]['id'] => $tables[1]];
         ksort($sortedTables);
         self::assertEquals(
-            [$outBucketId . '.table1a', $outBucketId . '.table2a'],
+            [$this->emptyOutputBucketId . '.table1a', $this->emptyOutputBucketId . '.table2a'],
             array_keys($sortedTables),
         );
-        self::assertArrayHasKey('distributionKey', $sortedTables[$outBucketId . '.table2a']);
-        self::assertEquals(['Id'], $sortedTables[$outBucketId . '.table2a']['distributionKey']);
+        self::assertArrayHasKey('distributionKey', $sortedTables[$this->emptyOutputBucketId . '.table2a']);
+        self::assertEquals(['Id'], $sortedTables[$this->emptyOutputBucketId . '.table2a']['distributionKey']);
         self::assertCount(2, $jobIds);
         self::assertNotEmpty($jobIds[0]);
         self::assertNotEmpty($jobIds[1]);
-        self::assertTableRowsEquals(
-            $outBucketId . '.table1a',
+        $this->assertTableRowsEquals(
+            $this->emptyOutputBucketId . '.table1a',
             [
                 '"id","name","foo","bar"',
                 '"id1","name1","foo1","bar1"',

--- a/libs/staging-provider/azure-pipelines.tests.yml
+++ b/libs/staging-provider/azure-pipelines.tests.yml
@@ -8,7 +8,7 @@ jobs:
       testCommand: bash -c 'composer install && composer ci'
       variables:
         STORAGE_API_URL: $(STORAGE_API_URL_AWS)
-        RUN_SYNAPSE_TESTS: 1
+        SYNAPSE_STORAGE_API_URL: $(STORAGE_API_URL_AZURE)
       secrets:
         STORAGE_API_TOKEN: $(STAGING_PROVIDER__STORAGE_API_TOKEN_AWS)
         SYNAPSE_STORAGE_API_TOKEN: $(STAGING_PROVIDER__SYNAPSE_STORAGE_API_TOKEN)


### PR DESCRIPTION
Mělo by fixovat build na CI
- output-mapping - přesunutí testů souvisejících se synapse do samostatné suity
- stagin-providier - synapse testy se pousti jen kdyz je nastavena variable