### PR TITLE
PAT-1672 (keboola-operator): Sync App CRD (`publicURL`)

### DIFF
--- a/libs/k8s-client/src/Model/Io/Keboola/Apps/V2/AppsProxyIngressSpec.php
+++ b/libs/k8s-client/src/Model/Io/Keboola/Apps/V2/AppsProxyIngressSpec.php
@@ -22,4 +22,13 @@ class AppsProxyIngressSpec extends AbstractModel
      * @var integer
      */
     public $targetPort = null;
+
+    /**
+     * Slug is an optional URL prefix used when building the public app URL.
+     * When set, the URL is https://{slug}-{appId}.{hostnameSuffix}
+     * When empty, the URL is https://{appId}.{hostnameSuffix}
+     *
+     * @var string|null
+     */
+    public $slug = null;
 }

--- a/libs/k8s-client/src/Model/Io/Keboola/Apps/V2/AppsProxyStatus.php
+++ b/libs/k8s-client/src/Model/Io/Keboola/Apps/V2/AppsProxyStatus.php
@@ -26,4 +26,13 @@ class AppsProxyStatus extends AbstractModel
      * @var string|null
      */
     public $upstreamUrl = null;
+
+    /**
+     * PublicUrl is the URL at which the app is exposed publicly via the Apps Proxy.
+     * Computed from spec.features.appsProxyIngress.slug, spec.appId, and the operator's
+     * HostnameSuffix. Empty when AppsProxyIngress is not enabled.
+     *
+     * @var string|null
+     */
+    public $publicUrl = null;
 }


### PR DESCRIPTION
## Release Notes 
https://linear.app/keboola/issue/PAT-1672/pass-public-url-to-app

Sync App CRD from https://github.com/keboola/keboola-operator/pull/173.

## Plans for customer communication
None.

## Impact analysis
No impact, only new optional fields added.

## Change type
New feature.

## Justification
E2B support

## Deployment
Merge & automatic deploy.

## Rollback plan
Revert of this PR.

## Post release support plan
None.