### PR TITLE
PAT-255 [staging-provider]: Getters on NewWorkspaceProvider must return real workspace values

### DIFF
--- a/libs/staging-provider/src/Provider/NewWorkspaceProvider.php
+++ b/libs/staging-provider/src/Provider/NewWorkspaceProvider.php
@@ -93,12 +93,12 @@ class NewWorkspaceProvider implements WorkspaceProviderInterface
 
     public function getBackendSize(): ?string
     {
-        return $this->workspaceBackendConfig->getStorageApiWorkspaceSize();
+        return $this->getWorkspace()->getBackendSize();
     }
 
     public function getBackendType(): string
     {
-        return $this->workspaceBackendConfig->getStorageApiWorkspaceType();
+        return $this->getWorkspace()->getBackendType();
     }
 
     public function getPath(): string


### PR DESCRIPTION
https://keboola.atlassian.net/browse/PAT-255

Tak pro velky uspech jeste zpatky na stromy. Vratil jsem `getBackendSize()` a `getBackendType()` na `NewWorkspaceProvider`, aby delaly inicializaci WS a vracely diky tomu hodnoty, ktery o WS tvrdi Connection.

V `docker-bundle` jsem narazil na test, ktery na tom failoval v situaci, kdy `WorkspaceBackendConfig` mel prazny `backendSize`. Connection v tu chvili totiz vraci default `small`.