### PR TITLE
feat[messenger-bundle]: AJDA-586 add admin deleted event from audit log

### DIFF
--- a/libs/messenger-bundle/src/ConnectionEvent/AuditLog/Admin/AdminDeletedEvent.php
+++ b/libs/messenger-bundle/src/ConnectionEvent/AuditLog/Admin/AdminDeletedEvent.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Keboola\MessengerBundle\ConnectionEvent\AuditLog\Admin;
+
+use Keboola\MessengerBundle\ConnectionEvent\AuditLog\BaseAuditLogEvent;
+
+class AdminDeletedEvent extends BaseAuditLogEvent
+{
+    public const NAME = 'auditLog.admin.deleted';
+
+    private string $subjectAdminId;
+
+    private string $subjectAdminName;
+
+    private string $subjectAdminEmail;
+
+    public static function fromArray(array $data): static
+    {
+        $event = parent::fromArray($data);
+
+        $event->subjectAdminId = (string) $data['context']['admin']['id'];
+        $event->subjectAdminName = $data['context']['admin']['name'];
+        $event->subjectAdminEmail = $data['context']['admin']['email'];
+
+        return $event;
+    }
+
+    public function toArray(): array
+    {
+        return parent::toArray() + [
+            'context' => [
+                'admin' => [
+                    'id' => $this->subjectAdminId,
+                    'name' => $this->subjectAdminName,
+                    'email' => $this->subjectAdminEmail,
+                ],
+            ],
+        ];
+    }
+
+    public function getSubjectAdminId(): string
+    {
+        return $this->subjectAdminId;
+    }
+
+    public function getSubjectAdminName(): string
+    {
+        return $this->subjectAdminName;
+    }
+
+    public function getSubjectAdminEmail(): string
+    {
+        return $this->subjectAdminEmail;
+    }
+}

--- a/libs/messenger-bundle/src/ConnectionEvent/AuditLog/AuditEventFactory.php
+++ b/libs/messenger-bundle/src/ConnectionEvent/AuditLog/AuditEventFactory.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Keboola\MessengerBundle\ConnectionEvent\AuditLog;
 
+use Keboola\MessengerBundle\ConnectionEvent\AuditLog\Admin\AdminDeletedEvent;
 use Keboola\MessengerBundle\ConnectionEvent\AuditLog\GenericAuditLogEvent;
 use Keboola\MessengerBundle\ConnectionEvent\AuditLog\Organization\OrganizationDeletedEvent;
 use Keboola\MessengerBundle\ConnectionEvent\AuditLog\Organization\ProjectCreatedEvent;
@@ -28,6 +29,7 @@ class AuditEventFactory implements EventFactoryInterface
         ProjectFeatureRemovedEvent::NAME => ProjectFeatureRemovedEvent::class,
         ProjectPurgedEvent::NAME => ProjectPurgedEvent::class,
         ProjectUndeletedEvent::NAME => ProjectUndeletedEvent::class,
+        AdminDeletedEvent::NAME => AdminDeletedEvent::class,
     ];
 
     public function createEventFromArray(array $data): EventInterface

--- a/libs/messenger-bundle/tests/ConnectionEvent/AuditLog/Admin/AdminDeletedEventTest.php
+++ b/libs/messenger-bundle/tests/ConnectionEvent/AuditLog/Admin/AdminDeletedEventTest.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Keboola\MessengerBundle\Tests\ConnectionEvent\AuditLog\Admin;
+
+use DateTimeImmutable;
+use InvalidArgumentException;
+use Keboola\MessengerBundle\ConnectionEvent\AuditLog\Admin\AdminDeletedEvent;
+use Keboola\MessengerBundle\ConnectionEvent\AuditLog\AuditEventFactory;
+use PHPUnit\Framework\TestCase;
+
+class AdminDeletedEventTest extends TestCase
+{
+    private const EVENT_MESSAGE_DATA = [
+        'data' => [
+            'id' => 1234,
+            'operation' => 'auditLog.admin.deleted',
+            'auditLogEventCreatedAt' => '2025-09-03T12:00:00Z',
+            'admin' => [
+                'id' => 456,
+                'name' => 'admin-name',
+                'email' => 'admin@example.com',
+            ],
+
+            'context' => [
+                'admin' => [
+                    'id' => 789,
+                    'name' => 'subject-admin',
+                    'email' => 'subject-admin@keboola.com',
+                ],
+            ],
+        ],
+    ];
+
+    public function testDecodeFromEvent(): void
+    {
+        $eventFactory = new AuditEventFactory();
+        $event = $eventFactory->createEventFromArray(self::EVENT_MESSAGE_DATA);
+
+        self::assertInstanceOf(AdminDeletedEvent::class, $event);
+        self::assertSame('1234', $event->getId());
+    }
+
+    public function testCreateFromArray(): void
+    {
+        $event = AdminDeletedEvent::fromArray(self::EVENT_MESSAGE_DATA['data']);
+
+        self::assertSame('1234', $event->getId());
+        self::assertEquals(new DateTimeImmutable('2025-09-03T12:00:00Z'), $event->getCreatedAt());
+
+        self::assertSame('456', $event->getAdminId());
+        self::assertSame('admin-name', $event->getAdminName());
+        self::assertSame('admin@example.com', $event->getAdminEmail());
+
+        self::assertSame('789', $event->getSubjectAdminId());
+        self::assertSame('subject-admin', $event->getSubjectAdminName());
+        self::assertSame('subject-admin@keboola.com', $event->getSubjectAdminEmail());
+    }
+
+    public function testCreateFromArrayWithInvalidOperation(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(
+            'Keboola\MessengerBundle\ConnectionEvent\AuditLog\Admin\AdminDeletedEvent expects event ' .
+            'name "auditLog.admin.deleted" but operation in data is "foo"',
+        );
+
+        AdminDeletedEvent::fromArray([
+            'operation' => 'foo',
+        ]);
+    }
+}


### PR DESCRIPTION
**Summary:**
Implements a new audit log event for admin deletion operations in the messenger-bundle library.

**Changes:**
- **Added** `AdminDeletedEvent` class to handle admin deletion audit events
- **Extended** `AuditEventFactory` to support the new `auditLog.admin.deleted` event type
- **Added** comprehensive unit tests for the new event class

**Details:**
- New event captures admin ID, name, and email from both the performing admin and the deleted admin
- Follows existing audit log event patterns with proper serialization/deserialization
- Includes full test coverage with positive and negative test cases
- Event name: `auditLog.admin.deleted`

**Ticket:** [AJDA-586](https://keboola.atlassian.net/browse/AJDA-586)

[AJDA-586]: https://keboola.atlassian.net/browse/AJDA-586?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ