### PR TITLE
feat(sandboxes-service-api-client): add persistentStorageReady and persistentStorageK8sStorageClassName to Sandbox model

### DIFF
--- a/libs/sandboxes-service-api-client/src/Sandboxes/Legacy/Sandbox.php
+++ b/libs/sandboxes-service-api-client/src/Sandboxes/Legacy/Sandbox.php
@@ -150,6 +150,8 @@ class Sandbox
 
     private ?string $persistentStoragePvcName = null;
     private ?string $persistentStorageK8sManifest = null;
+    private ?bool $persistentStorageReady = null;
+    private ?string $persistentStorageK8sStorageClassName = null;
 
     private ?SandboxCredentials $credentials = null;
 
@@ -204,6 +206,10 @@ class Sandbox
 
         $sandbox->persistentStoragePvcName = $in['persistentStorage']['pvcName'] ?? null;
         $sandbox->persistentStorageK8sManifest = $in['persistentStorage']['k8sManifest'] ?? null;
+        $sandbox->persistentStorageReady = isset($in['persistentStorage']['ready'])
+            ? (bool) $in['persistentStorage']['ready']
+            : null;
+        $sandbox->persistentStorageK8sStorageClassName = $in['persistentStorage']['k8sStorageClassName'] ?? null;
 
         self::setPasswordOrCredentials($in, $sandbox);
 
@@ -334,6 +340,8 @@ class Sandbox
 
         $result['persistentStorage']['pvcName'] = $this->persistentStoragePvcName;
         $result['persistentStorage']['k8sManifest'] = $this->persistentStorageK8sManifest;
+        $result['persistentStorage']['ready'] = $this->persistentStorageReady;
+        $result['persistentStorage']['k8sStorageClassName'] = $this->persistentStorageK8sStorageClassName;
 
         if ($this->credentials !== null) {
             $result['credentials'] = $this->credentials->toArray();
@@ -763,6 +771,22 @@ class Sandbox
     public function removePersistentStorageK8sManifest(): Sandbox
     {
         $this->persistentStorageK8sManifest = null;
+        return $this;
+    }
+
+    public function getPersistentStorageReady(): ?bool
+    {
+        return $this->persistentStorageReady;
+    }
+
+    public function getPersistentStorageK8sStorageClassName(): ?string
+    {
+        return $this->persistentStorageK8sStorageClassName;
+    }
+
+    public function setPersistentStorageK8sStorageClassName(?string $persistentStorageK8sStorageClassName): self
+    {
+        $this->persistentStorageK8sStorageClassName = $persistentStorageK8sStorageClassName;
         return $this;
     }
 

--- a/libs/sandboxes-service-api-client/tests/Sandboxes/Legacy/SandboxTest.php
+++ b/libs/sandboxes-service-api-client/tests/Sandboxes/Legacy/SandboxTest.php
@@ -56,6 +56,8 @@ class SandboxTest extends TestCase
             'persistentStorage' => [
                 'pvcName' => 'pvc-name',
                 'k8sManifest' => 'pvc-manifest',
+                'ready' => true,
+                'k8sStorageClassName' => 'standard',
             ],
         ]);
 
@@ -94,6 +96,45 @@ class SandboxTest extends TestCase
         self::assertSame('databricks-cluster-id', $sandbox->getDatabricksClusterId());
         self::assertSame('pvc-name', $sandbox->getPersistentStoragePvcName());
         self::assertSame('pvc-manifest', $sandbox->getPersistentStorageK8sManifest());
+        self::assertTrue($sandbox->getPersistentStorageReady());
+        self::assertSame('standard', $sandbox->getPersistentStorageK8sStorageClassName());
+
+        $array = $sandbox->toArray();
+        self::assertSame('branch-id', $array['branchId']);
+        self::assertSame('id', $array['id']);
+        self::assertSame('keboola.data-apps', $array['componentId']);
+        self::assertSame('configuration-id', $array['configurationId']);
+        self::assertSame('4', $array['configurationVersion']);
+        self::assertSame('physical-id', $array['physicalId']);
+        self::assertSame('python', $array['type']);
+        self::assertSame('small', $array['size']);
+        self::assertSame(['storageSize_GB' => 10], $array['sizeParameters']);
+        self::assertSame('user', $array['user']);
+        self::assertSame('password', $array['password']);
+        self::assertSame('host', $array['host']);
+        self::assertSame('url', $array['url']);
+        self::assertSame('image-version', $array['imageVersion']);
+        self::assertSame('staging-workspace-id', $array['stagingWorkspaceId']);
+        self::assertSame('staging-workspace-type', $array['stagingWorkspaceType']);
+        self::assertSame(['foo' => 'bar'], $array['workspaceDetails']);
+        self::assertSame('autosave-token-id', $array['autosaveTokenId']);
+        self::assertSame(['foo', 'bar'], $array['packages']);
+        self::assertSame('2024-02-02 12:00:00', $array['createdTimestamp']);
+        self::assertSame('2024-02-02 14:00:00', $array['updatedTimestamp']);
+        self::assertSame('2024-02-02 18:00:00', $array['expirationTimestamp']);
+        self::assertSame(1, $array['expirationAfterHours']);
+        self::assertSame(2, $array['autoSuspendAfterSeconds']);
+        self::assertSame('2024-02-02 20:00:00', $array['lastAutosaveTimestamp']);
+        self::assertTrue($array['active']);
+        self::assertTrue($array['shared']);
+        self::assertSame('databricks-spark-version', $array['databricks']['sparkVersion']);
+        self::assertSame('databricks-node-type', $array['databricks']['nodeType']);
+        self::assertSame(5, $array['databricks']['numberOfNodes']);
+        self::assertSame('databricks-cluster-id', $array['databricks']['clusterId']);
+        self::assertSame('pvc-name', $array['persistentStorage']['pvcName']);
+        self::assertSame('pvc-manifest', $array['persistentStorage']['k8sManifest']);
+        self::assertTrue($array['persistentStorage']['ready']);
+        self::assertSame('standard', $array['persistentStorage']['k8sStorageClassName']);
     }
 
     public function testPasswordNullable(): void


### PR DESCRIPTION
https://linear.app/keboola/issue/AJDA-2483/sandboxes-service-find-out-how-getcurrentproject-is-used

related to https://github.com/keboola/sandboxes-service/pull/524

## Description
Adds two new fields to the `Sandbox` model in the sandboxes API client: `persistentStorageReady` (bool) and `persistentStorageK8sStorageClassName` (string). Both are deserialized from the `persistentStorage` response object and exposed via getters, with a setter for `k8sStorageClassName`.

## Release Notes

**Change Type**
New feature — exposes additional persistent storage metadata on the Sandbox model.

**Justification**
The sandboxes service now returns `ready` and `k8sStorageClassName` fields in the `persistentStorage` object. The PVC garbage collector needs to consume this data from the API response rather than computing it independently.

**Plans for Customer Communication**
No customer communication needed; this is an internal API client change.

**Impact Analysis**
Low risk. Additive change only — new nullable fields with no effect on existing behaviour. No breaking changes.

**Deployment Plan**
Standard CI/CD continuous deployment across all stacks.

**Rollback Plan**
Standard git revert if issues detected post-deployment.

**Post-Release Support Plan**
No follow-up actions required.