### PR TITLE
PAT-317 [staging-provider] Improve StagingProvider constructor

### DIFF
--- a/libs/staging-provider/tests/Staging/StagingProviderTest.php
+++ b/libs/staging-provider/tests/Staging/StagingProviderTest.php
@@ -4,42 +4,37 @@ declare(strict_types=1);
 
 namespace Keboola\StagingProvider\Tests\Staging;
 
-use Keboola\StagingProvider\Exception\NoStagingAvailableException;
-use Keboola\StagingProvider\Staging\File\FileStagingInterface;
+use InvalidArgumentException;
 use Keboola\StagingProvider\Staging\File\LocalStaging;
-use Keboola\StagingProvider\Staging\StagingClass;
 use Keboola\StagingProvider\Staging\StagingProvider;
 use Keboola\StagingProvider\Staging\StagingType;
 use Keboola\StagingProvider\Staging\Workspace\WorkspaceStaging;
-use Keboola\StagingProvider\Staging\Workspace\WorkspaceStagingInterface;
 use PHPUnit\Framework\TestCase;
 
 class StagingProviderTest extends TestCase
 {
-    public static function provideFileStagingTypes(): iterable
+    public static function provideDiskStagingTypes(): iterable
     {
         yield 'local' => [StagingType::Local];
         yield 's3' => [StagingType::S3];
         yield 'abs' => [StagingType::Abs];
     }
 
-    /** @dataProvider provideFileStagingTypes */
-    public function testFileStagingIsReturnedForFileStaging(StagingType $stagingType): void
+    /** @dataProvider provideDiskStagingTypes */
+    public function testFileStagingIsReturnedForDiskStaging(StagingType $stagingType): void
     {
-        $localStaging = new LocalStaging('/tmp/random/data');
-        $workspaceStaging = new WorkspaceStaging('123');
-
+        $stagingDirPath = '/tmp/random/data';
         $provider = new StagingProvider(
             $stagingType,
-            $workspaceStaging,
-            $localStaging,
+            $stagingDirPath,
+            null,
         );
 
         self::assertSame($stagingType, $provider->getStagingType());
-        self::assertSame($localStaging, $provider->getFileDataStaging());
-        self::assertSame($localStaging, $provider->getFileMetadataStaging());
-        self::assertSame($localStaging, $provider->getTableDataStaging());
-        self::assertSame($localStaging, $provider->getTableMetadataStaging());
+        self::assertEquals(new LocalStaging('/tmp/random/data'), $provider->getFileDataStaging());
+        self::assertEquals(new LocalStaging('/tmp/random/data'), $provider->getFileMetadataStaging());
+        self::assertEquals(new LocalStaging('/tmp/random/data'), $provider->getTableDataStaging());
+        self::assertEquals(new LocalStaging('/tmp/random/data'), $provider->getTableMetadataStaging());
     }
 
     public static function provideWorkspaceStagingTypes(): iterable
@@ -51,75 +46,75 @@ class StagingProviderTest extends TestCase
     /** @dataProvider provideWorkspaceStagingTypes */
     public function testWorkspaceStagingIsReturnedForWorkspaceStaging(StagingType $stagingType): void
     {
-        $localStaging = new LocalStaging('/tmp/random/data');
-        $workspaceStaging = new WorkspaceStaging('123');
-
+        $stagingDirPath = '/tmp/random/data';
+        $workspaceId = '123';
         $provider = new StagingProvider(
             $stagingType,
-            $workspaceStaging,
-            $localStaging,
+            $stagingDirPath,
+            $workspaceId,
         );
 
         self::assertSame($stagingType, $provider->getStagingType());
-        self::assertSame($localStaging, $provider->getFileDataStaging());
-        self::assertSame($localStaging, $provider->getFileMetadataStaging());
-        self::assertSame($workspaceStaging, $provider->getTableDataStaging());
-        self::assertSame($localStaging, $provider->getTableMetadataStaging());
+        self::assertEquals(new LocalStaging('/tmp/random/data'), $provider->getFileDataStaging());
+        self::assertEquals(new LocalStaging('/tmp/random/data'), $provider->getFileMetadataStaging());
+        self::assertEquals(new WorkspaceStaging('123'), $provider->getTableDataStaging());
+        self::assertEquals(new LocalStaging('/tmp/random/data'), $provider->getTableMetadataStaging());
     }
 
-    public function testErrorWhenNoFileDataStagingIsConfigured(): void
+    public function testCreateForStagingTypeWithDiskStaging(): void
     {
+        $stagingDirPath = '/tmp/random/data';
         $provider = new StagingProvider(
-            StagingType::WorkspaceSnowflake,
-            null,
+            StagingType::Local,
+            $stagingDirPath,
             null,
         );
 
-        $this->expectException(NoStagingAvailableException::class);
-        $this->expectExceptionMessage('Undefined file data provider in "WorkspaceSnowflake" staging.');
-
-        $provider->getFileDataStaging();
+        self::assertSame(StagingType::Local, $provider->getStagingType());
+        self::assertEquals(new LocalStaging('/tmp/random/data'), $provider->getFileDataStaging());
+        self::assertEquals(new LocalStaging('/tmp/random/data'), $provider->getFileMetadataStaging());
+        self::assertEquals(new LocalStaging('/tmp/random/data'), $provider->getTableDataStaging());
+        self::assertEquals(new LocalStaging('/tmp/random/data'), $provider->getTableMetadataStaging());
     }
 
-    public function testErrorWhenNoFileMetadataStagingIsConfigured(): void
+    public function testCreateForStagingTypeWithWorkspaceStaging(): void
     {
+        $stagingDirPath = '/tmp/random/data';
+        $workspaceId = '123';
         $provider = new StagingProvider(
             StagingType::WorkspaceSnowflake,
-            null,
-            null,
+            $stagingDirPath,
+            $workspaceId,
         );
 
-        $this->expectException(NoStagingAvailableException::class);
-        $this->expectExceptionMessage('Undefined file metadata provider in "WorkspaceSnowflake" staging.');
-
-        $provider->getFileMetadataStaging();
+        self::assertSame(StagingType::WorkspaceSnowflake, $provider->getStagingType());
+        self::assertEquals(new LocalStaging('/tmp/random/data'), $provider->getFileDataStaging());
+        self::assertEquals(new LocalStaging('/tmp/random/data'), $provider->getFileMetadataStaging());
+        self::assertEquals(new WorkspaceStaging('123'), $provider->getTableDataStaging());
+        self::assertEquals(new LocalStaging('/tmp/random/data'), $provider->getTableMetadataStaging());
     }
 
-    public function testErrorWhenNoTableDataStagingIsConfigured(): void
+    public function testErrorWhenWorkspaceIdProvidedForDiskStaging(): void
     {
-        $provider = new StagingProvider(
-            StagingType::WorkspaceSnowflake,
-            null,
-            null,
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Staging workspace ID must be configured (only) with workspace staging.');
+
+        new StagingProvider(
+            StagingType::Local,
+            '/tmp/random/data',
+            '123',
         );
-
-        $this->expectException(NoStagingAvailableException::class);
-        $this->expectExceptionMessage('Undefined table data provider in "WorkspaceSnowflake" staging.');
-
-        $provider->getTableDataStaging();
     }
 
-    public function testErrorWhenNoTableMetadataStagingIsConfigured(): void
+    public function testErrorWhenWorkspaceIdNotProvidedForWorkspaceStaging(): void
     {
-        $provider = new StagingProvider(
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Staging workspace ID must be configured (only) with workspace staging.');
+
+        new StagingProvider(
             StagingType::WorkspaceSnowflake,
-            null,
+            '/tmp/random/data',
             null,
         );
-
-        $this->expectException(NoStagingAvailableException::class);
-        $this->expectExceptionMessage('Undefined table metadata provider in "WorkspaceSnowflake" staging.');
-
-        $provider->getTableMetadataStaging();
     }
 }


### PR DESCRIPTION
https://keboola.atlassian.net/browse/PAT-317
Vylepseni https://github.com/keboola/platform-libraries/pull/396

Uprava konstruktoru `StagingProvider` podle feedbacku:
* nove se do konstruktoru nepredava local/workspace staging objekt, ale jen path/workspaceId
  * diky tomu se bude moct zrusit `createStagingProvider` metoda a tim padem cely `BaseDataLoaderFactory` v `job-configuration` (https://github.com/keboola/job-queue/pull/562/files#diff-6969713a886141a2217d24fe9159272f105c33c15dad7e54f12e4c2c100ef04f)
* local staging neni optional, path je povinna
* validace ve staging getterech nejsou potreba, vsechny stagingy jsou vzdycky k dispozici
* do konstruktoru se presunula kontrola z `createStagingProvider`, ze pro WS staging je workspaceId nastaveny (a pro lokal neni)