### PR TITLE
fix(service-client): fix editor service internal URL

### DIFF
--- a/libs/service-client/src/Service.php
+++ b/libs/service-client/src/Service.php
@@ -60,7 +60,7 @@ enum Service
             self::BILLING => 'billing-api.default',
             self::BUFFER => 'buffer-api.buffer',
             self::CONNECTION => 'connection-api.connection',
-            self::EDITOR => 'editor-api.editor-service',
+            self::EDITOR => 'editor-service-api.editor-service',
             self::ENCRYPTION => 'encryption-api.default',
             self::IMPORT => 'sapi-importer.default',
             self::NOTIFICATION => 'notification-api.default',

--- a/libs/service-client/tests/ServiceClientTest.php
+++ b/libs/service-client/tests/ServiceClientTest.php
@@ -35,7 +35,7 @@ class ServiceClientTest extends TestCase
     private const INTERNAL_BUFFER_SERVICE = 'http://buffer-api.buffer.svc.cluster.local';
     private const INTERNAL_CONNECTION_SERVICE = 'http://connection-api.connection.svc.cluster.local';
     private const INTERNAL_DATA_SCIENCE_SERVICE = 'http://sandboxes-service-api.default.svc.cluster.local';
-    private const INTERNAL_EDITOR_SERVICE = 'http://editor-api.editor-service.svc.cluster.local';
+    private const INTERNAL_EDITOR_SERVICE = 'http://editor-service-api.editor-service.svc.cluster.local';
     private const INTERNAL_ENCRYPTION_SERVICE = 'http://encryption-api.default.svc.cluster.local';
     private const INTERNAL_IMPORT_SERVICE = 'http://sapi-importer.default.svc.cluster.local';
     private const INTERNAL_NOTIFICATION_SERVICE = 'http://notification-api.default.svc.cluster.local';

--- a/libs/service-client/tests/ServiceTest.php
+++ b/libs/service-client/tests/ServiceTest.php
@@ -59,7 +59,7 @@ class ServiceTest extends TestCase
         yield 'buffer' => [Service::BUFFER, 'buffer-api.buffer']; // <-- custom namespace
         yield 'connection' => [Service::CONNECTION, 'connection-api.connection']; // <-- custom namespace
         yield 'data-science' => [Service::SANDBOXES_SERVICE, 'sandboxes-service-api.default'];
-        yield 'editor' => [Service::EDITOR, 'editor-api.editor-service'];
+        yield 'editor' => [Service::EDITOR, 'editor-service-api.editor-service'];
         yield 'encryption' => [Service::ENCRYPTION, 'encryption-api.default'];
         yield 'import' => [Service::IMPORT, 'sapi-importer.default'];
         yield 'notification' => [Service::NOTIFICATION, 'notification-api.default'];


### PR DESCRIPTION
https://linear.app/keboola/issue/AJDA-2605

## Description
The internal Kubernetes URL for the editor service was wrong. The actual k8s service is named `editor-service-api` in the `editor-service` namespace, but the code referenced `editor-api.editor-service`. https://github.com/keboola/kbc-stacks/blob/main/apps/editor-service/templates/deployment-api.yaml#L4

## Release Notes

**Change Type**
Bug fix.

**Justification**
The wrong internal URL would cause requests to the editor service to fail in any context using `ServiceDnsType::INTERNAL`.

**Plans for Customer Communication**
No customer-facing change.

**Impact Analysis**
Low risk. Only affects internal service-to-service communication targeting the editor service. No breaking changes, no feature flags.

**Deployment Plan**
Standard CI/CD continuous deployment across all stacks.

**Rollback Plan**
Standard git revert if issues detected post-deployment.

**Post-Release Support Plan**
No follow-up actions needed.