### PR TITLE
[input-mapping,outupt-mapping]: Fix missing return types of lists in results

### DIFF
--- a/libs/input-mapping/src/Table/Result/TableInfo.php
+++ b/libs/input-mapping/src/Table/Result/TableInfo.php
@@ -56,6 +56,9 @@ class TableInfo
         return $this->sourceTableId;
     }
 
+    /**
+     * @return Column[]
+     */
     public function getColumns(): array
     {
         return $this->columns;

--- a/libs/output-mapping/src/Table/Result.php
+++ b/libs/output-mapping/src/Table/Result.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Keboola\OutputMapping\Table;
 
-use Generator;
 use Keboola\InputMapping\Table\Result\TableInfo;
 use Keboola\OutputMapping\Table\Result\Metrics;
 
@@ -21,13 +20,11 @@ class Result
     }
 
     /**
-     * @return Generator<TableInfo>
+     * @return TableInfo[]
      */
-    public function getTables(): Generator
+    public function getTables(): array
     {
-        foreach ($this->tables as $table) {
-            yield $table;
-        }
+        return $this->tables;
     }
 
     public function setMetrics(Metrics $metrics): void

--- a/libs/output-mapping/src/Table/Result/Metrics.php
+++ b/libs/output-mapping/src/Table/Result/Metrics.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace Keboola\OutputMapping\Table\Result;
 
-use Generator;
-
 class Metrics
 {
     /** @var TableMetrics[] */
@@ -18,10 +16,11 @@ class Metrics
         }
     }
 
-    public function getTableMetrics(): Generator
+    /**
+     * @return TableMetrics[]
+     */
+    public function getTableMetrics(): array
     {
-        foreach ($this->metrics as $metric) {
-            yield $metric;
-        }
+        return $this->metrics;
     }
 }


### PR DESCRIPTION
Poladeni Result classes na IM/OM:
* Doplneni chybejich typu u poli
* Prehozeni zbyvajicich `Generator` na `array` (kdysi jsem to uz menil na IM, ale neco malo zustalo jeste na OM)