### PR TITLE
[doctrine-retry-bundle] update to PHP 8.4

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -50,7 +50,7 @@ services:
 
   dev84: &dev84
     <<: *dev
-    image: keboola/php-dev83
+    image: keboola/php-dev84
     build:
       <<: *dev-build
       args:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -48,6 +48,17 @@ services:
     extra_hosts:
       - "host.docker.internal:host-gateway"
 
+  dev84: &dev84
+    <<: *dev
+    image: keboola/php-dev83
+    build:
+      <<: *dev-build
+      args:
+        PHP_VERSION: "8.4"
+        XDEBUG_VERSION: ""
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+
   dev-api-bundle:
     <<: *dev83
     image: keboola/api-bundle
@@ -173,11 +184,16 @@ services:
       - mysql
 
   dev-doctrine-retry-bundle:
-    <<: *dev82
+    <<: *dev84
     image: keboola/doctrine-retry-bundle
     working_dir: /code/libs/doctrine-retry-bundle
     environment:
-      TEST_DATABASE_URL: mysql://root:root@mysql:3306/testdatabase
+      TEST_DATABASE_HOST: mysql
+      TEST_DATABASE_USER: root
+      TEST_DATABASE_PASSWORD: root
+      TEST_DATABASE_PORT: 3306
+      TEST_DATABASE_DB: testdatabase
+      TEST_PROXY_HOST: toxiproxy
     depends_on:
       toxiproxy:
         condition: service_started

--- a/docker/php/php.ini
+++ b/docker/php/php.ini
@@ -9,7 +9,6 @@ output_buffering = 4096
 register_argc_argv = Off
 request_order = "GP"
 session.gc_divisor = 1000
-session.sid_bits_per_character = 5
 short_open_tag = Off
 track_errors = Off
 variables_order = "GPCS"

--- a/libs/doctrine-retry-bundle/composer.json
+++ b/libs/doctrine-retry-bundle/composer.json
@@ -17,16 +17,10 @@
         "symfony/dependency-injection": "^7.0|^6.4",
         "symfony/http-kernel": "^7.0|^6.4"
     },
-    "repositories": [
-        {
-            "type": "vcs",
-            "url": "https://github.com/keboola/toxiproxy-php-client"
-        }
-    ],
     "require-dev": {
         "ext-pdo": "*",
-        "ihsw/toxiproxy-php-client": "dev-odin-odin-KAB-1029",
-        "keboola/coding-standard": "dev-odin-KAB-1029",
+        "ihsw/toxiproxy-php-client": "^3.0",
+        "keboola/coding-standard": "^15.1",
         "monolog/monolog": "^3.9",
         "phpstan/phpstan": "^2.1",
         "phpstan/phpstan-phpunit": "^2.0",

--- a/libs/doctrine-retry-bundle/composer.json
+++ b/libs/doctrine-retry-bundle/composer.json
@@ -10,21 +10,27 @@
         }
     ],
     "require": {
-        "php": "^8.2",
-        "doctrine/dbal": "^3.3",
+        "php": "^8.4",
+        "doctrine/dbal": "^4.2",
         "doctrine/doctrine-bundle": "^2.1",
         "keboola/retry": "^0.5.0",
         "symfony/dependency-injection": "^7.0|^6.4",
         "symfony/http-kernel": "^7.0|^6.4"
     },
+    "repositories": [
+        {
+            "type": "vcs",
+            "url": "https://github.com/keboola/toxiproxy-php-client"
+        }
+    ],
     "require-dev": {
         "ext-pdo": "*",
-        "ihsw/toxiproxy-php-client": "^2.0",
-        "keboola/coding-standard": "^15.0",
-        "monolog/monolog": "^2.3",
-        "phpstan/phpstan": "^1.4",
-        "phpstan/phpstan-phpunit": "^1.0",
-        "phpunit/phpunit": "^9.5"
+        "ihsw/toxiproxy-php-client": "dev-odin-odin-KAB-1029",
+        "keboola/coding-standard": "dev-odin-KAB-1029",
+        "monolog/monolog": "^3.9",
+        "phpstan/phpstan": "^2.1",
+        "phpstan/phpstan-phpunit": "^2.0",
+        "phpunit/phpunit": "^12.1"
     },
     "autoload": {
         "psr-4": {

--- a/libs/doctrine-retry-bundle/src/DependencyInjection/Compiler/ConfigureDbalRetryProxyPass.php
+++ b/libs/doctrine-retry-bundle/src/DependencyInjection/Compiler/ConfigureDbalRetryProxyPass.php
@@ -72,9 +72,9 @@ class ConfigureDbalRetryProxyPass implements CompilerPassInterface
             }
 
             assert(is_array($arguments));
-            assert(count($arguments) > 0);
-            assert(is_array($arguments[0]));
-            return $arguments[0];
+            $config = $arguments[0] ?? null;
+            assert(is_array($config));
+            return $config;
         }
 
         return [];

--- a/libs/doctrine-retry-bundle/src/DependencyInjection/Compiler/ConfigureDbalRetryProxyPass.php
+++ b/libs/doctrine-retry-bundle/src/DependencyInjection/Compiler/ConfigureDbalRetryProxyPass.php
@@ -21,7 +21,11 @@ class ConfigureDbalRetryProxyPass implements CompilerPassInterface
     {
         $connections = (array) $container->getParameter('doctrine.connections');
         foreach ($connections as $serviceName) {
+            assert(is_string($serviceName));
             $connectionParams = $this->getConnectionParams($container, $serviceName);
+            assert(is_array($connectionParams['driverOptions']));
+            assert(is_scalar($connectionParams['driverOptions'][self::CONFIG_OPTION_RETRIES])
+                || !isset($connectionParams['driverOptions'][self::CONFIG_OPTION_RETRIES]));
             $retries = (int) ($connectionParams['driverOptions'][self::CONFIG_OPTION_RETRIES] ?? 0);
 
             if ($retries === 0) {
@@ -67,6 +71,9 @@ class ConfigureDbalRetryProxyPass implements CompilerPassInterface
                 continue;
             }
 
+            assert(is_array($arguments));
+            assert(count($arguments) > 0);
+            assert(is_array($arguments[0]));
             return $arguments[0];
         }
 

--- a/libs/doctrine-retry-bundle/tests/FailingRetryProxy.php
+++ b/libs/doctrine-retry-bundle/tests/FailingRetryProxy.php
@@ -8,7 +8,7 @@ use Retry\RetryProxyInterface;
 
 /**
  * RetryProxy wrapper that allows putting a callback before each call. The callback is supposed to enable/disable
- * some low-level functionality (for example a network proxy to external service) to simulate service failures.
+ * some low-level functionality (for example, a network proxy to external service) to simulate service failures.
  */
 class FailingRetryProxy implements RetryProxyInterface
 {

--- a/libs/doctrine-retry-bundle/tests/MysqlProxyTestTrait.php
+++ b/libs/doctrine-retry-bundle/tests/MysqlProxyTestTrait.php
@@ -8,6 +8,7 @@ use Doctrine\DBAL\Configuration;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\DriverManager;
 use Doctrine\DBAL\Logging\Middleware as LoggingMiddleware;
+use Ihsw\Toxiproxy\Proxy;
 use Ihsw\Toxiproxy\Toxiproxy;
 use Keboola\DoctrineRetryBundle\Database\Retry\Middleware as RetryMiddleware;
 use Monolog\Handler\TestHandler;
@@ -63,11 +64,27 @@ trait MysqlProxyTestTrait
         return DriverManager::getConnection([
             'driver' => 'pdo_mysql',
             'host' => $proxyHost,
-            'port' => (int) $mysqlProxy->getListen(),
+            'port' => (int) $this->getListenPort($mysqlProxy),
             'user' => $mysqlUser,
             'password' => $mysqlPassword,
             'dbname' => $mysqlDb,
         ], $configuration);
+    }
+
+    public function getListenIp(Proxy $proxy): string
+    {
+        $ip = implode(':', explode(':', $proxy->getListen(), -1));
+        if (str_starts_with($ip, '[')) {
+            $ip = substr($ip, 1, -1);
+        }
+        return $ip;
+    }
+
+    public function getListenPort(Proxy $proxy): string
+    {
+        $ip = $this->getListenIp($proxy);
+        $start = str_starts_with($proxy->getListen(), '[') ? 3 : 1;
+        return substr($proxy->getListen(), $start + strlen($ip));
     }
 
     /**

--- a/libs/doctrine-retry-bundle/tests/MysqlProxyTestTrait.php
+++ b/libs/doctrine-retry-bundle/tests/MysqlProxyTestTrait.php
@@ -63,7 +63,7 @@ trait MysqlProxyTestTrait
         return DriverManager::getConnection([
             'driver' => 'pdo_mysql',
             'host' => $proxyHost,
-            'port' => (int) $mysqlProxy->getListenPort(),
+            'port' => (int) $mysqlProxy->getListen(),
             'user' => $mysqlUser,
             'password' => $mysqlPassword,
             'dbname' => $mysqlDb,


### PR DESCRIPTION
vydal bych to jako major verzi, je tam BC break v DBAL a dělat to tak, aby to supportovalo obě verze mě přijde hroznej vofrk na to jak málo se takhle věc updatuje
