### PR TITLE
[messenger-bundle] use aymdev/messenger-azure-bundle upstream instead of fork

### DIFF
--- a/libs/messenger-bundle/composer.json
+++ b/libs/messenger-bundle/composer.json
@@ -20,17 +20,10 @@
             "Keboola\\MessengerBundle\\Tests\\": "tests/"
         }
     },
-    "repositories": [
-        {
-            "type": "vcs",
-            "url": "git@github.com:keboola/MessengerAzureBundle.git"
-        }
-    ],
-
     "require": {
         "php": ">=8.2",
         "ext-pcntl": "*",
-        "aymdev/messenger-azure-bundle": "dev-dsnParser",
+        "aymdev/messenger-azure-bundle": "^1.0",
         "petitpress/gps-messenger-bundle": "^1.6",
         "symfony/amazon-sqs-messenger": "^6.3|^7.0",
         "symfony/dependency-injection": "^6.0|^7.0",

--- a/libs/messenger-bundle/composer.json
+++ b/libs/messenger-bundle/composer.json
@@ -23,7 +23,7 @@
     "require": {
         "php": ">=8.2",
         "ext-pcntl": "*",
-        "aymdev/messenger-azure-bundle": "^1.0",
+        "aymdev/messenger-azure-bundle": "^2.0",
         "petitpress/gps-messenger-bundle": "^1.6",
         "symfony/amazon-sqs-messenger": "^6.3|^7.0",
         "symfony/dependency-injection": "^6.0|^7.0",

--- a/libs/messenger-bundle/composer.json
+++ b/libs/messenger-bundle/composer.json
@@ -24,7 +24,7 @@
         "php": ">=8.2",
         "ext-pcntl": "*",
         "aymdev/messenger-azure-bundle": "^2.0",
-        "petitpress/gps-messenger-bundle": "^1.6",
+        "petitpress/gps-messenger-bundle": "^2.0",
         "symfony/amazon-sqs-messenger": "^6.3|^7.0",
         "symfony/dependency-injection": "^6.0|^7.0",
         "symfony/messenger": "^6.0|^7.0"


### PR DESCRIPTION
Part of https://keboola.atlassian.net/browse/AJDA-582

aymdev/messenger-azure-bundle 2 je kompatibilní se symfony 7, která je v AI service