### PR TITLE
[AJDA-2302] fix(output-mapping): fix result.json lookup path

### DIFF
--- a/libs/output-mapping/src/TableLoader.php
+++ b/libs/output-mapping/src/TableLoader.php
@@ -170,7 +170,11 @@ class TableLoader
 
         $tableQueue = new LoadTableQueue($this->clientWrapper, $this->logger, $loadTableTasks);
         $tableQueue->start();
-        $tableQueue->loadCustomVariables(Path::join($strategy->getMetadataStorage()->getPath(), 'result.json'));
+        $tableQueue->loadCustomVariables(Path::join(
+            $strategy->getMetadataStorage()->getPath(),
+            dirname(rtrim($configuration->getSourcePathPrefix(), '/')),
+            'result.json',
+        ));
 
         return $tableQueue;
     }


### PR DESCRIPTION
## Problem

`loadCustomVariables` was looking for `result.json` at the metadata storage root (e.g. `/data/result.json`), but the file is placed in the output directory (e.g. `/data/out/result.json`).

The metadata storage path for local staging equals the data dir (`/data`), without the `out/` prefix. The `sourcePathPrefix` (e.g. `out/tables`) points to the tables subdirectory, so `result.json` lives one level up from that.

## Fix

Use `dirname(rtrim($configuration->getSourcePathPrefix(), '/')))` combined with `metadataStorage->getPath()` to correctly resolve the output directory containing `result.json`.

Before:
```php
Path::join($strategy->getMetadataStorage()->getPath(), 'result.json')
// => /data/result.json (wrong)
```

After:
```php
Path::join($strategy->getMetadataStorage()->getPath(), dirname(rtrim($configuration->getSourcePathPrefix(), '/')), 'result.json')
// => /data/out/result.json (correct)
```