### PR TITLE
PST-883 [service-client] Improve usage

### DIFF
--- a/libs/service-client/composer.json
+++ b/libs/service-client/composer.json
@@ -14,6 +14,11 @@
             "Keboola\\ServiceClient\\": "src/"
         }
     },
+    "autoload-dev": {
+        "psr-4": {
+            "Keboola\\ServiceClient\\Tests\\": "tests/"
+        }
+    },
     "require": {
         "php": ">=8.1"
     },

--- a/libs/service-client/src/Service.php
+++ b/libs/service-client/src/Service.php
@@ -68,4 +68,26 @@ enum Service
             self::VAULT => 'vault-api.default',
         };
     }
+
+    public function getServiceEnvPrefix(): string
+    {
+        return match ($this) {
+            self::AI => 'AI',
+            self::BILLING => 'BILLING',
+            self::BUFFER => 'BUFFER',
+            self::CONNECTION => 'CONNECTION',
+            self::ENCRYPTION => 'ENCRYPTION',
+            self::IMPORT => 'IMPORT',
+            self::NOTIFICATION => 'NOTIFICATION',
+            self::OAUTH => 'OAUTH',
+            self::QUEUE => 'QUEUE',
+            self::QUEUE_INTERNAL_API => 'QUEUE_INTERNAL_API',
+            self::SANDBOXES_API => 'SANDBOXES_API',
+            self::SANDBOXES_SERVICE => 'SANDBOXES_SERVICE',
+            self::SCHEDULER => 'SCHEDULER',
+            self::SYNC_ACTIONS => 'SYNC_ACTIONS',
+            self::TEMPLATES => 'TEMPLATES',
+            self::VAULT => 'VAULT',
+        };
+    }
 }

--- a/libs/service-client/src/ServiceClient.php
+++ b/libs/service-client/src/ServiceClient.php
@@ -76,8 +76,13 @@ class ServiceClient
      */
     public function getServiceUrl(Service $service, ?ServiceDnsType $dnsType = null): string
     {
-        $dnsType ??= $this->defaultDnsType;
+        $serviceUrlEnvName = sprintf('KBC_%s_SERVICE_URL', $service->getServiceEnvPrefix());
+        $serviceUrl = getenv($serviceUrlEnvName);
+        if ($serviceUrl !== false && $serviceUrl !== '') {
+            return $serviceUrl;
+        }
 
+        $dnsType ??= $this->defaultDnsType;
         if ($dnsType === ServiceDnsType::INTERNAL) {
             return sprintf('http://%s.%s', $service->getInternalServiceName(), self::K8S_SUFFIX);
         }

--- a/libs/service-client/tests/ServiceClientTest.php
+++ b/libs/service-client/tests/ServiceClientTest.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Keboola\ServiceClient\Tests;
 
+use InvalidArgumentException;
+use Keboola\ServiceClient\Service;
 use Keboola\ServiceClient\ServiceClient;
 use Keboola\ServiceClient\ServiceDnsType;
 use PHPUnit\Framework\TestCase;
@@ -153,5 +155,40 @@ class ServiceClientTest extends TestCase
         self::assertSame(self::INTERNAL_SYNC_ACTIONS_SERVICE, $client->getSyncActionsServiceUrl());
         self::assertSame(self::INTERNAL_TEMPLATES, $client->getTemplatesUrl());
         self::assertSame(self::INTERNAL_VAULT, $client->getVaultUrl());
+    }
+
+    public function testFromServicePublicUrlCreatesClient(): void
+    {
+        $client = ServiceClient::fromServicePublicUrl(
+            Service::CONNECTION,
+            'https://connection.north-europe.azure.keboola.com',
+        );
+
+        self::assertEquals(
+            new ServiceClient('north-europe.azure.keboola.com', ServiceDnsType::PUBLIC),
+            $client,
+        );
+    }
+
+    public function testFromServicePublicUrlFailsWithInvalidUrl(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid URL "not-an-url"');
+
+        ServiceClient::fromServicePublicUrl(
+            Service::CONNECTION,
+            'not-an-url',
+        );
+    }
+
+    public function testFromServicePublicUrlFailsForInvalidSubdomain(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('"https://billing.north-europe.azure.keboola.com" is not CONNECTION service URL');
+
+        ServiceClient::fromServicePublicUrl(
+            Service::CONNECTION,
+            'https://billing.north-europe.azure.keboola.com',
+        );
     }
 }

--- a/libs/service-client/tests/ServiceClientTest.php
+++ b/libs/service-client/tests/ServiceClientTest.php
@@ -226,4 +226,34 @@ class ServiceClientTest extends TestCase
             'https://billing.north-europe.azure.keboola.com',
         );
     }
+
+    /**
+     * @runInSeparateProcess because we override ENV
+     */
+    public function testGetServiceUrlOverridenByEnv(): void
+    {
+        $serviceClient = new ServiceClient('keboola.com', ServiceDnsType::PUBLIC);
+
+        putenv('KBC_CONNECTION_SERVICE_URL=https://connection.example.com');
+
+        // check both PUBLIC and INTERNAL dns is overridden
+        self::assertSame(
+            'https://connection.example.com',
+            $serviceClient->getConnectionServiceUrl(ServiceDnsType::PUBLIC),
+        );
+        self::assertSame(
+            'https://connection.example.com',
+            $serviceClient->getConnectionServiceUrl(ServiceDnsType::INTERNAL),
+        );
+
+        // check other services are unaffected
+        self::assertSame(
+            'https://queue.keboola.com',
+            $serviceClient->getQueueUrl(ServiceDnsType::PUBLIC),
+        );
+        self::assertSame(
+            'http://job-queue-api.default.svc.cluster.local',
+            $serviceClient->getQueueUrl(ServiceDnsType::INTERNAL),
+        );
+    }
 }

--- a/libs/service-client/tests/ServiceTest.php
+++ b/libs/service-client/tests/ServiceTest.php
@@ -72,4 +72,28 @@ class ServiceTest extends TestCase
     {
         self::assertSame($expectedValue, $service->getInternalServiceName());
     }
+
+    public function provideServiceEnvPrefixes(): iterable
+    {
+        yield 'ai' => [Service::AI, 'AI'];
+        yield 'billing' => [Service::BILLING, 'BILLING'];
+        yield 'buffer' => [Service::BUFFER, 'BUFFER'];
+        yield 'connection' => [Service::CONNECTION, 'CONNECTION'];
+        yield 'data-science' => [Service::SANDBOXES_SERVICE, 'SANDBOXES_SERVICE'];
+        yield 'encryption' => [Service::ENCRYPTION, 'ENCRYPTION'];
+        yield 'import' => [Service::IMPORT, 'IMPORT'];
+        yield 'notification' => [Service::NOTIFICATION, 'NOTIFICATION'];
+        yield 'oauth' => [Service::OAUTH, 'OAUTH'];
+        yield 'queue' => [Service::QUEUE, 'QUEUE'];
+        yield 'queue internal api' => [Service::QUEUE_INTERNAL_API, 'QUEUE_INTERNAL_API'];
+        yield 'sandboxes' => [Service::SANDBOXES_API, 'SANDBOXES_API'];
+        yield 'scheduler' => [Service::SCHEDULER, 'SCHEDULER'];
+        yield 'sync-actions' => [Service::SYNC_ACTIONS, 'SYNC_ACTIONS'];
+    }
+
+    /** @dataProvider provideServiceEnvPrefixes */
+    public function testGetServiceEnvPrefix(Service $service, string $expectedValue): void
+    {
+        self::assertSame($expectedValue, $service->getServiceEnvPrefix());
+    }
 }


### PR DESCRIPTION
https://keboola.atlassian.net/browse/PST-883

V `service-container` je takova zlvastni situace, jak je to komponenta, tak to nema `hostnameSuffix` a navic to muze mit spesl URL pro Job Queue Internal API. Kdyz jsem laboroval co s tim, hodilo by se mi par zlepsovaku.

Pro pouziti v `service-container` bych potreboval par zlepsovaku:
* pridana moznost nechat `hostnameSuffix: null`, pokud pracuju jen s `INTERNAL` DNS
* moznost vytvorit `ServiceContainer` bez `hostnameSuffix`, pokud uz mam URL nejaky service (`ServiceContainer::fromServicePublicUrl()`)
* pridana moznost pretizit URL konkretni service pres ENV (tohle bude asi dost kontroverzni :smile:)

Use-case k tomu pretizeni pres ENV je `job_queue_url`, ktera v `service-container` muze byt v testech nestandardni, protoze `job-queue-daemon` testy maji vlastni instanci Internal API. Tim padem potrebuju vlastne:
* v testech `job-queue`daemon` tam poslat URL te custom instance na dev/ci K8S clusteru, ktera je v ENV `job-queue-daemon`
* v testech `service-container` tam poslat URL mock serveru, ktery je nahozeny lokalne pres `docker-componse`
* v produkci tam teoreticky jde pouzit primo `INTERNAL` URL ze `ServiceContainer`

Cili, standardne (v produkci) by nebylo nastavene nic a pouzivala by se `INTERNAL` URL ze `ServiceClient`. V testech by se do ENV nastavila `KBC_QUEUE_INTERNAL_API_SERVICE_API` na URL z dev/CI clusteru a tim by se to out-of-box pretizilo.

V opacnym pripade je potreba v `service-container`
* pouzivat `ServiceClient` pro URL Storage API (v kombinaci s nejakym ENV, ktery bude prepinat mezi `INTERNAL` a `PUBLIC` URL v produkci vs dev/ci)
* predavat navic `job_queue_url` a tu pouzivat pro vytvareni Job Queue Internal API clienta

Je to celkem zamotany, tak klidne si na to muzem v rychlosti zavolat.