### PR TITLE
[AJDA-2300] feat(output-mapping): generic table metadata as flow variables

### DIFF
--- a/libs/output-mapping/src/DeferredTasks/LoadTableQueue.php
+++ b/libs/output-mapping/src/DeferredTasks/LoadTableQueue.php
@@ -100,7 +100,7 @@ class LoadTableQueue
                         );
                         $this->tableResult->addTable(new TableInfo($tableData));
                         $this->tableResult->addGenericVariable(
-                            $tableData['name'],
+                            $jobResult['tableId'],
                             'importedRowsCount',
                             (int) ($jobResult['results']['importedRowsCount'] ?? 0),
                         );

--- a/libs/output-mapping/src/DeferredTasks/LoadTableQueue.php
+++ b/libs/output-mapping/src/DeferredTasks/LoadTableQueue.php
@@ -95,10 +95,14 @@ class LoadTableQueue
 
                 switch ($jobResult['operationName']) {
                     case 'tableImport':
-                        $this->tableResult->addTable(
-                            new TableInfo($this->clientWrapper->getTableAndFileStorageClient()->getTable(
-                                $jobResult['tableId'],
-                            )),
+                        $tableData = $this->clientWrapper->getTableAndFileStorageClient()->getTable(
+                            $jobResult['tableId'],
+                        );
+                        $this->tableResult->addTable(new TableInfo($tableData));
+                        $this->tableResult->addGenericVariable(
+                            $tableData['name'],
+                            'importedRowsCount',
+                            (int) ($jobResult['results']['importedRowsCount'] ?? 0),
                         );
                         $jobResults[] = $jobResult;
                         break;

--- a/libs/output-mapping/src/Table/Result.php
+++ b/libs/output-mapping/src/Table/Result.php
@@ -40,9 +40,9 @@ class Result
         return $this->metrics;
     }
 
-    public function addGenericVariable(string $tableName, string $variableName, int|string $variableValue): void
+    public function addGenericVariable(string $tableId, string $variableName, int|string $variableValue): void
     {
-        $this->genericVariables[$tableName][$variableName] = $variableValue;
+        $this->genericVariables[$tableId][$variableName] = $variableValue;
     }
 
     /** @return array<string, array<string, int|string>> */

--- a/libs/output-mapping/src/Table/Result.php
+++ b/libs/output-mapping/src/Table/Result.php
@@ -14,6 +14,9 @@ class Result
 
     private ?Metrics $metrics = null;
 
+    /** @var array<string, array<string, int|string>> */
+    private array $genericVariables = [];
+
     public function addTable(TableInfo $table): void
     {
         $this->tables[] = $table;
@@ -35,5 +38,16 @@ class Result
     public function getMetrics(): ?Metrics
     {
         return $this->metrics;
+    }
+
+    public function addGenericVariable(string $tableName, string $variableName, int|string $variableValue): void
+    {
+        $this->genericVariables[$tableName][$variableName] = $variableValue;
+    }
+
+    /** @return array<string, array<string, int|string>> */
+    public function getGenericVariables(): array
+    {
+        return $this->genericVariables;
     }
 }

--- a/libs/output-mapping/tests/DeferredTasks/LoadTableQueueTest.php
+++ b/libs/output-mapping/tests/DeferredTasks/LoadTableQueueTest.php
@@ -533,7 +533,7 @@ class LoadTableQueueTest extends TestCase
             ],
             'expectedTableId' => 'in.c-myBucket.tableImported',
             'expectedGenericVariables' => [
-                'tableImported' => ['importedRowsCount' => 42],
+                'in.c-myBucket.tableImported' => ['importedRowsCount' => 42],
             ],
             'getTableColumns' => [],
             'getTableName' => 'tableImported',
@@ -571,7 +571,7 @@ class LoadTableQueueTest extends TestCase
             ],
             'expectedTableId' => 'in.c-myBucket.tableImported',
             'expectedGenericVariables' => [
-                'tableImported' => ['importedRowsCount' => 0],
+                'in.c-myBucket.tableImported' => ['importedRowsCount' => 0],
             ],
             'getTableColumns' => [],
             'getTableName' => 'tableImported',

--- a/libs/output-mapping/tests/DeferredTasks/LoadTableQueueTest.php
+++ b/libs/output-mapping/tests/DeferredTasks/LoadTableQueueTest.php
@@ -454,6 +454,148 @@ class LoadTableQueueTest extends TestCase
         ];
     }
 
+    /**
+     * @dataProvider genericVariablesData
+     * @param array<string, mixed> $jobResult
+     * @param array<string, array<string, int|string>> $expectedGenericVariables
+     * @param string[] $getTableColumns
+     */
+    public function testWaitForAllExtractsGenericVariables(
+        array $jobResult,
+        string $expectedTableId,
+        array $expectedGenericVariables,
+        array $getTableColumns = [],
+        string $getTableName = 'my-name',
+    ): void {
+        $clientMock = $this->createMock(Client::class);
+        $clientMock->expects(self::once())
+            ->method('getTable')
+            ->with($expectedTableId)
+            ->willReturn([
+                'id' => $expectedTableId,
+                'displayName' => $getTableName,
+                'name' => $getTableName,
+                'columns' => $getTableColumns,
+                'lastImportDate' => null,
+                'lastChangeDate' => null,
+            ])
+        ;
+
+        $branchClientMock = $this->createMock(BranchAwareClient::class);
+        $branchClientMock->expects(self::once())
+            ->method('waitForJob')
+            ->with(123)
+            ->willReturn($jobResult)
+        ;
+
+        $loadTask = $this->createMock(LoadTableTask::class);
+        $loadTask->expects(self::never())
+            ->method('startImport')
+        ;
+        $loadTask->expects(self::once())
+            ->method('getStorageJobId')
+            ->willReturn('123')
+        ;
+        $loadTask->expects(self::once())
+            ->method('applyMetadata')
+            ->with($this->callback(function ($client): bool {
+                self::assertInstanceOf(Metadata::class, $client);
+                return true;
+            }))
+        ;
+
+        $clientWrapperMock = $this->createMock(ClientWrapper::class);
+        $clientWrapperMock->method('getTableAndFileStorageClient')
+            ->willReturn($clientMock);
+        $clientWrapperMock->method('getBranchClient')
+            ->willReturn($branchClientMock);
+
+        $loadQueue = new LoadTableQueue($clientWrapperMock, new NullLogger(), [$loadTask]);
+        $loadQueue->waitForAll();
+
+        self::assertSame($expectedGenericVariables, $loadQueue->getTableResult()->getGenericVariables());
+    }
+
+    public function genericVariablesData(): Generator
+    {
+        yield 'tableImport with importedRowsCount' => [
+            'jobResult' => [
+                'operationName' => 'tableImport',
+                'status' => 'success',
+                'tableId' => 'in.c-myBucket.tableImported',
+                'results' => [
+                    'importedRowsCount' => 42,
+                ],
+                'metrics' => [
+                    'inBytes' => 10,
+                    'inBytesUncompressed' => 20,
+                ],
+            ],
+            'expectedTableId' => 'in.c-myBucket.tableImported',
+            'expectedGenericVariables' => [
+                'tableImported' => ['importedRowsCount' => 42],
+            ],
+            'getTableColumns' => [],
+            'getTableName' => 'tableImported',
+        ];
+
+        yield 'tableCreate does not add generic variables' => [
+            'jobResult' => [
+                'operationName' => 'tableCreate',
+                'tableId' => null,
+                'status' => 'success',
+                'results' => [
+                    'id' => 'in.c-myBucket.tableCreated',
+                    'name' => 'tableCreated',
+                    'columns' => ['id', 'name', 'value'],
+                ],
+                'metrics' => [
+                    'inBytes' => 0,
+                    'inBytesUncompressed' => 5,
+                ],
+            ],
+            'expectedTableId' => 'in.c-myBucket.tableCreated',
+            'expectedGenericVariables' => [],
+            'getTableColumns' => [],
+        ];
+
+        yield 'tableImport without importedRowsCount defaults to zero' => [
+            'jobResult' => [
+                'operationName' => 'tableImport',
+                'status' => 'success',
+                'tableId' => 'in.c-myBucket.tableImported',
+                'metrics' => [
+                    'inBytes' => 5,
+                    'inBytesUncompressed' => 10,
+                ],
+            ],
+            'expectedTableId' => 'in.c-myBucket.tableImported',
+            'expectedGenericVariables' => [
+                'tableImported' => ['importedRowsCount' => 0],
+            ],
+            'getTableColumns' => [],
+            'getTableName' => 'tableImported',
+        ];
+
+        yield 'tableCreate missing results.name and results.columns still adds no generic variables' => [
+            'jobResult' => [
+                'operationName' => 'tableCreate',
+                'tableId' => null,
+                'status' => 'success',
+                'results' => [
+                    'id' => 'in.c-myBucket.tableCreated',
+                ],
+                'metrics' => [
+                    'inBytes' => 0,
+                    'inBytesUncompressed' => 5,
+                ],
+            ],
+            'expectedTableId' => 'in.c-myBucket.tableCreated',
+            'expectedGenericVariables' => [],
+            'getTableColumns' => [],
+        ];
+    }
+
     public function testWaitForAllDeleteTableAfterFailedLoad(): void
     {
         $branchClientMock = $this->createMock(BranchAwareClient::class);

--- a/libs/output-mapping/tests/Table/ResultTest.php
+++ b/libs/output-mapping/tests/Table/ResultTest.php
@@ -75,6 +75,66 @@ class ResultTest extends TestCase
         self::assertSame($expectedImportData, $table1->getLastImportDate());
     }
 
+    public function testAddGenericVariableStoresData(): void
+    {
+        $result = new Result();
+
+        $result->addGenericVariable('my.table', 'importedRowsCount', 42);
+
+        self::assertSame(
+            ['my.table' => ['importedRowsCount' => 42]],
+            $result->getGenericVariables(),
+        );
+    }
+
+    public function testGetGenericVariablesReturnsAllStoredVariables(): void
+    {
+        $result = new Result();
+
+        $result->addGenericVariable('bucket.table1', 'importedRowsCount', 10);
+        $result->addGenericVariable('bucket.table2', 'importedRowsCount', 250);
+
+        self::assertSame(
+            [
+                'bucket.table1' => ['importedRowsCount' => 10],
+                'bucket.table2' => ['importedRowsCount' => 250],
+            ],
+            $result->getGenericVariables(),
+        );
+    }
+
+    public function testAddGenericVariableMultipleVariablesForSameTable(): void
+    {
+        $result = new Result();
+
+        $result->addGenericVariable('my.table', 'importedRowsCount', 5);
+        $result->addGenericVariable('my.table', 'someOtherVar', 'value');
+
+        self::assertSame(
+            ['my.table' => ['importedRowsCount' => 5, 'someOtherVar' => 'value']],
+            $result->getGenericVariables(),
+        );
+    }
+
+    public function testAddGenericVariableWithZeroRows(): void
+    {
+        $result = new Result();
+
+        $result->addGenericVariable('my.empty.table', 'importedRowsCount', 0);
+
+        self::assertSame(
+            ['my.empty.table' => ['importedRowsCount' => 0]],
+            $result->getGenericVariables(),
+        );
+    }
+
+    public function testGetGenericVariablesInitiallyEmpty(): void
+    {
+        $result = new Result();
+
+        self::assertSame([], $result->getGenericVariables());
+    }
+
     public function testSetResults(): void
     {
         $tablesResult = new Result();


### PR DESCRIPTION
## Summary
- Add `genericVariables` property to `Result` with `addGenericVariable(tableName, variableName, variableValue)` / `getGenericVariables()` methods
- Extract `importedRowsCount` from Storage API job result in `LoadTableQueue::waitForAll()` for `tableImport` operations only
- `addGenericVariable` accepts `int|string` value, allowing multiple variables per table

## Acceptance Criteria
- [x] `Result::addGenericVariable(tableName, variableName, variableValue)` stores data - implemented in `libs/output-mapping/src/Table/Result.php`
- [x] `Result::getGenericVariables()` returns all stored variables - implemented in `libs/output-mapping/src/Table/Result.php`
- [x] `LoadTableQueue::waitForAll()` calls `addGenericVariable` with `importedRowsCount` for tableImport - implemented in `libs/output-mapping/src/DeferredTasks/LoadTableQueue.php`
- [x] tableCreate does NOT call `addGenericVariable` - confirmed

## Tests
- `ResultTest.php` - tests for addGenericVariable/getGenericVariables
- `LoadTableQueueTest.php` - tests for generic variables extraction (tableImport only)

## Files Changed
- `libs/output-mapping/src/Table/Result.php`
- `libs/output-mapping/src/DeferredTasks/LoadTableQueue.php`
- `libs/output-mapping/tests/Table/ResultTest.php`
- `libs/output-mapping/tests/DeferredTasks/LoadTableQueueTest.php`