### PR TITLE
feat(service-client): remove decommissioned SANDBOXES_API and WAII services

### DIFF
--- a/libs/service-client/src/Service.php
+++ b/libs/service-client/src/Service.php
@@ -25,7 +25,6 @@ enum Service
     case SYNC_ACTIONS;
     case TEMPLATES;
     case VAULT;
-    case WAII;
 
     public function getPublicSubdomain(): string
     {
@@ -47,7 +46,6 @@ enum Service
             self::SYNC_ACTIONS => 'sync-actions',
             self::TEMPLATES => 'templates',
             self::VAULT => 'vault',
-            self::WAII => 'waii',
         };
     }
 
@@ -71,7 +69,6 @@ enum Service
             self::SYNC_ACTIONS => 'runner-sync-api.default',
             self::TEMPLATES => 'templates-api.templates-api',
             self::VAULT => 'vault-api.default',
-            self::WAII => 'waii-svc.waii',
         };
     }
 }

--- a/libs/service-client/src/Service.php
+++ b/libs/service-client/src/Service.php
@@ -20,7 +20,6 @@ enum Service
     case QUERY;
     case QUEUE;
     case QUEUE_INTERNAL_API;
-    case SANDBOXES_API;
     case SANDBOXES_SERVICE;
     case SCHEDULER;
     case SYNC_ACTIONS;
@@ -43,7 +42,6 @@ enum Service
             self::QUERY => 'query',
             self::QUEUE => 'queue',
             self::QUEUE_INTERNAL_API => throw new RuntimeException('Job queue internal API does not have public DNS'),
-            self::SANDBOXES_API => 'sandboxes',
             self::SANDBOXES_SERVICE => 'data-science',
             self::SCHEDULER => 'scheduler',
             self::SYNC_ACTIONS => 'sync-actions',
@@ -68,7 +66,6 @@ enum Service
             self::QUERY => 'query-service-api.query-service',
             self::QUEUE => 'job-queue-api.default',
             self::QUEUE_INTERNAL_API => 'job-queue-internal-api.default',
-            self::SANDBOXES_API => 'sandboxes-api.sandboxes',
             self::SANDBOXES_SERVICE => 'sandboxes-service-api.default',
             self::SCHEDULER => 'scheduler-api.default',
             self::SYNC_ACTIONS => 'runner-sync-api.default',

--- a/libs/service-client/src/ServiceClient.php
+++ b/libs/service-client/src/ServiceClient.php
@@ -172,11 +172,4 @@ class ServiceClient
         return $this->getServiceUrl(Service::VAULT, $dnsType);
     }
 
-    /**
-     * @return non-empty-string
-     */
-    public function getWaiiServiceUrl(?ServiceDnsType $dnsType = null): string
-    {
-        return $this->getServiceUrl(Service::WAII, $dnsType);
-    }
 }

--- a/libs/service-client/src/ServiceClient.php
+++ b/libs/service-client/src/ServiceClient.php
@@ -171,5 +171,4 @@ class ServiceClient
     {
         return $this->getServiceUrl(Service::VAULT, $dnsType);
     }
-
 }

--- a/libs/service-client/src/ServiceClient.php
+++ b/libs/service-client/src/ServiceClient.php
@@ -119,14 +119,6 @@ class ServiceClient
     /**
      * @return non-empty-string
      */
-    public function getSandboxesApiUrl(?ServiceDnsType $dnsType = null): string
-    {
-        return $this->getServiceUrl(Service::SANDBOXES_API, $dnsType);
-    }
-
-    /**
-     * @return non-empty-string
-     */
     public function getSchedulerServiceUrl(?ServiceDnsType $dnsType = null): string
     {
         return $this->getServiceUrl(Service::SCHEDULER, $dnsType);

--- a/libs/service-client/tests/ServiceClientTest.php
+++ b/libs/service-client/tests/ServiceClientTest.php
@@ -26,7 +26,6 @@ class ServiceClientTest extends TestCase
     private const PUBLIC_SYNC_ACTIONS_SERVICE = 'https://sync-actions.north-europe.azure.keboola.com';
     private const PUBLIC_TEMPLATES = 'https://templates.north-europe.azure.keboola.com';
     private const PUBLIC_VAULT = 'https://vault.north-europe.azure.keboola.com';
-    private const PUBLIC_WAII_SERVICE = 'https://waii.north-europe.azure.keboola.com';
     private const PUBLIC_QUERY_SERVICE = 'https://query.north-europe.azure.keboola.com';
 
     private const INTERNAL_AI_SERVICE = 'http://ai-service-api.default.svc.cluster.local';
@@ -46,7 +45,6 @@ class ServiceClientTest extends TestCase
     private const INTERNAL_SYNC_ACTIONS_SERVICE = 'http://runner-sync-api.default.svc.cluster.local';
     private const INTERNAL_TEMPLATES = 'http://templates-api.templates-api.svc.cluster.local';
     private const INTERNAL_VAULT = 'http://vault-api.default.svc.cluster.local';
-    private const INTERNAL_WAII_SERVICE = 'http://waii-svc.waii.svc.cluster.local';
 
     public function testGetExplicitPublicUrlMethods(): void
     {
@@ -69,7 +67,6 @@ class ServiceClientTest extends TestCase
         self::assertSame(self::PUBLIC_SYNC_ACTIONS_SERVICE, $client->getSyncActionsServiceUrl(ServiceDnsType::PUBLIC));
         self::assertSame(self::PUBLIC_TEMPLATES, $client->getTemplatesUrl(ServiceDnsType::PUBLIC));
         self::assertSame(self::PUBLIC_VAULT, $client->getVaultUrl(ServiceDnsType::PUBLIC));
-        self::assertSame(self::PUBLIC_WAII_SERVICE, $client->getWaiiServiceUrl(ServiceDnsType::PUBLIC));
     }
 
     public function testGetDefaultPublicUrlMethods(): void
@@ -92,7 +89,6 @@ class ServiceClientTest extends TestCase
         self::assertSame(self::PUBLIC_SYNC_ACTIONS_SERVICE, $client->getSyncActionsServiceUrl());
         self::assertSame(self::PUBLIC_TEMPLATES, $client->getTemplatesUrl());
         self::assertSame(self::PUBLIC_VAULT, $client->getVaultUrl());
-        self::assertSame(self::PUBLIC_WAII_SERVICE, $client->getWaiiServiceUrl());
     }
 
     public function testGetExplicitPublicUrlOfServiceWithoutPublicDns(): void
@@ -139,7 +135,6 @@ class ServiceClientTest extends TestCase
         self::assertSame(self::INTERNAL_SYNC_ACTIONS_SERVICE, $client->getSyncActionsServiceUrl(ServiceDnsType::INTERNAL));
         self::assertSame(self::INTERNAL_TEMPLATES, $client->getTemplatesUrl(ServiceDnsType::INTERNAL));
         self::assertSame(self::INTERNAL_VAULT, $client->getVaultUrl(ServiceDnsType::INTERNAL));
-        self::assertSame(self::INTERNAL_WAII_SERVICE, $client->getWaiiServiceUrl(ServiceDnsType::INTERNAL));
         // phpcs:enable Generic.Files.LineLength
     }
 
@@ -164,6 +159,5 @@ class ServiceClientTest extends TestCase
         self::assertSame(self::INTERNAL_SYNC_ACTIONS_SERVICE, $client->getSyncActionsServiceUrl());
         self::assertSame(self::INTERNAL_TEMPLATES, $client->getTemplatesUrl());
         self::assertSame(self::INTERNAL_VAULT, $client->getVaultUrl());
-        self::assertSame(self::INTERNAL_WAII_SERVICE, $client->getWaiiServiceUrl());
     }
 }

--- a/libs/service-client/tests/ServiceClientTest.php
+++ b/libs/service-client/tests/ServiceClientTest.php
@@ -22,7 +22,6 @@ class ServiceClientTest extends TestCase
     private const PUBLIC_NOTIFICATION_SERVICE = 'https://notification.north-europe.azure.keboola.com';
     private const PUBLIC_OAUTH = 'https://oauth.north-europe.azure.keboola.com';
     private const PUBLIC_QUEUE = 'https://queue.north-europe.azure.keboola.com';
-    private const PUBLIC_SANDBOXES_SERVICE = 'https://sandboxes.north-europe.azure.keboola.com';
     private const PUBLIC_SCHEDULER_SERVICE = 'https://scheduler.north-europe.azure.keboola.com';
     private const PUBLIC_SYNC_ACTIONS_SERVICE = 'https://sync-actions.north-europe.azure.keboola.com';
     private const PUBLIC_TEMPLATES = 'https://templates.north-europe.azure.keboola.com';
@@ -43,7 +42,6 @@ class ServiceClientTest extends TestCase
     private const INTERNAL_QUERY_SERVICE = 'http://query-service-api.query-service.svc.cluster.local';
     private const INTERNAL_QUEUE = 'http://job-queue-api.default.svc.cluster.local';
     private const INTERNAL_QUEUE_INTERNAL_API = 'http://job-queue-internal-api.default.svc.cluster.local';
-    private const INTERNAL_SANDBOXES_SERVICE = 'http://sandboxes-api.sandboxes.svc.cluster.local';
     private const INTERNAL_SCHEDULER_SERVICE = 'http://scheduler-api.default.svc.cluster.local';
     private const INTERNAL_SYNC_ACTIONS_SERVICE = 'http://runner-sync-api.default.svc.cluster.local';
     private const INTERNAL_TEMPLATES = 'http://templates-api.templates-api.svc.cluster.local';
@@ -67,7 +65,6 @@ class ServiceClientTest extends TestCase
         self::assertSame(self::PUBLIC_OAUTH, $client->getOauthUrl(ServiceDnsType::PUBLIC));
         self::assertSame(self::PUBLIC_QUERY_SERVICE, $client->getQueryServiceUrl(ServiceDnsType::PUBLIC));
         self::assertSame(self::PUBLIC_QUEUE, $client->getQueueUrl(ServiceDnsType::PUBLIC));
-        self::assertSame(self::PUBLIC_SANDBOXES_SERVICE, $client->getSandboxesApiUrl(ServiceDnsType::PUBLIC));
         self::assertSame(self::PUBLIC_SCHEDULER_SERVICE, $client->getSchedulerServiceUrl(ServiceDnsType::PUBLIC));
         self::assertSame(self::PUBLIC_SYNC_ACTIONS_SERVICE, $client->getSyncActionsServiceUrl(ServiceDnsType::PUBLIC));
         self::assertSame(self::PUBLIC_TEMPLATES, $client->getTemplatesUrl(ServiceDnsType::PUBLIC));
@@ -91,7 +88,6 @@ class ServiceClientTest extends TestCase
         self::assertSame(self::PUBLIC_OAUTH, $client->getOauthUrl());
         self::assertSame(self::PUBLIC_QUERY_SERVICE, $client->getQueryServiceUrl());
         self::assertSame(self::PUBLIC_QUEUE, $client->getQueueUrl());
-        self::assertSame(self::PUBLIC_SANDBOXES_SERVICE, $client->getSandboxesApiUrl());
         self::assertSame(self::PUBLIC_SCHEDULER_SERVICE, $client->getSchedulerServiceUrl());
         self::assertSame(self::PUBLIC_SYNC_ACTIONS_SERVICE, $client->getSyncActionsServiceUrl());
         self::assertSame(self::PUBLIC_TEMPLATES, $client->getTemplatesUrl());
@@ -139,7 +135,6 @@ class ServiceClientTest extends TestCase
         self::assertSame(self::INTERNAL_QUERY_SERVICE, $client->getQueryServiceUrl(ServiceDnsType::INTERNAL));
         self::assertSame(self::INTERNAL_QUEUE, $client->getQueueUrl(ServiceDnsType::INTERNAL));
         self::assertSame(self::INTERNAL_QUEUE_INTERNAL_API, $client->getQueueInternalApiUrl(ServiceDnsType::INTERNAL));
-        self::assertSame(self::INTERNAL_SANDBOXES_SERVICE, $client->getSandboxesApiUrl(ServiceDnsType::INTERNAL));
         self::assertSame(self::INTERNAL_SCHEDULER_SERVICE, $client->getSchedulerServiceUrl(ServiceDnsType::INTERNAL));
         self::assertSame(self::INTERNAL_SYNC_ACTIONS_SERVICE, $client->getSyncActionsServiceUrl(ServiceDnsType::INTERNAL));
         self::assertSame(self::INTERNAL_TEMPLATES, $client->getTemplatesUrl(ServiceDnsType::INTERNAL));
@@ -165,7 +160,6 @@ class ServiceClientTest extends TestCase
         self::assertSame(self::INTERNAL_QUERY_SERVICE, $client->getQueryServiceUrl());
         self::assertSame(self::INTERNAL_QUEUE, $client->getQueueUrl());
         self::assertSame(self::INTERNAL_QUEUE_INTERNAL_API, $client->getQueueInternalApiUrl());
-        self::assertSame(self::INTERNAL_SANDBOXES_SERVICE, $client->getSandboxesApiUrl());
         self::assertSame(self::INTERNAL_SCHEDULER_SERVICE, $client->getSchedulerServiceUrl());
         self::assertSame(self::INTERNAL_SYNC_ACTIONS_SERVICE, $client->getSyncActionsServiceUrl());
         self::assertSame(self::INTERNAL_TEMPLATES, $client->getTemplatesUrl());

--- a/libs/service-client/tests/ServiceTest.php
+++ b/libs/service-client/tests/ServiceTest.php
@@ -26,7 +26,6 @@ class ServiceTest extends TestCase
         yield 'queue' => [Service::QUEUE, 'queue'];
         yield 'scheduler' => [Service::SCHEDULER, 'scheduler'];
         yield 'sync-actions' => [Service::SYNC_ACTIONS, 'sync-actions'];
-        yield 'waii' => [Service::WAII, 'waii'];
     }
 
     #[DataProvider('providePublicSubdomains')]
@@ -67,7 +66,6 @@ class ServiceTest extends TestCase
         yield 'queue internal api' => [Service::QUEUE_INTERNAL_API, 'job-queue-internal-api.default'];
         yield 'scheduler' => [Service::SCHEDULER, 'scheduler-api.default'];
         yield 'sync-actions' => [Service::SYNC_ACTIONS, 'runner-sync-api.default'];
-        yield 'waii' => [Service::WAII, 'waii-svc.waii'];
     }
 
     #[DataProvider('provideInternalServiceNames')]

--- a/libs/service-client/tests/ServiceTest.php
+++ b/libs/service-client/tests/ServiceTest.php
@@ -24,7 +24,6 @@ class ServiceTest extends TestCase
         yield 'notification' => [Service::NOTIFICATION, 'notification'];
         yield 'oauth' => [Service::OAUTH, 'oauth'];
         yield 'queue' => [Service::QUEUE, 'queue'];
-        yield 'sandboxes' => [Service::SANDBOXES_API, 'sandboxes'];
         yield 'scheduler' => [Service::SCHEDULER, 'scheduler'];
         yield 'sync-actions' => [Service::SYNC_ACTIONS, 'sync-actions'];
         yield 'waii' => [Service::WAII, 'waii'];
@@ -66,7 +65,6 @@ class ServiceTest extends TestCase
         yield 'oauth' => [Service::OAUTH, 'oauth-api.default'];
         yield 'queue' => [Service::QUEUE, 'job-queue-api.default'];
         yield 'queue internal api' => [Service::QUEUE_INTERNAL_API, 'job-queue-internal-api.default'];
-        yield 'sandboxes' => [Service::SANDBOXES_API, 'sandboxes-api.sandboxes']; // <-- custom namespace
         yield 'scheduler' => [Service::SCHEDULER, 'scheduler-api.default'];
         yield 'sync-actions' => [Service::SYNC_ACTIONS, 'runner-sync-api.default'];
         yield 'waii' => [Service::WAII, 'waii-svc.waii'];


### PR DESCRIPTION
  Body:
  https://linear.app/keboola/issue/AJDA-2683

  ## Description
  Removes the `SANDBOXES_API` and `WAII` service enum cases, their corresponding helper methods (`getSandboxesApiUrl()`,
   `getWaiiServiceUrl()`), and all related tests, as both services have been decommissioned.

  ## Release Notes

  **Change Type**
  Internal improvement — removal of decommissioned service entries.

  **Justification**
  The Sandboxes API and WAII service have been decommissioned and their `Service` enum cases and URL helper methods are
  no longer needed.

  **Plans for Customer Communication**
  No customer communication needed — this is an internal library change.

  **Impact Analysis**
  Low risk. Any callers still using the removed methods or enum cases will get a compile-time error, making the breakage
   explicit. No feature flags or breaking changes beyond the removed symbols.

  **Deployment Plan**
  Standard CI/CD continuous deployment across all stacks.

  **Rollback Plan**
  Standard git revert if issues detected post-deployment.

  **Post-Release Support Plan**
  No follow-up actions needed.

  The commit has been pushed successfully. Only the PR description update needs to be done manually.