### PR TITLE
[output-mapping] LoadTableTaskCreatorTest table ids asserts fixup

### DIFF
--- a/libs/output-mapping/tests/LoadTableTaskCreatorTest.php
+++ b/libs/output-mapping/tests/LoadTableTaskCreatorTest.php
@@ -81,7 +81,7 @@ class LoadTableTaskCreatorTest extends AbstractTestCase
         self::assertInstanceOf(LoadTableTask::class, $loadTask);
         self::assertTrue($loadTask->isUsingFreshlyCreatedTable());
         self::assertSame(
-            'out.c-testNativeTypeLoadTaskTableNotExistsEmpty.destinationTable',
+            $this->emptyOutputBucketId . '.destinationTable',
             $loadTask->getDestinationTableName(),
         );
         $storageTable = $this->clientWrapper->getTableAndFileStorageClient()->getTable(
@@ -177,7 +177,7 @@ class LoadTableTaskCreatorTest extends AbstractTestCase
         self::assertInstanceOf(LoadTableTask::class, $loadTask);
         self::assertTrue($loadTask->isUsingFreshlyCreatedTable());
         self::assertSame(
-            'out.c-testNewNativeTypeLoadTaskTableNotExistsEmpty.destinationTable',
+            $this->emptyOutputBucketId . '.destinationTable',
             $loadTask->getDestinationTableName(),
         );
         $storageTable = $this->clientWrapper->getTableAndFileStorageClient()->getTable(
@@ -250,7 +250,7 @@ class LoadTableTaskCreatorTest extends AbstractTestCase
         self::assertInstanceOf(LoadTableTask::class, $loadTask);
         self::assertTrue($loadTask->isUsingFreshlyCreatedTable());
         self::assertSame(
-            'out.c-testLoadTaskTableNotExistsEmpty.destinationTable',
+            $this->emptyOutputBucketId . '.destinationTable',
             $loadTask->getDestinationTableName(),
         );
         $storageTable = $this->clientWrapper->getTableAndFileStorageClient()->getTable(
@@ -301,7 +301,7 @@ class LoadTableTaskCreatorTest extends AbstractTestCase
         self::assertInstanceOf(LoadTableTask::class, $loadTask);
         self::assertFalse($loadTask->isUsingFreshlyCreatedTable());
         self::assertSame(
-            'in.c-testLoadTaskTableExistsTest.test0',
+            $this->testBucketId . '.test0',
             $loadTask->getDestinationTableName(),
         );
     }
@@ -342,7 +342,7 @@ class LoadTableTaskCreatorTest extends AbstractTestCase
         self::assertInstanceOf(CreateAndLoadTableTask::class, $loadTask);
         self::assertTrue($loadTask->isUsingFreshlyCreatedTable());
         self::assertSame(
-            'out.c-testLoadTaskTableNotExistsManifestNotExistsEmpty.test0',
+            $this->emptyOutputBucketId . '.test0',
             $loadTask->getDestinationTableName(),
         );
     }

--- a/libs/output-mapping/tests/Needs/TestSatisfyer.php
+++ b/libs/output-mapping/tests/Needs/TestSatisfyer.php
@@ -119,7 +119,7 @@ class TestSatisfyer
     ): string {
         $clientWrapper = new ClientWrapper(
             new ClientOptions(
-                $clientWrapper->getBasicClient()->getApiUrl(),
+                $clientWrapper->getClientOptionsReadOnly()->getUrl(),
                 (string) getenv('STORAGE_API_TOKEN_MASTER'),
             ),
         );


### PR DESCRIPTION
Po uprave https://github.com/keboola/platform-libraries/pull/343 se mergoval nerebasnuty PR s paratestem https://github.com/keboola/platform-libraries/pull/346 ktery meni logiku pro generovani nazvu testovacich resourcu.

Tahle uprava to fixuje, aby prochazela pipeline.