### PR TITLE
fix(api-bundle): add list<string> type annotations to attribute array properties

### DIFF
--- a/libs/api-bundle/src/Attribute/ManageApiTokenAuth.php
+++ b/libs/api-bundle/src/Attribute/ManageApiTokenAuth.php
@@ -10,7 +10,7 @@ use Attribute;
 class ManageApiTokenAuth implements AuthAttributeInterface
 {
     public function __construct(
-        public readonly array $scopes = [],
+        /** @var list<string> */ public readonly array $scopes = [],
         public readonly ?bool $isSuperAdmin = null,
     ) {
     }

--- a/libs/api-bundle/src/Attribute/StorageApiTokenAuth.php
+++ b/libs/api-bundle/src/Attribute/StorageApiTokenAuth.php
@@ -10,7 +10,7 @@ use Attribute;
 class StorageApiTokenAuth implements AuthAttributeInterface
 {
     public function __construct(
-        public readonly array $features = [],
+        /** @var list<string> */ public readonly array $features = [],
     ) {
     }
 }


### PR DESCRIPTION
https://linear.app/keboola/issue/AJDA-2339

## Description
Adds `list<string>` PHPDoc type annotations to the `$scopes` property in `ManageApiTokenAuth` and `$features` property in `StorageApiTokenAuth`. Without these, PHPStan infers the bare `array` type as `array<mixed>`, causing errors in `array_diff` and `implode` calls in the authenticators.

## Release Notes

**Change Type**
Bug fix — resolves PHPStan type errors in api-bundle authenticators.

**Justification**
PHPStan (max level) flagged `array_diff` and `implode` calls in both `ManageApiTokenAuthenticator` and `StorageApiTokenAuthenticator` because the attribute properties lacked explicit string array type annotations.

**Plans for Customer Communication**
No customer communication needed — internal type annotation fix only.

**Impact Analysis**
Low risk. No runtime behaviour changes; purely a static analysis type annotation fix. No breaking changes.

**Deployment Plan**
Standard CI/CD continuous deployment across all stacks.

**Rollback Plan**
Standard git revert if issues detected post-deployment.

**Post-Release Support Plan**
No follow-up actions needed.