### PR TITLE
PAT-664 [output-mapping]: Update `keboola/php-datatypes` to `^8.0`

### DIFF
--- a/libs/output-mapping/composer.json
+++ b/libs/output-mapping/composer.json
@@ -30,7 +30,7 @@
         "ext-json": "*",
         "keboola/input-mapping": "*@dev",
         "keboola/key-generator": "*@dev",
-        "keboola/php-datatypes": "^7.10",
+        "keboola/php-datatypes": "^8.0",
         "keboola/php-file-storage-utils": "^0.2",
         "keboola/sanitizer": "^0.1.1",
         "keboola/slicer": "*@dev",


### PR DESCRIPTION
https://keboola.atlassian.net/browse/PAT-664

Potřebujeme na démonovi nasadit nový SAPI client [v18.4.0](https://github.com/keboola/storage-api-php-client/releases/tag/v18.4.0) (kvůli novému endpointu) se závislostí na `php-datatypes: ^8.0`.

A protože na démonovi máme přes `job-queue-job-configuration` závislost na `output-mapping`, potřebujeme releasnout i nový `output-mapping` s `php-datatypes: ^8.0`.