### PR TITLE
[AJDA-2302] feat(output-mapping): custom variables from result.json

### DIFF
--- a/libs/output-mapping/src/DeferredTasks/LoadTableQueue.php
+++ b/libs/output-mapping/src/DeferredTasks/LoadTableQueue.php
@@ -152,6 +152,7 @@ class LoadTableQueue
         }
         $content = json_decode($fileContent, true);
         if (!is_array($content) || !isset($content['variables']) || !is_array($content['variables'])) {
+            $this->logger->warning(sprintf('Failed to parse result.json file "%s".', $variablesFilePath));
             return;
         }
         foreach ($content['variables'] as $key => $value) {

--- a/libs/output-mapping/src/DeferredTasks/LoadTableQueue.php
+++ b/libs/output-mapping/src/DeferredTasks/LoadTableQueue.php
@@ -104,6 +104,10 @@ class LoadTableQueue
                             'importedRowsCount',
                             (int) ($jobResult['results']['importedRowsCount'] ?? 0),
                         );
+                        $this->tableResult->addGenericVariable(
+                            (string) ($jobResult['results']['name'] ?? ''),
+                            (array) ($jobResult['results']['columns'] ?? []),
+                        );
                         $jobResults[] = $jobResult;
                         break;
                     case 'tableCreate':

--- a/libs/output-mapping/src/DeferredTasks/LoadTableQueue.php
+++ b/libs/output-mapping/src/DeferredTasks/LoadTableQueue.php
@@ -140,4 +140,15 @@ class LoadTableQueue
     {
         return $this->loadTableTasks;
     }
+
+    public function loadCustomVariables(string $variablesFilePath): void
+    {
+        if (!file_exists($variablesFilePath)) {
+            return;
+        }
+        $content = json_decode((string) file_get_contents($variablesFilePath), true);
+        if (is_array($content)) {
+            $this->tableResult->setCustomVariables($content);
+        }
+    }
 }

--- a/libs/output-mapping/src/DeferredTasks/LoadTableQueue.php
+++ b/libs/output-mapping/src/DeferredTasks/LoadTableQueue.php
@@ -150,12 +150,10 @@ class LoadTableQueue
         if (!is_array($content)) {
             return;
         }
-        $variables = [];
         foreach ($content as $key => $value) {
             if (is_scalar($value) || $value === null) {
-                $variables[(string) $key] = $value;
+                $this->tableResult->addCustomVariable((string) $key, $value);
             }
         }
-        $this->tableResult->setCustomVariables($variables);
     }
 }

--- a/libs/output-mapping/src/DeferredTasks/LoadTableQueue.php
+++ b/libs/output-mapping/src/DeferredTasks/LoadTableQueue.php
@@ -104,10 +104,6 @@ class LoadTableQueue
                             'importedRowsCount',
                             (int) ($jobResult['results']['importedRowsCount'] ?? 0),
                         );
-                        $this->tableResult->addGenericVariable(
-                            (string) ($jobResult['results']['name'] ?? ''),
-                            (array) ($jobResult['results']['columns'] ?? []),
-                        );
                         $jobResults[] = $jobResult;
                         break;
                     case 'tableCreate':

--- a/libs/output-mapping/src/DeferredTasks/LoadTableQueue.php
+++ b/libs/output-mapping/src/DeferredTasks/LoadTableQueue.php
@@ -143,10 +143,14 @@ class LoadTableQueue
 
     public function loadCustomVariables(string $variablesFilePath): void
     {
-        if (!file_exists($variablesFilePath)) {
+        if (!is_file($variablesFilePath) || !is_readable($variablesFilePath)) {
             return;
         }
-        $content = json_decode((string) file_get_contents($variablesFilePath), true);
+        $fileContent = file_get_contents($variablesFilePath);
+        if ($fileContent === false) {
+            return;
+        }
+        $content = json_decode($fileContent, true);
         if (!is_array($content)) {
             return;
         }

--- a/libs/output-mapping/src/DeferredTasks/LoadTableQueue.php
+++ b/libs/output-mapping/src/DeferredTasks/LoadTableQueue.php
@@ -147,8 +147,15 @@ class LoadTableQueue
             return;
         }
         $content = json_decode((string) file_get_contents($variablesFilePath), true);
-        if (is_array($content)) {
-            $this->tableResult->setCustomVariables($content);
+        if (!is_array($content)) {
+            return;
         }
+        $variables = [];
+        foreach ($content as $key => $value) {
+            if (is_scalar($value) || $value === null) {
+                $variables[(string) $key] = $value;
+            }
+        }
+        $this->tableResult->setCustomVariables($variables);
     }
 }

--- a/libs/output-mapping/src/DeferredTasks/LoadTableQueue.php
+++ b/libs/output-mapping/src/DeferredTasks/LoadTableQueue.php
@@ -151,10 +151,10 @@ class LoadTableQueue
             return;
         }
         $content = json_decode($fileContent, true);
-        if (!is_array($content)) {
+        if (!is_array($content) || !isset($content['variables']) || !is_array($content['variables'])) {
             return;
         }
-        foreach ($content as $key => $value) {
+        foreach ($content['variables'] as $key => $value) {
             if (is_scalar($value) || $value === null) {
                 $this->tableResult->addCustomVariable((string) $key, $value);
             }

--- a/libs/output-mapping/src/Table/Result.php
+++ b/libs/output-mapping/src/Table/Result.php
@@ -17,6 +17,9 @@ class Result
     /** @var array<string, array<string, int|string>> */
     private array $genericVariables = [];
 
+    /** @var array<string, mixed> */
+    private array $customVariables = [];
+
     public function addTable(TableInfo $table): void
     {
         $this->tables[] = $table;
@@ -49,5 +52,17 @@ class Result
     public function getGenericVariables(): array
     {
         return $this->genericVariables;
+    }
+
+    /** @param array<string, mixed> $variables */
+    public function setCustomVariables(array $variables): void
+    {
+        $this->customVariables = $variables;
+    }
+
+    /** @return array<string, mixed> */
+    public function getCustomVariables(): array
+    {
+        return $this->customVariables;
     }
 }

--- a/libs/output-mapping/src/Table/Result.php
+++ b/libs/output-mapping/src/Table/Result.php
@@ -54,10 +54,9 @@ class Result
         return $this->genericVariables;
     }
 
-    /** @param array<string, scalar|null> $variables */
-    public function setCustomVariables(array $variables): void
+    public function addCustomVariable(string $key, int|float|string|bool|null $value): void
     {
-        $this->customVariables = $variables;
+        $this->customVariables[$key] = $value;
     }
 
     /** @return array<string, scalar|null> */

--- a/libs/output-mapping/src/Table/Result.php
+++ b/libs/output-mapping/src/Table/Result.php
@@ -17,7 +17,7 @@ class Result
     /** @var array<string, array<string, int|string>> */
     private array $genericVariables = [];
 
-    /** @var array<string, mixed> */
+    /** @var array<string, scalar|null> */
     private array $customVariables = [];
 
     public function addTable(TableInfo $table): void
@@ -54,13 +54,13 @@ class Result
         return $this->genericVariables;
     }
 
-    /** @param array<string, mixed> $variables */
+    /** @param array<string, scalar|null> $variables */
     public function setCustomVariables(array $variables): void
     {
         $this->customVariables = $variables;
     }
 
-    /** @return array<string, mixed> */
+    /** @return array<string, scalar|null> */
     public function getCustomVariables(): array
     {
         return $this->customVariables;

--- a/libs/output-mapping/src/TableLoader.php
+++ b/libs/output-mapping/src/TableLoader.php
@@ -172,7 +172,6 @@ class TableLoader
         $tableQueue->start();
         $tableQueue->loadCustomVariables(Path::join(
             $strategy->getMetadataStorage()->getPath(),
-            $configuration->getSourcePathPrefix(),
             'variables.json',
         ));
 

--- a/libs/output-mapping/src/TableLoader.php
+++ b/libs/output-mapping/src/TableLoader.php
@@ -170,15 +170,7 @@ class TableLoader
 
         $tableQueue = new LoadTableQueue($this->clientWrapper, $this->logger, $loadTableTasks);
         $tableQueue->start();
-        $metadataStoragePath = $strategy->getMetadataStorage()->getPath();
-        $sourcePathPrefix = $configuration->getSourcePathPrefix();
-        if ($sourcePathPrefix === '' || $sourcePathPrefix === '/') {
-            $variablesPath = Path::join($metadataStoragePath, 'result.json');
-        } else {
-            $tablesDir = Path::join($metadataStoragePath, $sourcePathPrefix);
-            $variablesPath = Path::join(dirname($tablesDir), 'result.json');
-        }
-        $tableQueue->loadCustomVariables($variablesPath);
+        $tableQueue->loadCustomVariables(Path::join($strategy->getMetadataStorage()->getPath(), 'result.json'));
 
         return $tableQueue;
     }

--- a/libs/output-mapping/src/TableLoader.php
+++ b/libs/output-mapping/src/TableLoader.php
@@ -170,8 +170,15 @@ class TableLoader
 
         $tableQueue = new LoadTableQueue($this->clientWrapper, $this->logger, $loadTableTasks);
         $tableQueue->start();
-        $tablesDir = Path::join($strategy->getMetadataStorage()->getPath(), $configuration->getSourcePathPrefix());
-        $tableQueue->loadCustomVariables(dirname($tablesDir) . '/variables.json');
+        $metadataStoragePath = $strategy->getMetadataStorage()->getPath();
+        $sourcePathPrefix = $configuration->getSourcePathPrefix();
+        if ($sourcePathPrefix === '' || $sourcePathPrefix === '/') {
+            $variablesPath = Path::join($metadataStoragePath, 'variables.json');
+        } else {
+            $tablesDir = Path::join($metadataStoragePath, $sourcePathPrefix);
+            $variablesPath = Path::join(dirname($tablesDir), 'variables.json');
+        }
+        $tableQueue->loadCustomVariables($variablesPath);
 
         return $tableQueue;
     }

--- a/libs/output-mapping/src/TableLoader.php
+++ b/libs/output-mapping/src/TableLoader.php
@@ -170,10 +170,8 @@ class TableLoader
 
         $tableQueue = new LoadTableQueue($this->clientWrapper, $this->logger, $loadTableTasks);
         $tableQueue->start();
-        $tableQueue->loadCustomVariables(Path::join(
-            $strategy->getMetadataStorage()->getPath(),
-            'variables.json',
-        ));
+        $tablesDir = Path::join($strategy->getMetadataStorage()->getPath(), $configuration->getSourcePathPrefix());
+        $tableQueue->loadCustomVariables(dirname($tablesDir) . '/variables.json');
 
         return $tableQueue;
     }

--- a/libs/output-mapping/src/TableLoader.php
+++ b/libs/output-mapping/src/TableLoader.php
@@ -173,10 +173,10 @@ class TableLoader
         $metadataStoragePath = $strategy->getMetadataStorage()->getPath();
         $sourcePathPrefix = $configuration->getSourcePathPrefix();
         if ($sourcePathPrefix === '' || $sourcePathPrefix === '/') {
-            $variablesPath = Path::join($metadataStoragePath, 'variables.json');
+            $variablesPath = Path::join($metadataStoragePath, 'result.json');
         } else {
             $tablesDir = Path::join($metadataStoragePath, $sourcePathPrefix);
-            $variablesPath = Path::join(dirname($tablesDir), 'variables.json');
+            $variablesPath = Path::join(dirname($tablesDir), 'result.json');
         }
         $tableQueue->loadCustomVariables($variablesPath);
 

--- a/libs/output-mapping/src/TableLoader.php
+++ b/libs/output-mapping/src/TableLoader.php
@@ -15,6 +15,7 @@ use Keboola\OutputMapping\Staging\StrategyFactory;
 use Keboola\OutputMapping\Storage\StoragePreparer;
 use Keboola\OutputMapping\Storage\TableChangesStore;
 use Keboola\OutputMapping\Storage\TableStructureValidatorFactory;
+use Keboola\OutputMapping\Writer\Helper\Path;
 use Keboola\OutputMapping\Writer\Table\BranchResolver;
 use Keboola\OutputMapping\Writer\Table\MetadataSetter;
 use Keboola\OutputMapping\Writer\Table\SlicerDecider;
@@ -169,6 +170,11 @@ class TableLoader
 
         $tableQueue = new LoadTableQueue($this->clientWrapper, $this->logger, $loadTableTasks);
         $tableQueue->start();
+        $tableQueue->loadCustomVariables(Path::join(
+            $strategy->getMetadataStorage()->getPath(),
+            $configuration->getSourcePathPrefix(),
+            'variables.json',
+        ));
 
         return $tableQueue;
     }

--- a/libs/output-mapping/tests/DeferredTasks/LoadTableQueueTest.php
+++ b/libs/output-mapping/tests/DeferredTasks/LoadTableQueueTest.php
@@ -634,7 +634,7 @@ class LoadTableQueueTest extends TestCase
             ->willReturn($this->createMock(Client::class));
 
         $tmpFile = tempnam(sys_get_temp_dir(), 'variables') . '.json';
-        file_put_contents($tmpFile, (string) json_encode(['my_var' => 'hello', 'count' => 42]));
+        file_put_contents($tmpFile, (string) json_encode(['variables' => ['my_var' => 'hello', 'count' => 42]]));
 
         $loadQueue = new LoadTableQueue($clientWrapperMock, new NullLogger(), []);
         $loadQueue->loadCustomVariables($tmpFile);

--- a/libs/output-mapping/tests/DeferredTasks/LoadTableQueueTest.php
+++ b/libs/output-mapping/tests/DeferredTasks/LoadTableQueueTest.php
@@ -662,7 +662,7 @@ class LoadTableQueueTest extends TestCase
         $clientWrapperMock->method('getTableAndFileStorageClient')
             ->willReturn($this->createMock(Client::class));
 
-        $tmpFile = tempnam(sys_get_temp_dir(), 'variables') . '.json';
+        $tmpFile = tempnam(sys_get_temp_dir(), 'result') . '.json';
         file_put_contents($tmpFile, 'not valid json {{{');
 
         $loadQueue = new LoadTableQueue($clientWrapperMock, new NullLogger(), []);

--- a/libs/output-mapping/tests/DeferredTasks/LoadTableQueueTest.php
+++ b/libs/output-mapping/tests/DeferredTasks/LoadTableQueueTest.php
@@ -626,4 +626,50 @@ class LoadTableQueueTest extends TestCase
         $this->expectExceptionMessage('Failed to load table "my-table": Hi');
         $loadQueue->waitForAll();
     }
+
+    public function testLoadCustomVariablesSetsVariablesFromValidJson(): void
+    {
+        $clientWrapperMock = $this->createMock(ClientWrapper::class);
+        $clientWrapperMock->method('getTableAndFileStorageClient')
+            ->willReturn($this->createMock(Client::class));
+
+        $tmpFile = tempnam(sys_get_temp_dir(), 'variables') . '.json';
+        file_put_contents($tmpFile, (string) json_encode(['my_var' => 'hello', 'count' => 42]));
+
+        $loadQueue = new LoadTableQueue($clientWrapperMock, new NullLogger(), []);
+        $loadQueue->loadCustomVariables($tmpFile);
+
+        self::assertSame(['my_var' => 'hello', 'count' => 42], $loadQueue->getTableResult()->getCustomVariables());
+
+        unlink($tmpFile);
+    }
+
+    public function testLoadCustomVariablesDoesNothingWhenFileMissing(): void
+    {
+        $clientWrapperMock = $this->createMock(ClientWrapper::class);
+        $clientWrapperMock->method('getTableAndFileStorageClient')
+            ->willReturn($this->createMock(Client::class));
+
+        $loadQueue = new LoadTableQueue($clientWrapperMock, new NullLogger(), []);
+        $loadQueue->loadCustomVariables('/nonexistent/path/variables.json');
+
+        self::assertSame([], $loadQueue->getTableResult()->getCustomVariables());
+    }
+
+    public function testLoadCustomVariablesIgnoresInvalidJson(): void
+    {
+        $clientWrapperMock = $this->createMock(ClientWrapper::class);
+        $clientWrapperMock->method('getTableAndFileStorageClient')
+            ->willReturn($this->createMock(Client::class));
+
+        $tmpFile = tempnam(sys_get_temp_dir(), 'variables') . '.json';
+        file_put_contents($tmpFile, 'not valid json {{{');
+
+        $loadQueue = new LoadTableQueue($clientWrapperMock, new NullLogger(), []);
+        $loadQueue->loadCustomVariables($tmpFile);
+
+        self::assertSame([], $loadQueue->getTableResult()->getCustomVariables());
+
+        unlink($tmpFile);
+    }
 }

--- a/libs/output-mapping/tests/Table/ResultTest.php
+++ b/libs/output-mapping/tests/Table/ResultTest.php
@@ -135,6 +135,32 @@ class ResultTest extends TestCase
         self::assertSame([], $result->getGenericVariables());
     }
 
+    public function testSetCustomVariablesStoresData(): void
+    {
+        $result = new Result();
+
+        $result->setCustomVariables(['my_var' => 'value', 'count' => 42]);
+
+        self::assertSame(['my_var' => 'value', 'count' => 42], $result->getCustomVariables());
+    }
+
+    public function testGetCustomVariablesInitiallyEmpty(): void
+    {
+        $result = new Result();
+
+        self::assertSame([], $result->getCustomVariables());
+    }
+
+    public function testSetCustomVariablesOverwritesPreviousValues(): void
+    {
+        $result = new Result();
+
+        $result->setCustomVariables(['old' => 'value']);
+        $result->setCustomVariables(['new' => 'data']);
+
+        self::assertSame(['new' => 'data'], $result->getCustomVariables());
+    }
+
     public function testSetResults(): void
     {
         $tablesResult = new Result();

--- a/libs/output-mapping/tests/Table/ResultTest.php
+++ b/libs/output-mapping/tests/Table/ResultTest.php
@@ -135,11 +135,12 @@ class ResultTest extends TestCase
         self::assertSame([], $result->getGenericVariables());
     }
 
-    public function testSetCustomVariablesStoresData(): void
+    public function testAddCustomVariableStoresData(): void
     {
         $result = new Result();
 
-        $result->setCustomVariables(['my_var' => 'value', 'count' => 42]);
+        $result->addCustomVariable('my_var', 'value');
+        $result->addCustomVariable('count', 42);
 
         self::assertSame(['my_var' => 'value', 'count' => 42], $result->getCustomVariables());
     }
@@ -151,14 +152,14 @@ class ResultTest extends TestCase
         self::assertSame([], $result->getCustomVariables());
     }
 
-    public function testSetCustomVariablesOverwritesPreviousValues(): void
+    public function testAddCustomVariableOverwritesExistingKey(): void
     {
         $result = new Result();
 
-        $result->setCustomVariables(['old' => 'value']);
-        $result->setCustomVariables(['new' => 'data']);
+        $result->addCustomVariable('key', 'old');
+        $result->addCustomVariable('key', 'new');
 
-        self::assertSame(['new' => 'data'], $result->getCustomVariables());
+        self::assertSame(['key' => 'new'], $result->getCustomVariables());
     }
 
     public function testSetResults(): void

--- a/libs/output-mapping/tests/Writer/StorageApiLocalTableWriterTest.php
+++ b/libs/output-mapping/tests/Writer/StorageApiLocalTableWriterTest.php
@@ -2760,6 +2760,35 @@ CSV;
     }
 
     #[NeedsEmptyOutputBucket]
+    public function testUploadTablesLoadsCustomVariablesWithRootSourcePathPrefix(): void
+    {
+        $root = $this->temp->getTmpFolder();
+        file_put_contents($root . '/table1a.csv', "\"Id\",\"Name\"\n\"test\",\"test\"\n");
+        file_put_contents($root . '/variables.json', (string) json_encode([
+            'my_var' => 'hello',
+            'count' => 42,
+        ]));
+
+        $configs = [['source' => 'table1a.csv', 'destination' => $this->emptyOutputBucketId . '.table1a']];
+        $tableQueue = $this->getTableLoader()->uploadTables(
+            configuration: new OutputMappingSettings(
+                configuration: ['mapping' => $configs],
+                sourcePathPrefix: '/',
+                storageApiToken: $this->clientWrapper->getToken(),
+                isFailedJob: false,
+                dataTypeSupport: 'none',
+            ),
+            systemMetadata: new SystemMetadata(['componentId' => 'foo']),
+        );
+        $tableQueue->waitForAll();
+
+        self::assertSame(
+            ['my_var' => 'hello', 'count' => 42],
+            $tableQueue->getTableResult()->getCustomVariables(),
+        );
+    }
+
+    #[NeedsEmptyOutputBucket]
     public function testUploadTablesCustomVariablesEmptyWhenVariablesJsonMissing(): void
     {
         $root = $this->temp->getTmpFolder();

--- a/libs/output-mapping/tests/Writer/StorageApiLocalTableWriterTest.php
+++ b/libs/output-mapping/tests/Writer/StorageApiLocalTableWriterTest.php
@@ -2760,38 +2760,6 @@ CSV;
     }
 
     #[NeedsEmptyOutputBucket]
-    public function testUploadTablesLoadsCustomVariablesWithRootSourcePathPrefix(): void
-    {
-        $stagingPath = $this->temp->getTmpFolder() . '/root-prefix-staging';
-        mkdir($stagingPath);
-        file_put_contents($stagingPath . '/table1a.csv', "\"Id\",\"Name\"\n\"test\",\"test\"\n");
-        file_put_contents($stagingPath . '/variables.json', (string) json_encode([
-            'my_var' => 'hello',
-            'count' => 42,
-        ]));
-
-        $configs = [['source' => 'table1a.csv', 'destination' => $this->emptyOutputBucketId . '.table1a']];
-        $tableQueue = $this->getTableLoader(
-            strategyFactory: $this->getLocalStagingFactory(stagingPath: $stagingPath),
-        )->uploadTables(
-            configuration: new OutputMappingSettings(
-                configuration: ['mapping' => $configs],
-                sourcePathPrefix: '/',
-                storageApiToken: $this->clientWrapper->getToken(),
-                isFailedJob: false,
-                dataTypeSupport: 'none',
-            ),
-            systemMetadata: new SystemMetadata(['componentId' => 'foo']),
-        );
-        $tableQueue->waitForAll();
-
-        self::assertSame(
-            ['my_var' => 'hello', 'count' => 42],
-            $tableQueue->getTableResult()->getCustomVariables(),
-        );
-    }
-
-    #[NeedsEmptyOutputBucket]
     public function testUploadTablesCustomVariablesEmptyWhenVariablesJsonMissing(): void
     {
         $root = $this->temp->getTmpFolder();

--- a/libs/output-mapping/tests/Writer/StorageApiLocalTableWriterTest.php
+++ b/libs/output-mapping/tests/Writer/StorageApiLocalTableWriterTest.php
@@ -2762,15 +2762,18 @@ CSV;
     #[NeedsEmptyOutputBucket]
     public function testUploadTablesLoadsCustomVariablesWithRootSourcePathPrefix(): void
     {
-        $root = $this->temp->getTmpFolder();
-        file_put_contents($root . '/table1a.csv', "\"Id\",\"Name\"\n\"test\",\"test\"\n");
-        file_put_contents($root . '/variables.json', (string) json_encode([
+        $stagingPath = $this->temp->getTmpFolder() . '/root-prefix-staging';
+        mkdir($stagingPath);
+        file_put_contents($stagingPath . '/table1a.csv', "\"Id\",\"Name\"\n\"test\",\"test\"\n");
+        file_put_contents($stagingPath . '/variables.json', (string) json_encode([
             'my_var' => 'hello',
             'count' => 42,
         ]));
 
         $configs = [['source' => 'table1a.csv', 'destination' => $this->emptyOutputBucketId . '.table1a']];
-        $tableQueue = $this->getTableLoader()->uploadTables(
+        $tableQueue = $this->getTableLoader(
+            strategyFactory: $this->getLocalStagingFactory(stagingPath: $stagingPath),
+        )->uploadTables(
             configuration: new OutputMappingSettings(
                 configuration: ['mapping' => $configs],
                 sourcePathPrefix: '/',

--- a/libs/output-mapping/tests/Writer/StorageApiLocalTableWriterTest.php
+++ b/libs/output-mapping/tests/Writer/StorageApiLocalTableWriterTest.php
@@ -2729,4 +2729,78 @@ CSV;
         $jobIds = $tableQueue->waitForAll();
         self::assertCount(1, $jobIds);
     }
+
+    #[NeedsEmptyOutputBucket]
+    public function testUploadTablesLoadsCustomVariablesFromVariablesJson(): void
+    {
+        $root = $this->temp->getTmpFolder();
+        file_put_contents($root . '/upload/table1a.csv', "\"Id\",\"Name\"\n\"test\",\"test\"\n");
+        file_put_contents($root . '/upload/variables.json', (string) json_encode([
+            'my_var' => 'hello',
+            'count' => 42,
+        ]));
+
+        $configs = [['source' => 'table1a.csv', 'destination' => $this->emptyOutputBucketId . '.table1a']];
+        $tableQueue = $this->getTableLoader()->uploadTables(
+            configuration: new OutputMappingSettings(
+                configuration: ['mapping' => $configs],
+                sourcePathPrefix: 'upload',
+                storageApiToken: $this->clientWrapper->getToken(),
+                isFailedJob: false,
+                dataTypeSupport: 'none',
+            ),
+            systemMetadata: new SystemMetadata(['componentId' => 'foo']),
+        );
+        $tableQueue->waitForAll();
+
+        self::assertSame(
+            ['my_var' => 'hello', 'count' => 42],
+            $tableQueue->getTableResult()->getCustomVariables(),
+        );
+    }
+
+    #[NeedsEmptyOutputBucket]
+    public function testUploadTablesCustomVariablesEmptyWhenVariablesJsonMissing(): void
+    {
+        $root = $this->temp->getTmpFolder();
+        file_put_contents($root . '/upload/table1a.csv', "\"Id\",\"Name\"\n\"test\",\"test\"\n");
+
+        $configs = [['source' => 'table1a.csv', 'destination' => $this->emptyOutputBucketId . '.table1a']];
+        $tableQueue = $this->getTableLoader()->uploadTables(
+            configuration: new OutputMappingSettings(
+                configuration: ['mapping' => $configs],
+                sourcePathPrefix: 'upload',
+                storageApiToken: $this->clientWrapper->getToken(),
+                isFailedJob: false,
+                dataTypeSupport: 'none',
+            ),
+            systemMetadata: new SystemMetadata(['componentId' => 'foo']),
+        );
+        $tableQueue->waitForAll();
+
+        self::assertSame([], $tableQueue->getTableResult()->getCustomVariables());
+    }
+
+    #[NeedsEmptyOutputBucket]
+    public function testUploadTablesIgnoresInvalidVariablesJson(): void
+    {
+        $root = $this->temp->getTmpFolder();
+        file_put_contents($root . '/upload/table1a.csv', "\"Id\",\"Name\"\n\"test\",\"test\"\n");
+        file_put_contents($root . '/upload/variables.json', 'not valid json {{{');
+
+        $configs = [['source' => 'table1a.csv', 'destination' => $this->emptyOutputBucketId . '.table1a']];
+        $tableQueue = $this->getTableLoader()->uploadTables(
+            configuration: new OutputMappingSettings(
+                configuration: ['mapping' => $configs],
+                sourcePathPrefix: 'upload',
+                storageApiToken: $this->clientWrapper->getToken(),
+                isFailedJob: false,
+                dataTypeSupport: 'none',
+            ),
+            systemMetadata: new SystemMetadata(['componentId' => 'foo']),
+        );
+        $tableQueue->waitForAll();
+
+        self::assertSame([], $tableQueue->getTableResult()->getCustomVariables());
+    }
 }

--- a/libs/output-mapping/tests/Writer/StorageApiLocalTableWriterTest.php
+++ b/libs/output-mapping/tests/Writer/StorageApiLocalTableWriterTest.php
@@ -2735,7 +2735,7 @@ CSV;
     {
         $root = $this->temp->getTmpFolder();
         file_put_contents($root . '/upload/table1a.csv', "\"Id\",\"Name\"\n\"test\",\"test\"\n");
-        file_put_contents($root . '/upload/variables.json', (string) json_encode([
+        file_put_contents($root . '/variables.json', (string) json_encode([
             'my_var' => 'hello',
             'count' => 42,
         ]));
@@ -2786,7 +2786,7 @@ CSV;
     {
         $root = $this->temp->getTmpFolder();
         file_put_contents($root . '/upload/table1a.csv', "\"Id\",\"Name\"\n\"test\",\"test\"\n");
-        file_put_contents($root . '/upload/variables.json', 'not valid json {{{');
+        file_put_contents($root . '/variables.json', 'not valid json {{{');
 
         $configs = [['source' => 'table1a.csv', 'destination' => $this->emptyOutputBucketId . '.table1a']];
         $tableQueue = $this->getTableLoader()->uploadTables(

--- a/libs/output-mapping/tests/Writer/StorageApiLocalTableWriterTest.php
+++ b/libs/output-mapping/tests/Writer/StorageApiLocalTableWriterTest.php
@@ -2731,13 +2731,15 @@ CSV;
     }
 
     #[NeedsEmptyOutputBucket]
-    public function testUploadTablesLoadsCustomVariablesFromVariablesJson(): void
+    public function testUploadTablesLoadsCustomVariablesFromResultJson(): void
     {
         $root = $this->temp->getTmpFolder();
         file_put_contents($root . '/upload/table1a.csv', "\"Id\",\"Name\"\n\"test\",\"test\"\n");
-        file_put_contents($root . '/variables.json', (string) json_encode([
-            'my_var' => 'hello',
-            'count' => 42,
+        file_put_contents($root . '/result.json', (string) json_encode([
+            'variables' => [
+                'my_var' => 'hello',
+                'count' => 42,
+            ],
         ]));
 
         $configs = [['source' => 'table1a.csv', 'destination' => $this->emptyOutputBucketId . '.table1a']];
@@ -2782,11 +2784,11 @@ CSV;
     }
 
     #[NeedsEmptyOutputBucket]
-    public function testUploadTablesIgnoresInvalidVariablesJson(): void
+    public function testUploadTablesIgnoresInvalidResultJson(): void
     {
         $root = $this->temp->getTmpFolder();
         file_put_contents($root . '/upload/table1a.csv', "\"Id\",\"Name\"\n\"test\",\"test\"\n");
-        file_put_contents($root . '/variables.json', 'not valid json {{{');
+        file_put_contents($root . '/result.json', 'not valid json {{{');
 
         $configs = [['source' => 'table1a.csv', 'destination' => $this->emptyOutputBucketId . '.table1a']];
         $tableQueue = $this->getTableLoader()->uploadTables(

--- a/libs/output-mapping/tests/Writer/StorageApiLocalTableWriterTest.php
+++ b/libs/output-mapping/tests/Writer/StorageApiLocalTableWriterTest.php
@@ -2730,11 +2730,9 @@ CSV;
         self::assertCount(1, $jobIds);
     }
 
-    #[NeedsEmptyOutputBucket]
     public function testUploadTablesLoadsCustomVariablesFromResultJson(): void
     {
         $root = $this->temp->getTmpFolder();
-        file_put_contents($root . '/upload/table1a.csv', "\"Id\",\"Name\"\n\"test\",\"test\"\n");
         file_put_contents($root . '/result.json', (string) json_encode([
             'variables' => [
                 'my_var' => 'hello',
@@ -2742,10 +2740,9 @@ CSV;
             ],
         ]));
 
-        $configs = [['source' => 'table1a.csv', 'destination' => $this->emptyOutputBucketId . '.table1a']];
         $tableQueue = $this->getTableLoader()->uploadTables(
             configuration: new OutputMappingSettings(
-                configuration: ['mapping' => $configs],
+                configuration: ['mapping' => []],
                 sourcePathPrefix: 'upload',
                 storageApiToken: $this->clientWrapper->getToken(),
                 isFailedJob: false,
@@ -2761,16 +2758,11 @@ CSV;
         );
     }
 
-    #[NeedsEmptyOutputBucket]
-    public function testUploadTablesCustomVariablesEmptyWhenVariablesJsonMissing(): void
+    public function testUploadTablesCustomVariablesEmptyWhenResultJsonMissing(): void
     {
-        $root = $this->temp->getTmpFolder();
-        file_put_contents($root . '/upload/table1a.csv', "\"Id\",\"Name\"\n\"test\",\"test\"\n");
-
-        $configs = [['source' => 'table1a.csv', 'destination' => $this->emptyOutputBucketId . '.table1a']];
         $tableQueue = $this->getTableLoader()->uploadTables(
             configuration: new OutputMappingSettings(
-                configuration: ['mapping' => $configs],
+                configuration: ['mapping' => []],
                 sourcePathPrefix: 'upload',
                 storageApiToken: $this->clientWrapper->getToken(),
                 isFailedJob: false,
@@ -2783,17 +2775,14 @@ CSV;
         self::assertSame([], $tableQueue->getTableResult()->getCustomVariables());
     }
 
-    #[NeedsEmptyOutputBucket]
     public function testUploadTablesIgnoresInvalidResultJson(): void
     {
         $root = $this->temp->getTmpFolder();
-        file_put_contents($root . '/upload/table1a.csv', "\"Id\",\"Name\"\n\"test\",\"test\"\n");
         file_put_contents($root . '/result.json', 'not valid json {{{');
 
-        $configs = [['source' => 'table1a.csv', 'destination' => $this->emptyOutputBucketId . '.table1a']];
-        $tableQueue = $this->getTableLoader()->uploadTables(
+        $tableQueue = $this->getTableLoader(logger: $this->testLogger)->uploadTables(
             configuration: new OutputMappingSettings(
-                configuration: ['mapping' => $configs],
+                configuration: ['mapping' => []],
                 sourcePathPrefix: 'upload',
                 storageApiToken: $this->clientWrapper->getToken(),
                 isFailedJob: false,
@@ -2804,5 +2793,6 @@ CSV;
         $tableQueue->waitForAll();
 
         self::assertSame([], $tableQueue->getTableResult()->getCustomVariables());
+        self::assertTrue($this->testHandler->hasWarningThatContains('Failed to parse result.json file'));
     }
 }


### PR DESCRIPTION
## Summary
- Add `customVariables` property to `Result` with `addCustomVariable()` / `getCustomVariables()` methods
- Add `loadCustomVariables(string $path)` method to `LoadTableQueue` that reads `result.json`, parses JSON, and stores the result
- `TableLoader::uploadTables()` calls `loadCustomVariables()` after `start()` with the resolved path
- Handle `sourcePathPrefix=''` or `'/'` correctly — resolve `result.json` directly from metadata storage root

## Acceptance Criteria
- [ ] `Result::addCustomVariable(string, scalar|null)` stores individual variables - implemented in `libs/output-mapping/src/Table/Result.php`
- [ ] `Result::getCustomVariables()` returns stored variables - implemented in `libs/output-mapping/src/Table/Result.php`
- [ ] `LoadTableQueue::loadCustomVariables(path)` reads and parses `result.json` - implemented in `libs/output-mapping/src/DeferredTasks/LoadTableQueue.php`
- [ ] Missing file is silently ignored (customVariables stays empty) - confirmed
- [ ] Invalid JSON is silently ignored (customVariables stays empty) - confirmed
- [ ] `TableLoader` calls `loadCustomVariables` after table upload - implemented in `libs/output-mapping/src/TableLoader.php`

## Tests
- `ResultTest.php` - unit tests for addCustomVariable/getCustomVariables
- `LoadTableQueueTest.php` - unit tests for loadCustomVariables (valid JSON, missing file, invalid JSON)
- `StorageApiLocalTableWriterTest.php` - integration tests for the full upload flow including sourcePathPrefix='/'

## Files Changed
- `libs/output-mapping/src/Table/Result.php`
- `libs/output-mapping/src/DeferredTasks/LoadTableQueue.php`
- `libs/output-mapping/src/TableLoader.php`
- `libs/output-mapping/tests/Table/ResultTest.php`
- `libs/output-mapping/tests/DeferredTasks/LoadTableQueueTest.php`
- `libs/output-mapping/tests/Writer/StorageApiLocalTableWriterTest.php`