### PR TITLE
PAT-319 [staging-provider] WorkspaceProvider::resetWorkspaceCredentials

### DIFF
--- a/libs/staging-provider/src/Workspace/WorkspaceWithCredentials.php
+++ b/libs/staging-provider/src/Workspace/WorkspaceWithCredentials.php
@@ -76,7 +76,7 @@ class WorkspaceWithCredentials implements WorkspaceWithCredentialsInterface
         return $this->credentials;
     }
 
-    public static function parseCredentialsData(
+    private static function parseCredentialsData(
         #[SensitiveParameter] array $data,
     ): array {
         $backend = $data['backend'];

--- a/libs/staging-provider/tests/Workspace/WorkspaceProviderFunctionalTest.php
+++ b/libs/staging-provider/tests/Workspace/WorkspaceProviderFunctionalTest.php
@@ -269,12 +269,16 @@ class WorkspaceProviderFunctionalTest extends TestCase
         ]);
         $workspaceId = (string) $workspaceData['id'];
 
-        // fetch the workspace through the workspace provider, as any client would do
-        $workspace = $this->workspaceProvider->getExistingWorkspace($workspaceId, null);
-        $newCredentials = $this->workspaceProvider->resetWorkspaceCredentials($workspace);
+        $workspace = $this->workspaceProvider->resetWorkspaceCredentials($workspaceId);
+        $workspaceCredentials = $workspace->getCredentials();
 
-        self::assertArrayHasKey('privateKey', $newCredentials);
-        self::assertStringStartsWith('-----BEGIN PRIVATE KEY-----', $newCredentials['privateKey']);
+        // validate private key is present
+        self::assertArrayHasKey('privateKey', $workspaceCredentials);
+        self::assertStringStartsWith('-----BEGIN PRIVATE KEY-----', $workspaceCredentials['privateKey'] ?? '');
+
+        // validate other connection parameters are present
+        self::assertArrayHasKey('host', $workspaceCredentials);
+        self::assertArrayHasKey('account', $workspaceCredentials);
     }
 
     public function testResetWorkspaceCredentialsWithPassword(): void
@@ -286,12 +290,16 @@ class WorkspaceProviderFunctionalTest extends TestCase
         $workspaceId = (string) $workspaceData['id'];
         $originalPassword = $workspaceData['connection']['password'];
 
-        // fetch the workspace through the workspace provider, as any client would do
-        $workspace = $this->workspaceProvider->getExistingWorkspace($workspaceId, null);
-        $newCredentials = $this->workspaceProvider->resetWorkspaceCredentials($workspace);
+        $workspace = $this->workspaceProvider->resetWorkspaceCredentials($workspaceId);
+        $workspaceCredentials = $workspace->getCredentials();
 
-        self::assertArrayHasKey('password', $newCredentials);
-        self::assertNotSame($originalPassword, $newCredentials['password']);
+        // validate password is present
+        self::assertArrayHasKey('password', $workspaceCredentials);
+        self::assertNotSame($originalPassword, $workspaceCredentials['password']);
+
+        // validate other connection parameters are present
+        self::assertArrayHasKey('host', $workspaceCredentials);
+        self::assertArrayHasKey('account', $workspaceCredentials);
     }
 
     public function testCleanupExistingWorkspace(): void


### PR DESCRIPTION
https://keboola.atlassian.net/browse/PAT-319

Pri upgrade `sandboxes` komponenty na refaktrovany `staging-provider` jsem narazil na problem, ze `resetCredentials` vraci jen heslo (`password` nebo `privateKey`), ale ne komplet credentials (co zahrnuje i veci jako `host`, `warehouse` atp.).