### PR TITLE
fix(input-mapping): ignore Symfony Config component generic type errors in PHPStan

### DIFF
--- a/libs/input-mapping/phpstan.neon
+++ b/libs/input-mapping/phpstan.neon
@@ -5,6 +5,11 @@ parameters:
         - tests
     ignoreErrors:
         - identifier: missingType.iterableValue
+        # Symfony Config component generics introduced in Symfony 7.4 are not fully supported by phpstan-symfony yet
+        - message: '#Call to method (\w+Node\(\)|append\(\)) on an unknown class Symfony\\Component\\Config\\Definition\\Builder\\NodeBuilder<.*>#'
+          identifier: class.notFound
+        - message: '#(Method .* return type with generic class|PHPDoc tag @(var|return) for (variable|method) .* contains generic class|Method .* has parameter .* with generic class) Symfony\\Component\\Config\\Definition\\Builder\\(TreeBuilder|ArrayNodeDefinition|NodeDefinition).*does not specify its types#'
+          identifier: missingType.generics
 
 includes:
     - vendor/phpstan/phpstan-phpunit/extension.neon


### PR DESCRIPTION
## Summary

Adds PHPStan ignore rules to suppress false positive errors caused by Symfony 7.4's new generic type annotations in the Config component (`TreeBuilder`, `ArrayNodeDefinition`, `NodeDefinition`, `NodeBuilder`). These generics are not yet fully supported by the `phpstan-symfony` extension.

This fix follows the same pattern already applied to `internal-api-php-client` and `job-configuration` libraries.

Before this change, input-mapping had 13 PHPStan errors like:
- "Method ... return type with generic class TreeBuilder does not specify its types: T"
- "Call to method arrayNode() on an unknown class NodeBuilder<...>"

## Review & Testing Checklist for Human

- [ ] Verify the regex patterns are appropriately scoped and don't suppress unrelated errors
- [ ] Confirm CI passes for input-mapping

### Notes

- Link to Devin run: https://app.devin.ai/sessions/eb673da9b44f490bb4706169aeec8866
- Requested by: Jan Vaníček (@janvanicek)