### PR TITLE
Make source optional when unload_strategy is direct-grant

### DIFF
--- a/libs/output-mapping/src/Configuration/Table.php
+++ b/libs/output-mapping/src/Configuration/Table.php
@@ -20,6 +20,14 @@ class Table extends Configuration
     public static function configureNode(ArrayNodeDefinition $node): void
     {
         Table\Manifest::configureNode($node);
-        $node->children()->scalarNode('source')->isRequired()->end();
+        $node->children()->scalarNode('source')->end();
+        $node->validate()
+            ->ifTrue(function ($values) {
+                $isDirectGrant = isset($values['unload_strategy']) &&
+                    $values['unload_strategy'] === 'direct-grant';
+                return !$isDirectGrant && !isset($values['source']);
+            })
+            ->thenInvalid('The child config "source" under "table" must be configured.')
+            ->end();
     }
 }

--- a/libs/output-mapping/src/Mapping/MappingFromRawConfiguration.php
+++ b/libs/output-mapping/src/Mapping/MappingFromRawConfiguration.php
@@ -11,13 +11,13 @@ class MappingFromRawConfiguration
     private string $delimiter;
     private string $enclosure;
     private array $columns;
-    private string $source;
+    private ?string $source;
     private array $mappingItem;
 
     public function __construct(array $mappingItem)
     {
         $this->mappingItem = $mappingItem;
-        $this->source = $mappingItem['source'];
+        $this->source = $mappingItem['source'] ?? null;
         $this->columns = $mappingItem['columns'] ?? [];
         $this->delimiter = $mappingItem['delimiter'] ?? Manifest::DEFAULT_DELIMITER;
         $this->enclosure = $mappingItem['enclosure'] ?? Manifest::DEFAULT_ENCLOSURE;
@@ -25,7 +25,7 @@ class MappingFromRawConfiguration
 
     public function getSourceName(): string
     {
-        return $this->source;
+        return $this->source ?? '';
     }
 
     public function asArray(): array

--- a/libs/output-mapping/tests/Configuration/TableTest.php
+++ b/libs/output-mapping/tests/Configuration/TableTest.php
@@ -147,4 +147,46 @@ class TableTest extends TestCase
         $processedConfiguration = (new Table())->parse(['config' => $config]);
         self::assertEquals($expectedArray, $processedConfiguration);
     }
+
+    public function testSourceNotRequiredWithDirectGrantUnloadStrategy(): void
+    {
+        $config = [
+            'destination' => 'in.c-main.test',
+            'unload_strategy' => 'direct-grant',
+        ];
+
+        $expectedArray = [
+            'destination' => 'in.c-main.test',
+            'unload_strategy' => 'direct-grant',
+            'primary_key' => [],
+            'distribution_key' => [],
+            'columns' => [],
+            'incremental' => false,
+            'delete_where_values' => [],
+            'delete_where_operator' => 'eq',
+            'delimiter' => ',',
+            'enclosure' => '"',
+            'metadata' => [],
+            'column_metadata' => [],
+            'write_always' => false,
+            'tags' => [],
+            'schema' => [],
+        ];
+
+        $processedConfiguration = (new Table())->parse(['config' => $config]);
+        self::assertEquals($expectedArray, $processedConfiguration);
+    }
+
+    public function testSourceRequiredWithOtherUnloadStrategy(): void
+    {
+        $config = [
+            'destination' => 'in.c-main.test',
+            'unload_strategy' => 'other-strategy',
+        ];
+
+        self::expectException(InvalidConfigurationException::class);
+        self::expectExceptionMessage('The child config "source" under "table" must be configured.');
+
+        (new Table())->parse(['config' => $config]);
+    }
 }

--- a/libs/output-mapping/tests/Mapping/MappingFromRawConfigurationTest.php
+++ b/libs/output-mapping/tests/Mapping/MappingFromRawConfigurationTest.php
@@ -53,4 +53,29 @@ class MappingFromRawConfigurationTest extends TestCase
     {
         $this->assertEquals(['column1', 'column2'], $this->mapping->getColumns());
     }
+
+    public function testSourceCanBeNull(): void
+    {
+        $mappingItem = [
+            'columns' => ['column1', 'column2'],
+            'delimiter' => ',',
+            'enclosure' => '"',
+        ];
+
+        $mapping = new MappingFromRawConfiguration($mappingItem);
+        $this->assertEquals('', $mapping->getSourceName());
+    }
+
+    public function testSourceCanBeNullWithUnloadStrategy(): void
+    {
+        $mappingItem = [
+            'unload_strategy' => 'direct-grant',
+            'destination' => 'in.c-main.test',
+            'columns' => ['column1', 'column2'],
+        ];
+
+        $mapping = new MappingFromRawConfiguration($mappingItem);
+        $this->assertEquals('', $mapping->getSourceName());
+        $this->assertEquals(['column1', 'column2'], $mapping->getColumns());
+    }
 }

--- a/libs/output-mapping/tests/Writer/TableDefinitionV2Test.php
+++ b/libs/output-mapping/tests/Writer/TableDefinitionV2Test.php
@@ -1037,4 +1037,43 @@ class TableDefinitionV2Test extends AbstractTestCase
         }
         return $result;
     }
+
+    #[NeedsEmptyOutputBucket]
+    public function testDirectGrantUnloadStrategySkipsTableUpload(): void
+    {
+        $this->initWorkspace();
+        $tableId = $this->emptyOutputBucketId . '.tableDefinition';
+
+        $config = [
+            'destination' => $tableId,
+            'unload_strategy' => 'direct-grant',
+        ];
+
+        $strategyFactory = $this->getWorkspaceStagingFactory(
+            clientWrapper: $this->clientWrapper,
+            logger: $this->testLogger,
+        );
+
+        $tableLoader = $this->getTableLoader(
+            clientWrapper: $this->clientWrapper,
+            logger: $this->testLogger,
+            strategyFactory: $strategyFactory,
+        );
+
+        $tableQueue = $tableLoader->uploadTables(
+            configuration: new OutputMappingSettings(
+                configuration: ['mapping' => [$config]],
+                sourcePathPrefix: 'upload',
+                storageApiToken: $this->clientWrapper->getToken(),
+                isFailedJob: false,
+                dataTypeSupport: 'none',
+            ),
+            systemMetadata: new SystemMetadata(['componentId' => 'foo']),
+        );
+        $jobIds = $tableQueue->waitForAll();
+        self::assertCount(0, $jobIds, 'No jobs should be created when unload_strategy is direct-grant');
+
+        $tables = $this->clientWrapper->getTableAndFileStorageClient()->listTables($this->emptyOutputBucketId);
+        self::assertCount(0, $tables, 'No tables should be imported when unload_strategy is direct-grant');
+    }
 }


### PR DESCRIPTION
This PR makes the source field optional in table configuration when unload_strategy is set to direct-grant.

Changes:
- Make source field optional in Table configuration when unload_strategy is direct-grant
- Update MappingFromRawConfiguration to handle nullable source
- Add tests for optional source with direct-grant unload strategy
- Add functional test for direct-grant unload strategy skipping table upload