### PR TITLE
PAT-1646 Extend AppRunSpec

### DIFF
--- a/libs/k8s-client/src/Model/Io/Keboola/Apps/V1/AppRunSpec.php
+++ b/libs/k8s-client/src/Model/Io/Keboola/Apps/V1/AppRunSpec.php
@@ -74,4 +74,18 @@ class AppRunSpec extends AbstractModel
      * @var string|null
      */
     public $configVersion = null;
+
+    /**
+     * RuntimeBackendType is the runtime backend type for this run (e.g. "k8sDeployment", "e2bSandbox")
+     *
+     * @var string|null
+     */
+    public $runtimeBackendType = null;
+
+    /**
+     * ImageVersion is the tag/digest extracted from the container image reference
+     *
+     * @var string|null
+     */
+    public $imageVersion = null;
 }


### PR DESCRIPTION
## Release Notes 
https://linear.app/keboola/issue/PAT-1646/extend-apprun

Add `imageVersion` and `runtimeBackendType` fields to AppRun CRD.

Fields implementation: https://github.com/keboola/keboola-operator/pull/154

## Plans for customer communication
None.

## Impact analysis
No negative impact expected. Just new fields added to CRD.

## Change type
Improvement

## Justification
E2B billing support.

## Deployment
Merge & automatic deploy.

## Rollback plan
Revert of this PR.

## Post release support plan
None.