### PR TITLE
fix(staging-provider): add redshift backend support to workspace credentials parsing

### DIFF
--- a/libs/staging-provider/src/Workspace/WorkspaceWithCredentials.php
+++ b/libs/staging-provider/src/Workspace/WorkspaceWithCredentials.php
@@ -97,6 +97,13 @@ class WorkspaceWithCredentials implements WorkspaceWithCredentialsInterface
                 'privateKey' => $data['privateKey'] ?? null,
                 'account' => self::parseSnowflakeAccount($data['host']),
             ],
+            'redshift' => [
+                'host' => $data['host'],
+                'database' => $data['database'],
+                'schema' => $data['schema'],
+                'user' => $data['user'],
+                'password' => $data['password'] ?? null,
+            ],
             default => throw new StagingProviderException(sprintf('Unsupported backend "%s"', $backend)),
         };
     }

--- a/libs/staging-provider/tests/Workspace/WorkspaceWithCredentialsTest.php
+++ b/libs/staging-provider/tests/Workspace/WorkspaceWithCredentialsTest.php
@@ -85,6 +85,32 @@ class WorkspaceWithCredentialsTest extends TestCase
             ],
         ];
 
+        yield 'redshift' => [
+            'data' => [
+                'id' => '654',
+                'backendSize' => 'small',
+                'connection' => [
+                    'backend' => 'redshift',
+                    'host' => 'some-host',
+                    'database' => 'some-database',
+                    'schema' => 'some-schema',
+                    'user' => 'some-user',
+                    'password' => 'some-secret',
+                ],
+            ],
+            'expectedId' => '654',
+            'expectedBackendType' => 'redshift',
+            'expectedBackendSize' => 'small',
+            'expectedLoginType' => WorkspaceLoginType::DEFAULT,
+            'expectedCredentials' => [
+                'host' => 'some-host',
+                'database' => 'some-database',
+                'schema' => 'some-schema',
+                'user' => 'some-user',
+                'password' => 'some-secret',
+            ],
+        ];
+
         yield 'snowflake-sso' => [
             'data' => [
                 'id' => '987',


### PR DESCRIPTION
## Summary
Add `redshift` as a supported backend in `WorkspaceWithCredentials::parseCredentialsData()`.

The docker-bundle CI tests use an old Keboola project with a Redshift backend. When workspace data is returned from the Storage API with `backend: 'redshift'`, the `parseCredentialsData()` method throws `Unsupported backend "redshift"` because the match statement only handles `bigquery` and `snowflake`.

Redshift credentials follow a standard database connection pattern (host, database, schema, user, password).

## Review & Testing Checklist for Human
- [ ] Verify redshift credential fields match what the Storage API returns for Redshift workspaces (host, database, schema, user, password)
- [ ] Confirm docker-bundle CI passes against the Redshift project after bumping the staging-provider dependency

### Notes
- phpcs and phpstan pass cleanly
- Unit tests for `WorkspaceWithCredentialsTest` pass (11 tests, 39 assertions)

## Release Notes
**Justification, description**

Adds redshift backend support to workspace credentials parsing to fix `Unsupported backend "redshift"` error when running against projects with Redshift storage backend.

**Plans for Customer Communication**

N/A

**Impact Analysis**

Low risk — adds a new case to a match statement without changing existing behavior for snowflake or bigquery.

**Deployment Plan**

N/A

**Rollback Plan**

N/A

**Post-Release Support Plan**

N/A

Link to Devin session: https://app.devin.ai/sessions/07e732a58e2b49dca150debc16f9aa7f
Requested by: @romantmb