### PR TITLE
DMD-289 add file_type support for file input mapping

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 ARG PHP_VERSION=8.1
 ARG XDEBUG_VERSION="-3.1.6"
 
-FROM php:${PHP_VERSION}-cli as dev
+FROM php:${PHP_VERSION}-cli-bookworm as dev
 
 ARG DEBIAN_FRONTEND=noninteractivef
 ARG XDEBUG_VERSION

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ COPY docker/php/xdebug.ini /usr/local/etc/php/conf.d/
 
 RUN apt update -q \
  && apt install -y --no-install-recommends git zip unzip libzip4 libzip-dev zlib1g-dev \
- && docker-php-ext-install pdo_mysql pcntl zip \
+ && docker-php-ext-install pdo_mysql pcntl zip bcmath \
  && apt-get remove --autoremove -y libzip-dev zlib1g-dev \
  && rm -rf /var/lib/apt/lists/*
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,14 +10,6 @@ services:
     volumes:
       - .:/code
 
-  dev74:
-    <<: *dev
-    image: keboola/php-dev74
-    build:
-      <<: *dev-build
-      args:
-        PHP_VERSION: "7.4"
-
   dev81: &dev81
     <<: *dev
     image: keboola/php-dev81

--- a/libs/input-mapping/composer.json
+++ b/libs/input-mapping/composer.json
@@ -21,7 +21,7 @@
         "keboola/php-file-storage-utils": "^0.2",
         "keboola/key-generator": "*@dev",
         "keboola/staging-provider": "*@dev",
-        "keboola/storage-api-client": "dev-zajca/dmd-289/parquet as v18.3.0",
+        "keboola/storage-api-client": "^18.3.0",
         "keboola/storage-api-php-client-branch-wrapper": "^6.0",
         "symfony/config": "^5.4|^6.0|^7.0",
         "symfony/finder": "^5.4|^6.0|^7.0",
@@ -30,6 +30,9 @@
     },
     "require-dev": {
         "brianium/paratest": "^6.11",
+        "flow-php/filesystem": "^0.22.0",
+        "flow-php/parquet": "^0.22.0",
+        "flow-php/types": "^0.22.0",
         "keboola/coding-standard": ">=14.0",
         "keboola/php-temp": "^2.0",
         "keboola/settle": "*@dev",

--- a/libs/input-mapping/composer.json
+++ b/libs/input-mapping/composer.json
@@ -21,7 +21,7 @@
         "keboola/php-file-storage-utils": "^0.2",
         "keboola/key-generator": "*@dev",
         "keboola/staging-provider": "*@dev",
-        "keboola/storage-api-client": "^18.0",
+        "keboola/storage-api-client": "dev-zajca/dmd-289/parquet as v18.3.0",
         "keboola/storage-api-php-client-branch-wrapper": "^6.0",
         "symfony/config": "^5.4|^6.0|^7.0",
         "symfony/finder": "^5.4|^6.0|^7.0",

--- a/libs/input-mapping/src/Configuration/Table.php
+++ b/libs/input-mapping/src/Configuration/Table.php
@@ -75,6 +75,15 @@ class Table extends Configuration
                 ->booleanNode('overwrite')->defaultValue(false)->end()
                 ->booleanNode('use_view')->defaultValue(false)->end()
                 ->booleanNode('keep_internal_timestamp_column')->defaultValue(true)->end()
+                ->scalarNode('file_type')->end()
+            ->end()
+            ->validate()
+            ->always(function ($v) {
+                if (empty($v['file_type'])) {
+                    unset($v['file_type']);
+                }
+                return $v;
+            })
             ->end()
             ->validate()
                 ->ifTrue(function ($v) {

--- a/libs/input-mapping/src/Staging/StrategyFactory.php
+++ b/libs/input-mapping/src/Staging/StrategyFactory.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Keboola\InputMapping\Staging;
 
+use Keboola\InputMapping\Exception\StagingException;
 use Keboola\InputMapping\File\Strategy\Local as FileLocal;
 use Keboola\InputMapping\File\StrategyInterface as FileStrategyInterface;
 use Keboola\InputMapping\State\InputFileStateList;
@@ -42,6 +43,9 @@ class StrategyFactory
             StagingType::Abs,
             StagingType::WorkspaceSnowflake,
             StagingType::WorkspaceBigquery => FileLocal::class,
+            StagingType::None => throw new StagingException(
+                'Staging type "none" is not supported.',
+            ),
         };
 
         $this->tableStrategyClass = match ($stagingType) {
@@ -50,6 +54,9 @@ class StrategyFactory
             StagingType::Abs => TableABS::class,
             StagingType::WorkspaceSnowflake => TableSnowflake::class,
             StagingType::WorkspaceBigquery => TableBigQuery::class,
+            StagingType::None => throw new StagingException(
+                'Staging type "none" is not supported.',
+            ),
         };
     }
 

--- a/libs/input-mapping/src/Table/Options/InputTableOptions.php
+++ b/libs/input-mapping/src/Table/Options/InputTableOptions.php
@@ -17,7 +17,7 @@ use Keboola\InputMapping\State\InputTableStateList;
  *     nullable?: bool,
  *     convertEmptyValuesToNull?: bool,
  * }
-*/
+ */
 class InputTableOptions
 {
     public const ADAPTIVE_INPUT_MAPPING_VALUE = 'adaptive';
@@ -197,5 +197,10 @@ class InputTableOptions
     public function getSourceBranchId(): ?int
     {
         return isset($this->definition['source_branch_id']) ? (int) $this->definition['source_branch_id'] : null;
+    }
+
+    public function getFileType(): ?string
+    {
+        return isset($this->definition['file_type']) ? (string) $this->definition['file_type'] : null;
     }
 }

--- a/libs/input-mapping/src/Table/Options/RewrittenInputTableOptions.php
+++ b/libs/input-mapping/src/Table/Options/RewrittenInputTableOptions.php
@@ -26,6 +26,7 @@ class RewrittenInputTableOptions extends InputTableOptions
 
     /**
      * @return array{
+     *     sourceBranchId?: int,
      *     columns?: array<string>,
      *     changedSince?: string,
      *     whereColumn?: string,
@@ -33,6 +34,7 @@ class RewrittenInputTableOptions extends InputTableOptions
      *     whereOperator?: string,
      *     limit?: integer,
      *     overwrite?: bool,
+     *     fileType?: string,
      * }
      */
     public function getStorageApiExportOptions(InputTableStateList $states): array
@@ -69,6 +71,9 @@ class RewrittenInputTableOptions extends InputTableOptions
         }
         if (isset($this->definition['limit'])) {
             $exportOptions['limit'] = (int) $this->definition['limit'];
+        }
+        if ($this->getFileType() !== null) {
+            $exportOptions['fileType'] = $this->getFileType();
         }
         $exportOptions['overwrite'] = (bool) $this->definition['overwrite'];
         return $exportOptions;

--- a/libs/input-mapping/tests/Configuration/TableConfigurationTest.php
+++ b/libs/input-mapping/tests/Configuration/TableConfigurationTest.php
@@ -385,6 +385,43 @@ class TableConfigurationTest extends TestCase
                     'keep_internal_timestamp_column' => true,
                 ],
             ],
+            'FileType' => [
+                [
+                    'source' => 'in.c-main.test',
+                    'source_branch_id' => null,
+                    'file_type' => 'parquet',
+                ],
+                [
+                    'source' => 'in.c-main.test',
+                    'source_branch_id' => null,
+                    'where_values' => [],
+                    'columns' => [],
+                    'column_types' => [],
+                    'where_operator' => 'eq',
+                    'overwrite' => false,
+                    'use_view' => false,
+                    'keep_internal_timestamp_column' => true,
+                    'file_type' => 'parquet',
+                ],
+            ],
+            'FileTypeEmpty' => [
+                [
+                    'source' => 'in.c-main.test',
+                    'source_branch_id' => null,
+                    'file_type' => '',
+                ],
+                [
+                    'source' => 'in.c-main.test',
+                    'source_branch_id' => null,
+                    'where_values' => [],
+                    'columns' => [],
+                    'column_types' => [],
+                    'where_operator' => 'eq',
+                    'overwrite' => false,
+                    'use_view' => false,
+                    'keep_internal_timestamp_column' => true,
+                ],
+            ],
         ];
     }
 

--- a/libs/input-mapping/tests/Staging/StrategyFactoryTest.php
+++ b/libs/input-mapping/tests/Staging/StrategyFactoryTest.php
@@ -59,7 +59,13 @@ class StrategyFactoryTest extends TestCase
             array_keys(self::STAGING_MAP),
         );
 
-        self::assertSame([], $missingStagingTypes, 'Not all staging types are covered by the test');
+        self::assertSame(
+            [
+                StagingType::None->value,
+            ],
+            $missingStagingTypes,
+            'Not all staging types are covered by the test',
+        );
     }
 
     public static function provideFileInputStrategyMapping(): iterable

--- a/libs/input-mapping/tests/Table/Options/RewrittenInputTableOptionsTest.php
+++ b/libs/input-mapping/tests/Table/Options/RewrittenInputTableOptionsTest.php
@@ -7,7 +7,6 @@ namespace Keboola\InputMapping\Tests\Table\Options;
 use Keboola\InputMapping\State\InputTableStateList;
 use Keboola\InputMapping\Table\Options\InputTableOptions;
 use Keboola\InputMapping\Table\Options\RewrittenInputTableOptions;
-use Keboola\InputMapping\Table\Options\RewrittenInputTableOptionsList;
 use PHPUnit\Framework\TestCase;
 
 class RewrittenInputTableOptionsTest extends TestCase
@@ -18,6 +17,7 @@ class RewrittenInputTableOptionsTest extends TestCase
             [
                 'source' => 'test',
                 'source_branch_id' => 123,
+                'file_type' => 'csv',
             ],
             'source',
             24,
@@ -26,6 +26,7 @@ class RewrittenInputTableOptionsTest extends TestCase
         self::assertSame('source', $definition->getSource());
         self::assertSame(24, $definition->getSourceBranchId());
         self::assertSame(['a' => 'b'], $definition->getTableInfo());
+        self::assertSame('csv', $definition->getFileType());
     }
 
 


### PR DESCRIPTION
JIRA: DMD-289

storage hase new option for table exports fileType: {csv,parquet}
add corresponding file_type option for input mapping

--

waiting for:
https://github.com/keboola/storage-api-php-client/pull/1543
https://github.com/keboola/platform-libraries/pull/409
to be released and deployed