### PR TITLE
Allow Symfony 7 across libs

### DIFF
--- a/libs/configuration-variables-resolver/composer.json
+++ b/libs/configuration-variables-resolver/composer.json
@@ -44,7 +44,7 @@
         "keboola/vault-api-client": "*@dev",
         "mustache/mustache": "^2.13",
         "psr/log": "^1.1|^2.0|^3.0",
-        "symfony/config": "^5.2|^6.2"
+        "symfony/config": "^5.2|^6.2|^7.0"
     },
     "require-dev": {
         "infection/infection": "^0.26",
@@ -53,7 +53,7 @@
         "phpstan/phpstan-phpunit": "^1.3",
         "phpunit/phpunit": "^9.5",
         "sempro/phpunit-pretty-print": "^1.4",
-        "symfony/dotenv": "^5.4|^6.2",
+        "symfony/dotenv": "^5.4|^6.2|^7.0",
         "symfony/http-client": "^7.2"
     },
     "scripts": {

--- a/libs/configuration-variables-resolver/src/Configuration/SharedCodeRow.php
+++ b/libs/configuration-variables-resolver/src/Configuration/SharedCodeRow.php
@@ -8,7 +8,7 @@ use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 
 class SharedCodeRow extends AbstractConfiguration
 {
-    public function getConfigTreeBuilder()
+    public function getConfigTreeBuilder(): TreeBuilder
     {
         $treeBuilder = new TreeBuilder('configuration');
         $rootNode = $treeBuilder->getRootNode();

--- a/libs/logging-bundle/azure-pipelines.tests.yml
+++ b/libs/logging-bundle/azure-pipelines.tests.yml
@@ -1,16 +1,16 @@
 jobs:
   - template: ../../azure-pipelines/jobs/run-tests.yml
     parameters:
-      displayName: Tests (Symfony 5.4)
-      serviceName: dev74
-      testCommand: bash -c 'cd libs/logging-bundle && composer install && composer ci'
-      variables:
-        SYMFONY_REQUIRE: "5.4.*"
-
-  - template: ../../azure-pipelines/jobs/run-tests.yml
-    parameters:
-      displayName: Tests (Symfony 6.1)
+      displayName: Tests (Symfony 6.4)
       serviceName: dev81
       testCommand: bash -c 'cd libs/logging-bundle && composer install && composer ci'
       variables:
-        SYMFONY_REQUIRE: "6.1.*"
+        SYMFONY_REQUIRE: "6.4.*"
+
+  - template: ../../azure-pipelines/jobs/run-tests.yml
+    parameters:
+      displayName: Tests (Symfony 7.2)
+      serviceName: dev83
+      testCommand: bash -c 'cd libs/logging-bundle && composer install && composer ci'
+      variables:
+        SYMFONY_REQUIRE: "7.2.*"

--- a/libs/logging-bundle/composer.json
+++ b/libs/logging-bundle/composer.json
@@ -3,8 +3,8 @@
     "description": "Keboola Logging Bundle",
     "type": "symfony-bundle",
     "require": {
-        "monolog/monolog": "^2.0|^3.0",
-        "symfony/dependency-injection": "^5.4|^6.0|^7.0",
+        "monolog/monolog": "^3.0",
+        "symfony/dependency-injection": "^6.0|^7.0",
         "symfony/monolog-bundle": "^3.8"
     },
     "require-dev": {
@@ -13,8 +13,8 @@
         "phpstan/phpstan-phpunit": "^1.1",
         "phpunit/phpunit": "^9.5",
         "sempro/phpunit-pretty-print": "^1.4",
-        "symfony/framework-bundle": "^5.4|^6.0",
-        "symfony/yaml": "^5.4|^6.0"
+        "symfony/framework-bundle": "^6.0|^7.0",
+        "symfony/yaml": "^6.0|^7.0"
     },
     "license": "MIT",
     "autoload": {
@@ -53,6 +53,10 @@
         "ci": [
             "@composer validate --no-check-all --strict",
             "@build"
-        ]
+        ],
+        "auto-scripts": {
+            "cache:clear": "symfony-cmd",
+            "assets:install %PUBLIC_DIR%": "symfony-cmd"
+        }
     }
 }

--- a/libs/logging-bundle/composer.json
+++ b/libs/logging-bundle/composer.json
@@ -3,7 +3,7 @@
     "description": "Keboola Logging Bundle",
     "type": "symfony-bundle",
     "require": {
-        "monolog/monolog": "^2.0",
+        "monolog/monolog": "^2.0|^3.0",
         "symfony/dependency-injection": "^5.4|^6.0|^7.0",
         "symfony/monolog-bundle": "^3.8"
     },

--- a/libs/logging-bundle/src/Monolog/DataDogContextProcessor.php
+++ b/libs/logging-bundle/src/Monolog/DataDogContextProcessor.php
@@ -4,17 +4,18 @@ declare(strict_types=1);
 
 namespace Keboola\LoggingBundle\Monolog;
 
+use Monolog\LogRecord;
 use Monolog\Processor\ProcessorInterface;
 
 use function DDTrace\current_context;
 
 class DataDogContextProcessor implements ProcessorInterface
 {
-    public function __invoke(array $record): array
+    public function __invoke(LogRecord $record): LogRecord
     {
         $context = current_context();
 
-        $record['dd'] = [
+        $record->extra['dd'] = [
             'trace_id' => $context['trace_id'],
             'span_id'  => $context['span_id'],
         ];

--- a/libs/messenger-bundle/composer.json
+++ b/libs/messenger-bundle/composer.json
@@ -32,9 +32,9 @@
         "ext-pcntl": "*",
         "aymdev/messenger-azure-bundle": "dev-dsnParser",
         "petitpress/gps-messenger-bundle": "^1.6",
-        "symfony/amazon-sqs-messenger": "^6.3",
-        "symfony/dependency-injection": "^6.0",
-        "symfony/messenger": "^6.0"
+        "symfony/amazon-sqs-messenger": "^6.3|^7.0",
+        "symfony/dependency-injection": "^6.0|^7.0",
+        "symfony/messenger": "^6.0|^7.0"
     },
     "require-dev": {
         "keboola/coding-standard": "^15.0",
@@ -43,10 +43,10 @@
         "phpstan/phpstan-symfony": "^1.3",
         "phpunit/phpunit": "^9.6",
         "sempro/phpunit-pretty-print": "^1.4",
-        "symfony/console": "^6.3",
-        "symfony/dotenv": "^6.3",
-        "symfony/framework-bundle": "^6.0",
-        "symfony/yaml": "^6.0"
+        "symfony/console": "^6.3|^7.0",
+        "symfony/dotenv": "^6.3|^7.0",
+        "symfony/framework-bundle": "^6.0|^7.0",
+        "symfony/yaml": "^6.0|^7.0"
     },
 
     "config": {

--- a/libs/permission-checker/composer.json
+++ b/libs/permission-checker/composer.json
@@ -37,8 +37,8 @@
         "phpstan/phpstan-phpunit": "^1.1",
         "phpunit/phpunit": "^9.5",
         "sempro/phpunit-pretty-print": "^1.4",
-        "symfony/dotenv": "^6.2",
-        "symfony/filesystem": "^6.1"
+        "symfony/dotenv": "^6.2|^7.0",
+        "symfony/filesystem": "^6.1|^7.0"
     },
     "config": {
         "sort-packages": true,

--- a/libs/sandboxes-service-api-client/composer.json
+++ b/libs/sandboxes-service-api-client/composer.json
@@ -40,7 +40,7 @@
         "phpstan/phpstan-phpunit": "^1.3",
         "phpstan/phpstan-webmozart-assert": "^1.2",
         "sempro/phpunit-pretty-print": "^1.4",
-        "symfony/http-client": "^6.4"
+        "symfony/http-client": "^6.4|^7.0"
     },
     "scripts": {
         "ci": [

--- a/libs/service-client/composer.json
+++ b/libs/service-client/composer.json
@@ -24,7 +24,7 @@
         "phpstan/phpstan": "^1.10.59",
         "phpunit/phpunit": "^9.6.17",
         "sempro/phpunit-pretty-print": "^1.4",
-        "symfony/dotenv": "^6.4.4"
+        "symfony/dotenv": "^6.4.4|^7.0"
     },
     "scripts": {
         "tests": [

--- a/libs/settle/composer.json
+++ b/libs/settle/composer.json
@@ -29,7 +29,7 @@
         "ext-json": "*",
         "keboola/common-exceptions": "^1.1",
         "psr/log": "^1.1|^2.0|^3.0",
-        "symfony/config": "^5.2|^6.2"
+        "symfony/config": "^5.2|^6.2|^7.0"
     },
     "require-dev": {
         "infection/infection": "^0.26",
@@ -38,7 +38,7 @@
         "phpstan/phpstan": "^1.9",
         "phpunit/phpunit": "^9.5",
         "sempro/phpunit-pretty-print": "^1.4",
-        "symfony/dotenv": "^6.2"
+        "symfony/dotenv": "^6.2|^7.0"
     },
     "scripts": {
         "tests": [

--- a/libs/slicer/composer.json
+++ b/libs/slicer/composer.json
@@ -28,12 +28,12 @@
         "php": ">=8.1",
         "ext-curl": "*",
         "psr/log": "^1.1|^2.0|^3.0",
-        "symfony/filesystem": "^6.2"
+        "symfony/filesystem": "^6.2|^7.0"
     },
     "require-dev": {
         "infection/infection": "^0.26",
         "keboola/coding-standard": ">=14.0.0",
-        "monolog/monolog": "^2.1",
+        "monolog/monolog": "^3.0",
         "phpstan/phpstan": "^1.9",
         "phpunit/phpunit": "^9.5",
         "sempro/phpunit-pretty-print": "^1.4"

--- a/libs/staging-provider/composer.json
+++ b/libs/staging-provider/composer.json
@@ -41,7 +41,7 @@
         "phpstan/phpstan-phpunit": "^1.1",
         "phpunit/phpunit": "^9.5",
         "sempro/phpunit-pretty-print": "^1.4",
-        "symfony/dotenv": "^5.2|^6.0"
+        "symfony/dotenv": "^5.2|^6.0|^7.0"
     },
     "scripts": {
         "tests": "phpunit",

--- a/libs/vault-api-client/composer.json
+++ b/libs/vault-api-client/composer.json
@@ -41,7 +41,7 @@
         "phpstan/phpstan-webmozart-assert": "^1.2",
         "phpunit/phpunit": "^9.6",
         "sempro/phpunit-pretty-print": "^1.4",
-        "symfony/http-client": "^6.3"
+        "symfony/http-client": "^6.3|^7.0"
     },
     "scripts": {
         "ci": [


### PR DESCRIPTION
V predchozich PR (https://github.com/keboola/platform-libraries/pull/384, https://github.com/keboola/platform-libraries/pull/385) jsem updatoval podporu pro Monolog 3.x a Symfony 7.x v IM a OM, ale je to past vedle pasti, zavislost za zavislosti. Tak jsme to vzal z gruntu a pridal Symfony 7.x ke vsem libs.

Je to vice/mene jen povoleny Symfony 7.x v `composer.json`, takze to pujde ven jako patch verze. Jedina vyjimka je `logging-bundle`, kde je breaking-change, protoze obsahuje log processor, takze ten pujde ven jako major verze.