### PR TITLE
fix[k8s-client]: Fix App models (again)

### DIFF
--- a/libs/k8s-client/phpstan.neon
+++ b/libs/k8s-client/phpstan.neon
@@ -1,6 +1,5 @@
 parameters:
     level: max
-    treatPhpDocTypesAsCertain: false
     paths:
         - src
         - tests

--- a/libs/k8s-client/provisioning/local/.terraform.lock.hcl
+++ b/libs/k8s-client/provisioning/local/.terraform.lock.hcl
@@ -5,6 +5,7 @@ provider "registry.terraform.io/hashicorp/aws" {
   version     = "6.21.0"
   constraints = "~> 6.8"
   hashes = [
+    "h1:YfPC5vxQr014wnHI6tBqLxaHZcZQvkaVr19ipqXijdw=",
     "h1:lhPGtXHoctW6UiIg2Av8d6Dk7mLl2J2ORR91ZUYzRVk=",
     "zh:03b65e7d275a48bbe5de9aed2bcacf841ea0a85352744587729d179ceb227994",
     "zh:1a50fc50365602769b6844c6eba920b5c6941161508c2ebd5c1a60f7577edd18",
@@ -29,6 +30,7 @@ provider "registry.terraform.io/hashicorp/azurerm" {
   constraints = "~> 4.39"
   hashes = [
     "h1:AeE+jsY9HfzMrTLjQZZ8IWtI/XxqBxbd3BRDSbGU2oM=",
+    "h1:uYLSLApU3bG/q6nxNb2N5FV0YddZxsg6Jlq27hDmPOA=",
     "zh:0adda2cfb2ae9ec394943164cbd5ab1f1fac89a0125ad3966a97363b06b1bd11",
     "zh:23dcc71a1586c2b8644476ccd3b4d4d22aa651d6ceb03d32f801bb7ecb09c84f",
     "zh:4573833c692a87df167e3adf71c4291879e1a5d2e430ba5255509d3510c7a2f5",
@@ -46,8 +48,9 @@ provider "registry.terraform.io/hashicorp/azurerm" {
 
 provider "registry.terraform.io/hashicorp/kubernetes" {
   version     = "2.38.0"
-  constraints = "~> 2.17"
+  constraints = "~> 2.17, ~> 2.38"
   hashes = [
+    "h1:5CkveFo5ynsLdzKk+Kv+r7+U9rMrNjfZPT3a0N/fhgE=",
     "h1:soK8Lt0SZ6dB+HsypFRDzuX/npqlMU6M0fvyaR1yW0k=",
     "zh:0af928d776eb269b192dc0ea0f8a3f0f5ec117224cd644bdacdc682300f84ba0",
     "zh:1be998e67206f7cfc4ffe77c01a09ac91ce725de0abaec9030b22c0a832af44f",

--- a/libs/k8s-client/src/Model/Io/Keboola/Apps/V1/AppRunSpec.php
+++ b/libs/k8s-client/src/Model/Io/Keboola/Apps/V1/AppRunSpec.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Keboola\K8sClient\Model\Io\Keboola\Apps\V1;
 
-use Kubernetes\Model\Io\K8s\Apimachinery\Pkg\Apis\Meta\V1\Time;
 use KubernetesRuntime\AbstractModel;
 
 /**
@@ -29,21 +28,21 @@ class AppRunSpec extends AbstractModel
     /**
      * CreatedAt is the timestamp when this run was created
      *
-     * @var Time
+     * @var string
      */
     public $createdAt = null;
 
     /**
      * StartedAt is the timestamp when this run started
      *
-     * @var Time|null
+     * @var string|null
      */
     public $startedAt = null;
 
     /**
      * StoppedAt is the timestamp when this run stopped
      *
-     * @var Time|null
+     * @var string|null
      */
     public $stoppedAt = null;
 

--- a/libs/k8s-client/src/Model/Io/Keboola/Apps/V1/AppRunStatus.php
+++ b/libs/k8s-client/src/Model/Io/Keboola/Apps/V1/AppRunStatus.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Keboola\K8sClient\Model\Io\Keboola\Apps\V1;
 
 use Kubernetes\Model\Io\K8s\Apimachinery\Pkg\Apis\Meta\V1\Condition;
-use Kubernetes\Model\Io\K8s\Apimachinery\Pkg\Apis\Meta\V1\Time;
 use KubernetesRuntime\AbstractModel;
 
 /**
@@ -16,7 +15,7 @@ class AppRunStatus extends AbstractModel
     /**
      * SyncedAt is the timestamp when this AppRun was synced to the backend
      *
-     * @var Time|null
+     * @var string|null
      */
     public $syncedAt = null;
 

--- a/libs/k8s-client/src/Model/Io/Keboola/Apps/V2/AppSpec.php
+++ b/libs/k8s-client/src/Model/Io/Keboola/Apps/V2/AppSpec.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Keboola\K8sClient\Model\Io\Keboola\Apps\V2;
 
-use Kubernetes\Model\Io\K8s\Apimachinery\Pkg\Apis\Meta\V1\Time;
 use KubernetesRuntime\AbstractModel;
 
 /**
@@ -52,7 +51,7 @@ class AppSpec extends AbstractModel
     /**
      * RestartRequestedAt is the timestamp when the restart was requested.
      *
-     * @var Time|null
+     * @var string|null
      */
     public $restartRequestedAt = null;
 

--- a/libs/k8s-client/src/Model/Io/Keboola/Apps/V2/AppStatus.php
+++ b/libs/k8s-client/src/Model/Io/Keboola/Apps/V2/AppStatus.php
@@ -6,7 +6,6 @@ namespace Keboola\K8sClient\Model\Io\Keboola\Apps\V2;
 
 use Kubernetes\Model\Io\K8s\Api\Core\V1\LocalObjectReference;
 use Kubernetes\Model\Io\K8s\Apimachinery\Pkg\Apis\Meta\V1\Condition;
-use Kubernetes\Model\Io\K8s\Apimachinery\Pkg\Apis\Meta\V1\Time;
 use KubernetesRuntime\AbstractModel;
 
 /**
@@ -46,7 +45,7 @@ class AppStatus extends AbstractModel
     /**
      * LastStartedTime is the timestamp when the app last transitioned to Running state
      *
-     * @var Time|null
+     * @var string|null
      */
     public $lastStartedTime = null;
 
@@ -54,7 +53,7 @@ class AppStatus extends AbstractModel
      * RunStartRequestedAt is set (microsecond precision) when spec.state transitions to Running
      * and cleared when the app stops.
      *
-     * @var Time|null
+     * @var string|null
      */
     public $runStartRequestedAt = null;
 

--- a/libs/k8s-client/src/Model/Io/Keboola/Apps/V2/E2bSandboxStatus.php
+++ b/libs/k8s-client/src/Model/Io/Keboola/Apps/V2/E2bSandboxStatus.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Keboola\K8sClient\Model\Io\Keboola\Apps\V2;
 
-use Kubernetes\Model\Io\K8s\Apimachinery\Pkg\Apis\Meta\V1\Time;
 use KubernetesRuntime\AbstractModel;
 
 /**
@@ -29,7 +28,7 @@ class E2bSandboxStatus extends AbstractModel
     /**
      * StartupLaunchedAt records when the startup script was launched.
      *
-     * @var Time|null
+     * @var string|null
      */
     public $startupLaunchedAt = null;
 


### PR DESCRIPTION
https://linear.app/keboola/issue/PAT-1576/resume-vs-re-deploy-handling

## Description
Aligns model classes with current `App/v2` CRD.

* timestamp fields are `string` (the under-the-hood client lib wrongly marks them as `Time` type)

## Release Notes
- **Justification**
   K8s request data and responses need to be aligned with current CRD.

- **Plans for Customer Communication**
   None.

- **Impact Analysis**
   Has no impact since it's just an update of the lib.

- **Deployment Plan**
   Merge & Deploy.

- **Rollback Plan**
   Revert this PR.

- **Post-Release Support Plan**
   None.