### PR TITLE
[configuration-variables-resolver]: Allow keboola/storage-api-client version 16 & 17

### DIFF
--- a/libs/configuration-variables-resolver/composer.json
+++ b/libs/configuration-variables-resolver/composer.json
@@ -39,7 +39,7 @@
         "ext-json": "*",
         "keboola/common-exceptions": "^1.1",
         "keboola/service-client": "*@dev",
-        "keboola/storage-api-client": "^15.2",
+        "keboola/storage-api-client": "^15.2|^16|^17",
         "keboola/storage-api-php-client-branch-wrapper": "^6.0",
         "keboola/vault-api-client": "*@dev",
         "mustache/mustache": "^2.13",


### PR DESCRIPTION
Povoleni verzu 16 & 17 `keboola/storage-api-client`. Jsou to sice major verze, ale zadna z breaking-changes se netyka pouziti v `configuration-variables-resolver`