### PR TITLE
PST-2512 [messenger-bundle] Replace event ID with UUID

### DIFF
--- a/libs/messenger-bundle/src/ConnectionEvent/ApplicationEvent/GenericApplicationEvent.php
+++ b/libs/messenger-bundle/src/ConnectionEvent/ApplicationEvent/GenericApplicationEvent.php
@@ -14,7 +14,7 @@ class GenericApplicationEvent implements EventInterface
 {
     public function __construct(
         public readonly string $name,
-        public readonly int $id,
+        public readonly string $uuid,
         public readonly string $type,
 
         // identification
@@ -59,8 +59,8 @@ class GenericApplicationEvent implements EventInterface
             throw new InvalidArgumentException('Event is missing property "name"');
         }
 
-        if (empty($data['idEvent'])) {
-            throw new InvalidArgumentException('Event is missing property "idEvent"');
+        if (empty($data['uuid'])) {
+            throw new InvalidArgumentException('Event is missing property "uuid"');
         }
 
         if (empty($data['type'])) {
@@ -69,7 +69,7 @@ class GenericApplicationEvent implements EventInterface
 
         return new self(
             $data['name'],
-            $data['idEvent'],
+            $data['uuid'],
             $data['type'],
             isset($data['idAdmin']) ? (int) $data['idAdmin'] : null,
             isset($data['idProject']) ? (int) $data['idProject'] : null,
@@ -102,7 +102,7 @@ class GenericApplicationEvent implements EventInterface
     {
         return [
             'name' => $this->name,
-            'idEvent' => $this->id,
+            'uuid' => $this->uuid,
             'type' => $this->type,
 
             'idAdmin' => $this->idAdmin,
@@ -139,7 +139,7 @@ class GenericApplicationEvent implements EventInterface
 
     public function getId(): string
     {
-        return (string) $this->id;
+        return (string) $this->uuid;
     }
 
     public function getEventName(): string

--- a/libs/messenger-bundle/src/ConnectionEvent/ApplicationEvent/Storage/DevBranchCreatedEvent.php
+++ b/libs/messenger-bundle/src/ConnectionEvent/ApplicationEvent/Storage/DevBranchCreatedEvent.php
@@ -12,7 +12,7 @@ class DevBranchCreatedEvent implements EventInterface
     public const NAME = 'storage.devBranchCreated';
 
     public function __construct(
-        public readonly int $id,
+        public readonly string $uuid,
         public readonly int $projectId,
 
         public readonly int $accessTokenId,
@@ -39,7 +39,7 @@ class DevBranchCreatedEvent implements EventInterface
         }
 
         return new self(
-            $data['idEvent'],
+            $data['uuid'],
             $data['idProject'],
             $data['idAccessToken'],
             $data['accessTokenName'],
@@ -55,7 +55,7 @@ class DevBranchCreatedEvent implements EventInterface
     {
         return [
             'name' => self::NAME,
-            'idEvent' => $this->id,
+            'uuid' => $this->uuid,
             'idProject' => $this->projectId,
             'idAccessToken' => $this->accessTokenId,
             'accessTokenName' => $this->accessTokenName,
@@ -69,7 +69,7 @@ class DevBranchCreatedEvent implements EventInterface
 
     public function getId(): string
     {
-        return (string) $this->id;
+        return $this->uuid;
     }
 
     public function getEventName(): string

--- a/libs/messenger-bundle/src/ConnectionEvent/ApplicationEvent/Storage/DevBranchDeletedEvent.php
+++ b/libs/messenger-bundle/src/ConnectionEvent/ApplicationEvent/Storage/DevBranchDeletedEvent.php
@@ -13,7 +13,7 @@ class DevBranchDeletedEvent implements EventInterface
     public const NAME = 'storage.devBranchDeleted';
 
     public function __construct(
-        public readonly int $id,
+        public readonly string $uuid,
         public readonly int $projectId,
 
         public readonly int $accessTokenId,
@@ -40,7 +40,7 @@ class DevBranchDeletedEvent implements EventInterface
         }
 
         return new self(
-            $data['idEvent'],
+            $data['uuid'],
             $data['idProject'],
             $data['idAccessToken'],
             $data['accessTokenName'],
@@ -56,7 +56,7 @@ class DevBranchDeletedEvent implements EventInterface
     {
         return [
             'name' => self::NAME,
-            'idEvent' => $this->id,
+            'uuid' => $this->uuid,
             'idProject' => $this->projectId,
             'idAccessToken' => $this->accessTokenId,
             'accessTokenName' => $this->accessTokenName,
@@ -70,7 +70,7 @@ class DevBranchDeletedEvent implements EventInterface
 
     public function getId(): string
     {
-        return (string) $this->id;
+        return (string) $this->uuid;
     }
 
     public function getEventName(): string

--- a/libs/messenger-bundle/tests/ConnectionEvent/ApplicationEvent/ApplicationEventFactoryTest.php
+++ b/libs/messenger-bundle/tests/ConnectionEvent/ApplicationEvent/ApplicationEventFactoryTest.php
@@ -45,7 +45,7 @@ class ApplicationEventFactoryTest extends TestCase
         $this->expectException(EventFactoryException::class);
         $this->expectExceptionMessage(
             'Failed to create Keboola\MessengerBundle\ConnectionEvent\ApplicationEvent\GenericApplicationEvent ' .
-            'from event data: Event is missing property "idEvent"',
+            'from event data: Event is missing property "uuid"',
         );
 
         $factory->createEventFromArray([
@@ -64,7 +64,7 @@ class ApplicationEventFactoryTest extends TestCase
             'created' => '2023-10-18T16:08:48+02:00',
             'data' => [
                 'name' => 'storage.devBranchCreated',
-                'idEvent' => 20224549,
+                'uuid' => '01958fcb-6cf6-778b-ac16-fb7cd4f9ab3d',
                 'idProject' => 34,
                 'idAccessToken' => 107,
                 'accessTokenName' => 'josef.martinec@keboolaconnection.onmicrosoft.com',
@@ -79,7 +79,7 @@ class ApplicationEventFactoryTest extends TestCase
         ]);
 
         self::assertInstanceOf(DevBranchCreatedEvent::class, $event);
-        self::assertSame(20224549, $event->id);
+        self::assertSame('01958fcb-6cf6-778b-ac16-fb7cd4f9ab3d', $event->uuid);
     }
 
     public function testCreateGenericEvent(): void
@@ -96,7 +96,7 @@ class ApplicationEventFactoryTest extends TestCase
                 'params' => [
                     'task' => 'file-import',
                 ],
-                'idEvent' => 20219944,
+                'uuid' => '01958fcb-6cf6-778b-ac16-fb7cd4f9ab3d',
                 'type' => 'info',
             ],
         ]);
@@ -106,7 +106,7 @@ class ApplicationEventFactoryTest extends TestCase
         self::assertSame('', $event->objectId);
         self::assertSame(18, $event->idProject);
         self::assertSame(['task' => 'file-import'], $event->params);
-        self::assertSame(20219944, $event->id);
+        self::assertSame('01958fcb-6cf6-778b-ac16-fb7cd4f9ab3d', $event->uuid);
         self::assertSame('info', $event->type);
     }
 }

--- a/libs/messenger-bundle/tests/ConnectionEvent/ApplicationEvent/ApplicationEventTest.php
+++ b/libs/messenger-bundle/tests/ConnectionEvent/ApplicationEvent/ApplicationEventTest.php
@@ -14,12 +14,12 @@ class ApplicationEventTest extends TestCase
     {
         $event = GenericApplicationEvent::fromArray([
             'name' => 'ext.keboola.keboola-buffer.',
-            'idEvent' => 20219944,
+            'uuid' => '01958fcb-6cf6-778b-ac16-fb7cd4f9ab3d',
             'type' => 'info',
         ]);
 
         self::assertSame('ext.keboola.keboola-buffer.', $event->name);
-        self::assertSame(20219944, $event->id);
+        self::assertSame('01958fcb-6cf6-778b-ac16-fb7cd4f9ab3d', $event->uuid);
         self::assertSame('info', $event->type);
         self::assertNull($event->idAdmin);
         self::assertNull($event->idProject);
@@ -69,7 +69,7 @@ class ApplicationEventTest extends TestCase
             'performance' => [
                 'foo' => 'bar',
             ],
-            'idEvent' => 20219944,
+            'uuid' => '01958fcb-6cf6-778b-ac16-fb7cd4f9ab3d',
             'type' => 'info',
             'description' => 'event description',
             'context' => [
@@ -110,7 +110,7 @@ class ApplicationEventTest extends TestCase
         self::assertSame('object-name', $event->objectName);
         self::assertSame(['task' => 'file-import'], $event->params);
         self::assertSame(['foo' => 'bar'], $event->performance);
-        self::assertSame(20219944, $event->id);
+        self::assertSame('01958fcb-6cf6-778b-ac16-fb7cd4f9ab3d', $event->uuid);
         self::assertSame('info', $event->type);
         self::assertSame('event description', $event->description);
         self::assertSame([
@@ -140,24 +140,24 @@ class ApplicationEventTest extends TestCase
     {
         yield 'missing name' => [
             'data' => [
-                'idEvent' => 20219944,
+                'uuid' => '01958fcb-6cf6-778b-ac16-fb7cd4f9ab3d',
                 'type' => 'info',
             ],
             'error' => 'Event is missing property "name"',
         ];
 
-        yield 'missing idEvent' => [
+        yield 'missing uuid' => [
             'data' => [
                 'name' => 'ext.keboola.keboola-buffer.',
                 'type' => 'info',
             ],
-            'error' => 'Event is missing property "idEvent"',
+            'error' => 'Event is missing property "uuid"',
         ];
 
         yield 'missing type' => [
             'data' => [
                 'name' => 'ext.keboola.keboola-buffer.',
-                'idEvent' => 20219944,
+                'uuid' => '01958fcb-6cf6-778b-ac16-fb7cd4f9ab3d',
             ],
             'error' => 'Event is missing property "type"',
         ];
@@ -176,13 +176,13 @@ class ApplicationEventTest extends TestCase
     {
         $event = new GenericApplicationEvent(
             name: 'ext.keboola.keboola-buffer.',
-            id: 20219944,
+            uuid: '01958fcb-6cf6-778b-ac16-fb7cd4f9ab3d',
             type: 'info',
         );
 
         self::assertSame([
             'name' => 'ext.keboola.keboola-buffer.',
-            'idEvent' => 20219944,
+            'uuid' => '01958fcb-6cf6-778b-ac16-fb7cd4f9ab3d',
             'type' => 'info',
             'idAdmin' => null,
             'idProject' => null,
@@ -215,7 +215,7 @@ class ApplicationEventTest extends TestCase
     {
         $event = new GenericApplicationEvent(
             name: 'ext.keboola.keboola-buffer.',
-            id: 20219944,
+            uuid: '01958fcb-6cf6-778b-ac16-fb7cd4f9ab3d',
             type: 'info',
             idAdmin: 19,
             idProject: 18,
@@ -261,7 +261,7 @@ class ApplicationEventTest extends TestCase
 
         self::assertSame([
             'name' => 'ext.keboola.keboola-buffer.',
-            'idEvent' => 20219944,
+            'uuid' => '01958fcb-6cf6-778b-ac16-fb7cd4f9ab3d',
             'type' => 'info',
             'idAdmin' => 19,
             'idProject' => 18,
@@ -310,11 +310,11 @@ class ApplicationEventTest extends TestCase
     {
         $event = GenericApplicationEvent::fromArray([
             'name' => 'ext.keboola.keboola-buffer.',
-            'idEvent' => 20219944,
+            'uuid' => '01958fcb-6cf6-778b-ac16-fb7cd4f9ab3d',
             'type' => 'info',
         ]);
 
         self::assertSame('ext.keboola.keboola-buffer.', $event->getEventName());
-        self::assertSame('20219944', $event->getId());
+        self::assertSame('01958fcb-6cf6-778b-ac16-fb7cd4f9ab3d', $event->getId());
     }
 }

--- a/libs/messenger-bundle/tests/ConnectionEvent/ApplicationEvent/Storage/DevBranchCreatedEventTest.php
+++ b/libs/messenger-bundle/tests/ConnectionEvent/ApplicationEvent/Storage/DevBranchCreatedEventTest.php
@@ -14,7 +14,7 @@ class DevBranchCreatedEventTest extends TestCase
     private const EVENT_MESSAGE_DATA = [
         'data' => [
             'name' => 'storage.devBranchCreated',
-            'idEvent' => 123,
+            'uuid' => '01958fcb-6cf6-778b-ac16-fb7cd4f9ab3d',
             'idProject' => 456,
             'idAccessToken' => 789,
             'accessTokenName' => 'test@example.com',
@@ -32,14 +32,14 @@ class DevBranchCreatedEventTest extends TestCase
         $event = $eventFactory->createEventFromArray(self::EVENT_MESSAGE_DATA);
 
         self::assertInstanceOf(DevBranchCreatedEvent::class, $event);
-        self::assertSame(123, $event->id);
+        self::assertSame('01958fcb-6cf6-778b-ac16-fb7cd4f9ab3d', $event->uuid);
     }
 
     public function testCreateFromArray(): void
     {
         $event = DevBranchCreatedEvent::fromArray(self::EVENT_MESSAGE_DATA['data']);
 
-        self::assertSame(123, $event->id);
+        self::assertSame('01958fcb-6cf6-778b-ac16-fb7cd4f9ab3d', $event->uuid);
         self::assertSame(456, $event->projectId);
         self::assertSame(789, $event->accessTokenId);
         self::assertSame('test@example.com', $event->accessTokenName);
@@ -66,7 +66,7 @@ class DevBranchCreatedEventTest extends TestCase
     public function testToArray(): void
     {
         $event = new DevBranchCreatedEvent(
-            id: 123,
+            uuid: '01958fcb-6cf6-778b-ac16-fb7cd4f9ab3d',
             projectId: 456,
             accessTokenId: 789,
             accessTokenName: 'test@example.com',
@@ -79,7 +79,7 @@ class DevBranchCreatedEventTest extends TestCase
 
         self::assertSame([
             'name' => 'storage.devBranchCreated',
-            'idEvent' => 123,
+            'uuid' => '01958fcb-6cf6-778b-ac16-fb7cd4f9ab3d',
             'idProject' => 456,
             'idAccessToken' => 789,
             'accessTokenName' => 'test@example.com',

--- a/libs/messenger-bundle/tests/ConnectionEvent/ApplicationEvent/Storage/DevBranchDeletedEventTest.php
+++ b/libs/messenger-bundle/tests/ConnectionEvent/ApplicationEvent/Storage/DevBranchDeletedEventTest.php
@@ -14,7 +14,7 @@ class DevBranchDeletedEventTest extends TestCase
     private const EVENT_MESSAGE_DATA = [
         'data' => [
             'name' => 'storage.devBranchDeleted',
-            'idEvent' => 123,
+            'uuid' => '01958fcb-6cf6-778b-ac16-fb7cd4f9ab3d',
             'idProject' => 456,
             'idAccessToken' => 789,
             'accessTokenName' => 'test@example.com',
@@ -32,14 +32,14 @@ class DevBranchDeletedEventTest extends TestCase
         $event = $eventFactory->createEventFromArray(self::EVENT_MESSAGE_DATA);
 
         self::assertInstanceOf(DevBranchDeletedEvent::class, $event);
-        self::assertSame(123, $event->id);
+        self::assertSame('01958fcb-6cf6-778b-ac16-fb7cd4f9ab3d', $event->uuid);
     }
 
     public function testCreateFromArray(): void
     {
         $event = DevBranchDeletedEvent::fromArray(self::EVENT_MESSAGE_DATA['data']);
 
-        self::assertSame(123, $event->id);
+        self::assertSame('01958fcb-6cf6-778b-ac16-fb7cd4f9ab3d', $event->uuid);
         self::assertSame(456, $event->projectId);
         self::assertSame(789, $event->accessTokenId);
         self::assertSame('test@example.com', $event->accessTokenName);
@@ -66,7 +66,7 @@ class DevBranchDeletedEventTest extends TestCase
     public function testToArray(): void
     {
         $event = new DevBranchDeletedEvent(
-            id: 123,
+            uuid: '01958fcb-6cf6-778b-ac16-fb7cd4f9ab3d',
             projectId: 456,
             accessTokenId: 789,
             accessTokenName: 'test@example.com',
@@ -79,7 +79,7 @@ class DevBranchDeletedEventTest extends TestCase
 
         self::assertSame([
             'name' => 'storage.devBranchDeleted',
-            'idEvent' => 123,
+            'uuid' => '01958fcb-6cf6-778b-ac16-fb7cd4f9ab3d',
             'idProject' => 456,
             'idAccessToken' => 789,
             'accessTokenName' => 'test@example.com',


### PR DESCRIPTION
https://keboola.atlassian.net/browse/PST-2512
https://keboolaglobal.slack.com/archives/C08HLV1E5LH/p1741873983545469?thread_ts=1741854899.043299&cid=C08HLV1E5LH

@zajca v ramci reseni performance eventu v [#prod_24_7___inc_21370](https://keboolaglobal.slack.com/archives/C08HLV1E5LH) rusi jejich `int $id` a nahrazuje to za `string $uuid`. To potrebujem reflektovat v nasi reprezentaci Connection eventu (a pak updatnout ve vsech appkach, kde se to pouizva).