### PR TITLE
PAT-1772 (k8s-client) Add Mode and Dev fields to App spec

### DIFF
--- a/libs/k8s-client/src/Model/Io/Keboola/Apps/V1/AppRunSpec.php
+++ b/libs/k8s-client/src/Model/Io/Keboola/Apps/V1/AppRunSpec.php
@@ -88,4 +88,12 @@ class AppRunSpec extends AbstractModel
      * @var string|null
      */
     public $imageVersion = null;
+
+    /**
+     * DevMode records whether this run was started in dev mode. Mirrors the
+     * parent App's spec.devMode.enabled at AppRun creation time. Default false.
+     *
+     * @var bool|null
+     */
+    public $devMode = null;
 }

--- a/libs/k8s-client/src/Model/Io/Keboola/Apps/V2/AppDevModeSpec.php
+++ b/libs/k8s-client/src/Model/Io/Keboola/Apps/V2/AppDevModeSpec.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Keboola\K8sClient\Model\Io\Keboola\Apps\V2;
+
+use KubernetesRuntime\AbstractModel;
+
+/**
+ * AppDevModeSpec configures dev-mode behaviour for the app (AppSpec.devMode).
+ */
+class AppDevModeSpec extends AbstractModel
+{
+    /**
+     * Enabled toggles dev mode. When true, the runtime loads the dev
+     * supervisord profile and the in-pod git-watcher runs. Default false.
+     *
+     * @var bool|null
+     */
+    public $enabled = null;
+
+    /**
+     * GitPollInterval is how often the in-pod git-watcher fetches and resets
+     * to origin/<branch>. ISO-8601 duration string (e.g. "1s", "30s", "5m").
+     * Default 1s, min 1s, max 5m (enforced at admission via CRD CEL).
+     *
+     * @var string|null
+     */
+    public $gitPollInterval = null;
+
+    /**
+     * AutoRunSetupOnDepChange controls whether the in-pod git-watcher runs
+     * setup-dev.sh and restarts the app program when a tracked dependency
+     * file changes during a poll cycle. Default true.
+     *
+     * @var bool|null
+     */
+    public $autoRunSetupOnDepChange = null;
+}

--- a/libs/k8s-client/src/Model/Io/Keboola/Apps/V2/AppSpec.php
+++ b/libs/k8s-client/src/Model/Io/Keboola/Apps/V2/AppSpec.php
@@ -83,4 +83,12 @@ class AppSpec extends AbstractModel
      * @var AppFeatures|null
      */
     public $features = null;
+
+    /**
+     * DevMode configures dev-mode behaviour (spec.devMode).
+     * When null or `enabled: false`, the app runs in prod mode.
+     *
+     * @var AppDevModeSpec|null
+     */
+    public $devMode = null;
 }

--- a/libs/k8s-client/tests/Model/V1/AppRunModelTest.php
+++ b/libs/k8s-client/tests/Model/V1/AppRunModelTest.php
@@ -42,6 +42,7 @@ class AppRunModelTest extends TestCase
                 'startupLogs' => "foo\nbar\n",
                 'runtimeSize' => 'small',
                 'configVersion' => '1',
+                'devMode' => true,
             ],
             'status' => [
                 'syncedAt' => '2025-01-15T13:05:00Z',
@@ -77,6 +78,7 @@ class AppRunModelTest extends TestCase
         self::assertSame("foo\nbar\n", $appRun->spec->startupLogs);
         self::assertSame('small', $appRun->spec->runtimeSize);
         self::assertSame('1', $appRun->spec->configVersion);
+        self::assertTrue($appRun->spec->devMode);
 
         // PodRef
         self::assertNotNull($appRun->spec->podRef);
@@ -118,5 +120,6 @@ class AppRunModelTest extends TestCase
         self::assertSame('Finished', $serialized['spec']['state']);
         self::assertSame('small', $serialized['spec']['runtimeSize']);
         self::assertSame('1', $serialized['spec']['configVersion']);
+        self::assertTrue($serialized['spec']['devMode']);
     }
 }

--- a/libs/k8s-client/tests/Model/V2/AppModelTest.php
+++ b/libs/k8s-client/tests/Model/V2/AppModelTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Keboola\K8sClient\Tests\Model\V2;
 
 use Keboola\K8sClient\Model\Io\Keboola\Apps\V2\App;
+use Keboola\K8sClient\Model\Io\Keboola\Apps\V2\AppDevModeSpec;
 use Keboola\K8sClient\Model\Io\Keboola\Apps\V2\AppFeatures;
 use Keboola\K8sClient\Model\Io\Keboola\Apps\V2\AppRuntime;
 use Keboola\K8sClient\Model\Io\Keboola\Apps\V2\AppSpec;
@@ -62,6 +63,11 @@ class AppModelTest extends TestCase
                     'backend' => [
                         'type' => 'e2bSandbox',
                     ],
+                ],
+                'devMode' => [
+                    'enabled' => true,
+                    'gitPollInterval' => '5s',
+                    'autoRunSetupOnDepChange' => false,
                 ],
                 'features' => [
                     'storageToken' => [
@@ -250,6 +256,13 @@ class AppModelTest extends TestCase
         self::assertNotNull($app->spec->runtime->backend);
         self::assertInstanceOf(Backend::class, $app->spec->runtime->backend);
         self::assertSame('e2bSandbox', $app->spec->runtime->backend->type);
+
+        // DevMode
+        self::assertNotNull($app->spec->devMode);
+        self::assertInstanceOf(AppDevModeSpec::class, $app->spec->devMode);
+        self::assertTrue($app->spec->devMode->enabled);
+        self::assertSame('5s', $app->spec->devMode->gitPollInterval);
+        self::assertFalse($app->spec->devMode->autoRunSetupOnDepChange);
 
         // Features
         self::assertNotNull($app->spec->features);
@@ -474,6 +487,12 @@ class AppModelTest extends TestCase
         self::assertSame('small', $serialized['spec']['runtime']['size']);
         self::assertSame('e2bSandbox', $serialized['spec']['runtime']['backend']['type']);
         self::assertSame('small', $serialized['spec']['runtimeSize']);
+
+        // Verify devMode survives round-trip
+        self::assertArrayHasKey('devMode', $serialized['spec']);
+        self::assertTrue($serialized['spec']['devMode']['enabled']);
+        self::assertSame('5s', $serialized['spec']['devMode']['gitPollInterval']);
+        self::assertFalse($serialized['spec']['devMode']['autoRunSetupOnDepChange']);
 
         // Verify containerSpec is present and podSpec is not
         self::assertArrayHasKey('containerSpec', $serialized['spec']);


### PR DESCRIPTION
## Release Notes

https://linear.app/keboola/issue/PAT-1772/mvp-dev-mode-for-data-apps

* Related `keboola-operator` update: https://github.com/keboola/keboola-operator/pull/204
* Related `sandboxes-service` update: https://github.com/keboola/sandboxes-service/pull/577
* Related `data-app-python-js` update: https://github.com/keboola/data-app-python-js/pull/21
* Related `kbc-stacks` branch: https://github.com/keboola/kbc-stacks/tree/pepa/PAT-1771_devMode

Adds `devMode` to the typed App v2 and AppRun v1 specs so consumers — primarily `sandboxes-service` — can serialise and deserialise the new dev-mode CRD fields through the typed client without raw-HTTP reads or `extraSpecFields` workarounds. The CRD itself is extended in `keboola-operator` (PR #204); this PR is the matching `keboola/k8s-client` typed-model update.

`App.spec.devMode` is a new optional `AppDevModeSpec` carrying `enabled` (bool), `gitPollInterval` (ISO-8601 duration string, e.g. `"1s"`, `"5m"`), and `autoRunSetupOnDepChange` (bool). `AppRun.spec.devMode` is a new bool that mirrors the parent App's `devMode.enabled` at run-create time. The `AppModelTest` and `AppRunModelTest` round-trip suites are extended to cover hydration and serialisation of both fields.

## Plans for customer communication
None.

## Impact analysis
No end-user impact. New optional fields on the typed model; existing callers that don't set or read them are unaffected.

## Change type
New feature

## Justification
Unblocks `sandboxes-service` plumbing for the data-app dev-mode MVP (PAT-1772).

## Deployment
Merge & automatic deploy.

## Rollback plan
Revert of this PR.

## Post release support plan
None.