### PR TITLE
AJDA-922: feat (output-mapping): add method LoadTableQueue::getLoadTableTasks()

### DIFF
--- a/libs/output-mapping/src/DeferredTasks/LoadTableQueue.php
+++ b/libs/output-mapping/src/DeferredTasks/LoadTableQueue.php
@@ -134,5 +134,6 @@ class LoadTableQueue
 
     public function getLoadTableTasks(): array
     {
+        return $this->loadTableTasks;
     }
 }

--- a/libs/output-mapping/src/DeferredTasks/LoadTableQueue.php
+++ b/libs/output-mapping/src/DeferredTasks/LoadTableQueue.php
@@ -131,4 +131,8 @@ class LoadTableQueue
     {
         return $this->tableResult;
     }
+
+    public function getLoadTableTasks(): array
+    {
+    }
 }

--- a/libs/output-mapping/tests/DeferredTasks/LoadTableQueueTest.php
+++ b/libs/output-mapping/tests/DeferredTasks/LoadTableQueueTest.php
@@ -22,6 +22,27 @@ use Psr\Log\NullLogger;
 
 class LoadTableQueueTest extends TestCase
 {
+    public function testGetLoadTableTasks(): void
+    {
+        $clientWrapperMock = $this->createMock(ClientWrapper::class);
+        $clientWrapperMock->method('getTableAndFileStorageClient')
+            ->willReturn($this->createMock(Client::class));
+
+        $loadTask1 = $this->createMock(LoadTableTask::class);
+        $loadTask2 = $this->createMock(LoadTableTask::class);
+
+        $loadQueue = new LoadTableQueue(
+            $clientWrapperMock,
+            new NullLogger(),
+            [
+                $loadTask1,
+                $loadTask2,
+            ],
+        );
+
+        self::assertSame([$loadTask1, $loadTask2], $loadQueue->getLoadTableTasks());
+    }
+
     public function testTaskCount(): void
     {
         $clientWrapperMock = $this->createMock(ClientWrapper::class);


### PR DESCRIPTION
In Ai Service "SQL Editor" we need to get to the Storage jobs. 

- add getter method getLoadTableTasks on LoadTableQueue

https://keboolaglobal.slack.com/archives/C08AG6VQWG6/p1756316998873219?thread_ts=1756300066.458899&cid=C08AG6VQWG6