### PR TITLE
[output-mapping] allow values_from_workspace without workspace id

### DIFF
--- a/libs/output-mapping/src/Configuration/Table/BaseConfiguration.php
+++ b/libs/output-mapping/src/Configuration/Table/BaseConfiguration.php
@@ -86,7 +86,7 @@ abstract class BaseConfiguration extends Configuration
                                         ->end()
                                         ->arrayNode('values_from_workspace')
                                             ->children()
-                                                ->scalarNode('workspace_id')->isRequired()->cannotBeEmpty()->end()
+                                                ->scalarNode('workspace_id')->end()
                                                 ->scalarNode('table')->isRequired()->cannotBeEmpty()->end()
                                                 ->scalarNode('column')->end()
                                             ->end()

--- a/libs/output-mapping/tests/Configuration/Table/BaseConfigurationTest.php
+++ b/libs/output-mapping/tests/Configuration/Table/BaseConfigurationTest.php
@@ -763,6 +763,34 @@ class BaseConfigurationTest extends TestCase
             ],
         ];
 
+        yield 'single where_filter with values_from_workspace wihout column and workspace_id' => [
+            'deleteWhere' => [
+                [
+                    'where_filters' => [
+                        [
+                            'column' => 'city',
+                            'values_from_workspace' => [
+                                'table' => 'cities',
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+            'expectedDeleteWhereConfig' => [
+                [
+                    'where_filters' => [
+                        [
+                            'column' => 'city',
+                            'operator' => 'eq',
+                            'values_from_workspace' => [
+                                'table' => 'cities',
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
         yield 'single where_filter with values_from_storage' => [
             'deleteWhere' => [
                 [


### PR DESCRIPTION
Fixes: https://keboola.atlassian.net/browse/PST-2398
Oprava pro https://github.com/keboola/platform-libraries/pull/362

> The child config "workspace_id" under "container.storage.output.tables.0.delete_where.0.where_filters.0.values_from_workspace" must be configured.