### PR TITLE
feat(sandboxes-service-api-client): add type filter and type field to AppsApiClient

### DIFF
--- a/libs/sandboxes-service-api-client/src/Apps/App.php
+++ b/libs/sandboxes-service-api-client/src/Apps/App.php
@@ -61,6 +61,7 @@ class App
     private string $id;
     private string $projectId;
     private string $componentId;
+    private ?string $type = null;
     private ?string $branchId = null;
     private string $configId;
     private string $configVersion;
@@ -83,6 +84,7 @@ class App
         $app->setId((string) $in['id']);
         $app->setProjectId((string) $in['projectId']);
         $app->setComponentId((string) $in['componentId']);
+        $app->setType(isset($in['type']) ? (string) $in['type'] : null);
         $app->setBranchId(isset($in['branchId']) ? $in['branchId'] : null);
         $app->setConfigId((string) $in['configId']);
         $app->setConfigVersion((string) $in['configVersion']);
@@ -102,6 +104,7 @@ class App
             'id' => $this->id,
             'projectId' => $this->projectId,
             'componentId' => $this->componentId,
+            'type' => $this->type,
             'branchId' => $this->branchId,
             'configId' => $this->configId,
             'configVersion' => $this->configVersion,
@@ -144,6 +147,17 @@ class App
     public function setComponentId(string $componentId): self
     {
         $this->componentId = $componentId;
+        return $this;
+    }
+
+    public function getType(): ?string
+    {
+        return $this->type;
+    }
+
+    public function setType(?string $type): self
+    {
+        $this->type = $type;
         return $this;
     }
 

--- a/libs/sandboxes-service-api-client/src/Apps/AppsApiClient.php
+++ b/libs/sandboxes-service-api-client/src/Apps/AppsApiClient.php
@@ -19,11 +19,12 @@ class AppsApiClient
     }
 
     /**
-     * @param int|null $offset
-     * @param int|null $limit
+     * @param int|null      $offset
+     * @param int|null      $limit
+     * @param list<string>  $types Filter by app type (e.g. 'python', 'r', 'streamlit')
      * @return array<App>
      */
-    public function listApps(?int $offset = null, ?int $limit = null): array
+    public function listApps(?int $offset = null, ?int $limit = null, array $types = []): array
     {
         $queryParams = [];
         if ($offset !== null) {
@@ -31,6 +32,9 @@ class AppsApiClient
         }
         if ($limit !== null) {
             $queryParams['limit'] = (string) $limit;
+        }
+        foreach ($types as $type) {
+            $queryParams['type'][] = $type;
         }
 
         $uri = '/apps';

--- a/libs/sandboxes-service-api-client/src/Apps/AppsApiClient.php
+++ b/libs/sandboxes-service-api-client/src/Apps/AppsApiClient.php
@@ -21,11 +21,16 @@ class AppsApiClient
     /**
      * @param int|null      $offset
      * @param int|null      $limit
-     * @param list<string>  $types Filter by app type (e.g. 'python', 'r', 'streamlit')
+     * @param list<string>  $types   Filter by app type (e.g. 'python', 'r', 'streamlit')
+     * @param bool          $listAll When true, lists all apps in the project regardless of token ownership
      * @return array<App>
      */
-    public function listApps(?int $offset = null, ?int $limit = null, array $types = []): array
-    {
+    public function listApps(
+        ?int $offset = null,
+        ?int $limit = null,
+        array $types = [],
+        bool $listAll = false,
+    ): array {
         $queryParams = [];
         if ($offset !== null) {
             $queryParams['offset'] = (string) $offset;
@@ -35,6 +40,9 @@ class AppsApiClient
         }
         foreach ($types as $type) {
             $queryParams['type'][] = $type;
+        }
+        if ($listAll) {
+            $queryParams['listAll'] = '1';
         }
 
         $uri = '/apps';

--- a/libs/sandboxes-service-api-client/src/Apps/AppsApiClient.php
+++ b/libs/sandboxes-service-api-client/src/Apps/AppsApiClient.php
@@ -19,18 +19,25 @@ class AppsApiClient
     }
 
     /**
-     * @param int|null $offset
-     * @param int|null $limit
+     * @param int|null      $offset
+     * @param int|null      $limit
+     * @param list<string>  $types   Filter by app type (e.g. 'python', 'r', 'streamlit')
      * @return array<App>
      */
-    public function listApps(?int $offset = null, ?int $limit = null): array
-    {
+    public function listApps(
+        ?int $offset = null,
+        ?int $limit = null,
+        array $types = [],
+    ): array {
         $queryParams = [];
         if ($offset !== null) {
             $queryParams['offset'] = (string) $offset;
         }
         if ($limit !== null) {
             $queryParams['limit'] = (string) $limit;
+        }
+        foreach ($types as $type) {
+            $queryParams['type'][] = $type;
         }
 
         $uri = '/apps';

--- a/libs/sandboxes-service-api-client/tests/Apps/AppTest.php
+++ b/libs/sandboxes-service-api-client/tests/Apps/AppTest.php
@@ -71,6 +71,7 @@ class AppTest extends TestCase
             'id' => 'app-id',
             'projectId' => 'project-id',
             'componentId' => 'keboola.data-apps',
+            'type' => null,
             'branchId' => 'branch-id',
             'configId' => 'config-id',
             'configVersion' => '5',

--- a/libs/sandboxes-service-api-client/tests/Apps/AppsApiClientTest.php
+++ b/libs/sandboxes-service-api-client/tests/Apps/AppsApiClientTest.php
@@ -326,6 +326,42 @@ class AppsApiClientTest extends TestCase
         );
     }
 
+    public function testListAppsWithListAll(): void
+    {
+        $responseBody = [];
+
+        $requestHandler = self::createRequestHandler($requestsHistory, [
+            new Response(
+                200,
+                ['Content-Type' => 'application/json'],
+                Json::encodeArray($responseBody),
+            ),
+        ]);
+
+        $client = new AppsApiClient(
+            new ApiClientConfiguration(
+                baseUrl: 'https://data-apps.keboola.com',
+                storageToken: 'my-token',
+                userAgent: 'Keboola Sandboxes Service API PHP Client',
+                requestHandler: $requestHandler(...),
+            ),
+        );
+        $result = $client->listApps(listAll: true);
+
+        self::assertEquals([], $result);
+
+        self::assertCount(1, $requestsHistory);
+        self::assertRequestEquals(
+            'GET',
+            'https://data-apps.keboola.com/apps?listAll=1',
+            [
+                'X-StorageApi-Token' => 'my-token',
+            ],
+            '',
+            $requestsHistory[0]['request'],
+        );
+    }
+
     public function testListAppsWithTypes(): void
     {
         $responseBody = [

--- a/libs/sandboxes-service-api-client/tests/Apps/AppsApiClientTest.php
+++ b/libs/sandboxes-service-api-client/tests/Apps/AppsApiClientTest.php
@@ -326,6 +326,58 @@ class AppsApiClientTest extends TestCase
         );
     }
 
+    public function testListAppsWithTypes(): void
+    {
+        $responseBody = [
+            [
+                'id' => 'app-id-1',
+                'projectId' => 'project-id',
+                'componentId' => 'keboola.jupyter-sandbox',
+                'type' => 'python',
+                'branchId' => null,
+                'configId' => 'config-id-1',
+                'configVersion' => '1',
+                'state' => 'running',
+                'desiredState' => 'running',
+                'lastRequestTimestamp' => '2024-02-01T08:00:00+01:00',
+                'url' => null,
+                'autoSuspendAfterSeconds' => 3600,
+                'provisioningStrategy' => 'operator',
+            ],
+        ];
+
+        $requestHandler = self::createRequestHandler($requestsHistory, [
+            new Response(
+                200,
+                ['Content-Type' => 'application/json'],
+                Json::encodeArray($responseBody),
+            ),
+        ]);
+
+        $client = new AppsApiClient(
+            new ApiClientConfiguration(
+                baseUrl: 'https://data-apps.keboola.com',
+                storageToken: 'my-token',
+                userAgent: 'Keboola Sandboxes Service API PHP Client',
+                requestHandler: $requestHandler(...),
+            ),
+        );
+        $result = $client->listApps(types: ['python', 'r']);
+
+        self::assertEquals([App::fromArray($responseBody[0])], $result);
+
+        self::assertCount(1, $requestsHistory);
+        self::assertRequestEquals(
+            'GET',
+            'https://data-apps.keboola.com/apps?type%5B0%5D=python&type%5B1%5D=r',
+            [
+                'X-StorageApi-Token' => 'my-token',
+            ],
+            '',
+            $requestsHistory[0]['request'],
+        );
+    }
+
     public function testCreateApp(): void
     {
         $responseBody = [


### PR DESCRIPTION
https://linear.app/keboola/issue/AJDA-1942

## Description
Adds a `$types` array parameter to `AppsApiClient::listApps()` that sends `type[]=value` query params to the `/apps` endpoint, enabling server-side filtering by app type (e.g. `python`, `r`, `streamlit`). Also maps the nullable `type` field from the `ExistingApp` API response into the `App` model.

## Release Notes

**Change Type**
New feature — adds type filtering support and exposes the `type` field on the `App` model.

**Justification**
The CLI needs to list only Python/R sandbox apps when replacing the legacy sandboxes-api with the new apps API. Without this filter, callers would receive all app types and have to filter client-side.

**Plans for Customer Communication**
No customer communication needed — this is an internal API client library used by other Keboola services.

**Impact Analysis**
Low risk. Additive change only: new optional parameter defaults to `[]` (no filtering), and the new `type` field on `App` is nullable. No breaking changes.

**Deployment Plan**
Standard CI/CD continuous deployment across all stacks.

**Rollback Plan**
Standard git revert if issues detected post-deployment.

**Post-Release Support Plan**
No follow-up actions needed.