### PR TITLE
Make unified configuration resolver related classes non-readonly

### DIFF
--- a/libs/configuration-variables-resolver/src/UnifiedConfigurationResolver.php
+++ b/libs/configuration-variables-resolver/src/UnifiedConfigurationResolver.php
@@ -4,18 +4,18 @@ declare(strict_types=1);
 
 namespace Keboola\ConfigurationVariablesResolver;
 
-readonly class UnifiedConfigurationResolver
+class UnifiedConfigurationResolver
 {
     /**
      * @param non-empty-string $branchId
      * @param non-empty-string|null $variableValuesId
      */
     public function __construct(
-        private SharedCodeResolver $sharedCodeResolver,
-        private VariablesResolver $variablesResolver,
-        private string $branchId,
-        private ?string $variableValuesId = null,
-        private ?array $variableValuesData = null,
+        private readonly SharedCodeResolver $sharedCodeResolver,
+        private readonly VariablesResolver $variablesResolver,
+        private readonly string $branchId,
+        private readonly ?string $variableValuesId = null,
+        private readonly ?array $variableValuesData = null,
     ) {
     }
 

--- a/libs/configuration-variables-resolver/src/UnifiedConfigurationResolverFactory.php
+++ b/libs/configuration-variables-resolver/src/UnifiedConfigurationResolverFactory.php
@@ -10,12 +10,12 @@ use Keboola\VaultApiClient\ApiClientConfiguration as VaultVariablesApiClientConf
 use Keboola\VaultApiClient\Variables\VariablesApiClient;
 use Psr\Log\LoggerInterface;
 
-readonly class UnifiedConfigurationResolverFactory
+class UnifiedConfigurationResolverFactory
 {
     public function __construct(
-        private ServiceClient $serviceClient,
-        private VaultVariablesApiClientConfiguration $vaultVariablesApiClientConfiguration,
-        private LoggerInterface $logger,
+        private readonly ServiceClient $serviceClient,
+        private readonly VaultVariablesApiClientConfiguration $vaultVariablesApiClientConfiguration,
+        private readonly LoggerInterface $logger,
     ) {
     }
 


### PR DESCRIPTION
Viz. dnešní call kolem testů, tj. nejde namockovat readonly class v rámci testů na daemonovi, takže tímhle to obejdeme.