### PR TITLE
DMD-431 Fix failing job runner when "deduplication_strategy" is set

### DIFF
--- a/libs/output-mapping/src/Configuration/Table/BaseConfiguration.php
+++ b/libs/output-mapping/src/Configuration/Table/BaseConfiguration.php
@@ -38,7 +38,6 @@ abstract class BaseConfiguration extends Configuration
                         DeduplicationStrategy::INSERT->value,
                         DeduplicationStrategy::UPSERT->value,
                     ])
-                    ->validate()->always(fn(string $value) => DeduplicationStrategy::from($value))->end()
                 ->end()
                 ->arrayNode('primary_key')
                     ->prototype('scalar')

--- a/libs/output-mapping/src/Mapping/MappingFromProcessedConfiguration.php
+++ b/libs/output-mapping/src/Mapping/MappingFromProcessedConfiguration.php
@@ -229,6 +229,10 @@ class MappingFromProcessedConfiguration
 
     public function getDeduplicationStrategy(): ?DeduplicationStrategy
     {
-        return $this->mapping['deduplication_strategy'] ?? null;
+        $value = $this->mapping['deduplication_strategy'] ?? null;
+
+        return $value !== null
+            ? DeduplicationStrategy::from($value)
+            : null;
     }
 }

--- a/libs/output-mapping/tests/Configuration/Table/BaseConfigurationTest.php
+++ b/libs/output-mapping/tests/Configuration/Table/BaseConfigurationTest.php
@@ -1099,7 +1099,7 @@ class BaseConfigurationTest extends TestCase
     /**
      * @dataProvider deduplicationStrategiesProvider
      */
-    public function testDeduplicationStrategySuccess(string $input, Table\DeduplicationStrategy $expected): void
+    public function testDeduplicationStrategySuccess(string $input, string $expected): void
     {
         $config = [
             'deduplication_strategy' => $input,
@@ -1116,8 +1116,8 @@ class BaseConfigurationTest extends TestCase
 
     public function deduplicationStrategiesProvider(): Generator
     {
-        yield ['insert', Table\DeduplicationStrategy::INSERT];
-        yield ['upsert', Table\DeduplicationStrategy::UPSERT];
+        yield ['insert', Table\DeduplicationStrategy::INSERT->value];
+        yield ['upsert', Table\DeduplicationStrategy::UPSERT->value];
     }
 
     public function testDeduplicationStrategyFail(): void


### PR DESCRIPTION
- DMD-431

**What is broken?**
Keboola\ObjectEncryptor\ObjectEncryptor::decryptForBranchTypeConfiguration used in job runner cannot decrypt enum (only scalar, array or stdClass). We decided that this is the easiest and safest fix.

https://linear.app/keboola/issue/DMD-431/