### PR TITLE
PAT-509 [staging-provider]: Introduce StagingType::None

### DIFF
--- a/libs/staging-provider/src/Staging/StagingClass.php
+++ b/libs/staging-provider/src/Staging/StagingClass.php
@@ -6,6 +6,7 @@ namespace Keboola\StagingProvider\Staging;
 
 enum StagingClass
 {
+    case None;
     case Disk;
     case Workspace;
 }

--- a/libs/staging-provider/src/Staging/StagingProvider.php
+++ b/libs/staging-provider/src/Staging/StagingProvider.php
@@ -22,22 +22,32 @@ class StagingProvider
         $this->stagingType = $stagingType;
         $this->localStaging = new LocalStaging($localStagingPath);
 
-        if ($stagingType->getStagingClass() === StagingClass::Workspace) {
-            if ($stagingWorkspaceId === null) {
-                throw new InvalidArgumentException(
-                    'Staging workspace ID must be configured (only) with workspace staging.',
-                );
-            }
+        switch ($stagingType->getStagingClass()) {
+            case StagingClass::Workspace:
+                if ($stagingWorkspaceId === null) {
+                    throw new InvalidArgumentException(
+                        'Staging workspace ID must be configured (only) with workspace staging.',
+                    );
+                }
 
-            $this->tableDataStaging = new WorkspaceStaging($stagingWorkspaceId);
-        } else {
-            if ($stagingWorkspaceId !== null) {
-                throw new InvalidArgumentException(
-                    'Staging workspace ID must be configured (only) with workspace staging.',
-                );
-            }
+                $this->tableDataStaging = new WorkspaceStaging($stagingWorkspaceId);
+                break;
 
-            $this->tableDataStaging = $this->localStaging;
+            case StagingClass::Disk:
+                if ($stagingWorkspaceId !== null) {
+                    throw new InvalidArgumentException(
+                        'Staging workspace ID must be configured (only) with workspace staging.',
+                    );
+                }
+
+                $this->tableDataStaging = $this->localStaging;
+                break;
+
+            default:
+                throw new InvalidArgumentException(sprintf(
+                    'Stating type "%s" is not supported.',
+                    $stagingType->value,
+                ));
         }
     }
 

--- a/libs/staging-provider/src/Staging/StagingType.php
+++ b/libs/staging-provider/src/Staging/StagingType.php
@@ -6,6 +6,7 @@ namespace Keboola\StagingProvider\Staging;
 
 enum StagingType: string
 {
+    case None = 'none';
     case Local = 'local';
     case Abs = 'abs';
     case S3 = 's3';
@@ -16,6 +17,8 @@ enum StagingType: string
     public function getStagingClass(): StagingClass
     {
         return match ($this) {
+            self::None => StagingClass::None,
+
             self::Local,
             self::Abs,
             self::S3 => StagingClass::Disk,

--- a/libs/staging-provider/tests/Staging/StagingProviderTest.php
+++ b/libs/staging-provider/tests/Staging/StagingProviderTest.php
@@ -117,4 +117,16 @@ class StagingProviderTest extends TestCase
             null,
         );
     }
+
+    public function testErrorWhenUnsupportedStagingTypeProvided(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Stating type "none" is not supported.');
+
+        new StagingProvider(
+            StagingType::None,
+            '/tmp/random/data',
+            null,
+        );
+    }
 }


### PR DESCRIPTION
https://keboola.atlassian.net/browse/PAT-509

Pridani `stagingType: none`.

Pokud ma komponenta staveny `stagingType: none`, odpovida to v podstate situaci, kdy se na ni nema delat zadny IM/OM a nedostane zadny staging, takze staging provider nema co delat a nemelo by ho tak jit IMHO vubec vytvorit.