### PR TITLE
PAT-1754 Register git-service-api-client in tag publish pipeline

### DIFF
--- a/azure-pipelines.tags.yml
+++ b/azure-pipelines.tags.yml
@@ -26,6 +26,10 @@ resources:
       type: github
       endpoint: keboola
       name: keboola/doctrine-retry-bundle
+    - repository: git-service-php-api-client
+      type: github
+      endpoint: keboola
+      name: keboola/git-service-php-api-client
     - repository: input-mapping
       type: github
       endpoint: keboola
@@ -131,6 +135,14 @@ jobs:
       targetRepo: doctrine-retry-bundle
       libraryPath: libs/doctrine-retry-bundle
       tagPrefix: doctrine-retry-bundle/
+
+  - template: azure-pipelines/jobs/split-library.yml
+    parameters:
+      condition: startsWith(variables['Build.SourceBranch'], 'refs/tags/git-service-api-client/')
+      sourceRepo: platform-libraries
+      targetRepo: git-service-php-api-client
+      libraryPath: libs/git-service-api-client
+      tagPrefix: git-service-api-client/
 
   - template: azure-pipelines/jobs/split-library.yml
     parameters:

--- a/libs/doctrine-retry-bundle/src/DependencyInjection/Compiler/ConfigureDbalRetryProxyPass.php
+++ b/libs/doctrine-retry-bundle/src/DependencyInjection/Compiler/ConfigureDbalRetryProxyPass.php
@@ -66,7 +66,9 @@ class ConfigureDbalRetryProxyPass implements CompilerPassInterface
 
     private function getConfiguredMiddlewares(Definition $configurationDefinition): array
     {
-        foreach (array_reverse($configurationDefinition->getMethodCalls()) as [$method, $arguments]) {
+        foreach (array_reverse($configurationDefinition->getMethodCalls()) as $call) {
+            assert(is_array($call));
+            [$method, $arguments] = $call;
             if ($method !== self::SET_MIDDLEWARES_METHOD) {
                 continue;
             }


### PR DESCRIPTION
## Release Notes
https://linear.app/keboola/issue/PAT-1754

Follow-up to #493. The library was missed in `azure-pipelines.tags.yml`, so tag pushes matching `git-service-api-client/*` weren't splitting into `keboola/git-service-php-api-client`. Adds the repository entry and the `split-library` job.

## Plans for customer communication
None.

## Impact analysis
No end-user impact. Pipeline config only.

## Change type
Fix

## Justification
Without this, tagging a release of `git-service-api-client` does not publish to the standalone repo.

## Deployment
Merge & automatic deploy.

## Rollback plan
Revert of this PR.

## Post release support plan
None.