### PR TITLE
PAT-1767 Add managed-git fields to App CRD model

### DIFF
--- a/libs/k8s-client/src/Model/Io/Keboola/Apps/V2/AppSpec.php
+++ b/libs/k8s-client/src/Model/Io/Keboola/Apps/V2/AppSpec.php
@@ -91,4 +91,13 @@ class AppSpec extends AbstractModel
      * @var AppDevModeSpec|null
      */
     public $devMode = null;
+
+    /**
+     * ManagedGitRepo, when set, signals the operator to mint per-AppRun ephemeral
+     * SSH deploy keys and overlay the private key into the rendered config.json
+     * Secret. Presence alone is the activation switch.
+     *
+     * @var ManagedGitRepoSpec|null
+     */
+    public $managedGitRepo = null;
 }

--- a/libs/k8s-client/src/Model/Io/Keboola/Apps/V2/AppSpec.php
+++ b/libs/k8s-client/src/Model/Io/Keboola/Apps/V2/AppSpec.php
@@ -93,9 +93,9 @@ class AppSpec extends AbstractModel
     public $devMode = null;
 
     /**
-     * ManagedGitRepo, when set, signals the operator to mint per-AppRun ephemeral
-     * SSH deploy keys and overlay the private key into the rendered config.json
-     * Secret. Presence alone is the activation switch.
+     * ManagedGitRepo, when set, signals that the operator should mint per-AppRun
+     * ephemeral git credentials (HTTP token or SSH key) and overlay them into the
+     * rendered config.json Secret. Requires mountConfig to be set.
      *
      * @var ManagedGitRepoSpec|null
      */

--- a/libs/k8s-client/src/Model/Io/Keboola/Apps/V2/AppStatus.php
+++ b/libs/k8s-client/src/Model/Io/Keboola/Apps/V2/AppStatus.php
@@ -80,6 +80,15 @@ class AppStatus extends AbstractModel
     public $e2bSandbox = null;
 
     /**
+     * ManagedGitCredential holds the active credential identifier for the current
+     * AppRun, populated when the operator successfully registers an ephemeral credential
+     * with git-service and cleared when revoked.
+     *
+     * @var ManagedGitCredentialStatus|null
+     */
+    public $managedGitCredential = null;
+
+    /**
      * Conditions represents the latest available observations of the app's current state
      *
      * @var Condition[]|null

--- a/libs/k8s-client/src/Model/Io/Keboola/Apps/V2/ManagedGitCredentialStatus.php
+++ b/libs/k8s-client/src/Model/Io/Keboola/Apps/V2/ManagedGitCredentialStatus.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Keboola\K8sClient\Model\Io\Keboola\Apps\V2;
+
+use KubernetesRuntime\AbstractModel;
+
+/**
+ * ManagedGitCredentialStatus holds the active credential identifier for the current
+ * AppRun, populated when the operator successfully registers an ephemeral credential
+ * with git-service and cleared when revoked.
+ */
+class ManagedGitCredentialStatus extends AbstractModel
+{
+    /**
+     * Id is the credential ID (Forgejo user ID) returned by the git-service credentials API.
+     *
+     * @var string|null
+     */
+    public $id = null;
+
+    /**
+     * RepoId is the git-service repository ID for which this credential was minted.
+     * Persisted here so the credential can be revoked even if managedGitRepo is removed from spec.
+     *
+     * @var string|null
+     */
+    public $repoId = null;
+}

--- a/libs/k8s-client/src/Model/Io/Keboola/Apps/V2/ManagedGitRepoSpec.php
+++ b/libs/k8s-client/src/Model/Io/Keboola/Apps/V2/ManagedGitRepoSpec.php
@@ -7,18 +7,23 @@ namespace Keboola\K8sClient\Model\Io\Keboola\Apps\V2;
 use KubernetesRuntime\AbstractModel;
 
 /**
- * ManagedGitRepoSpec describes a managed Git repository whose deploy key is minted per AppRun.
+ * ManagedGitRepoSpec describes a managed Git repository whose credential is minted per AppRun.
  */
 class ManagedGitRepoSpec extends AbstractModel
 {
     /**
      * RepoId is the git-service identifier for the managed repository.
-     * When set, the operator generates an ephemeral SSH keypair per AppRun,
-     * registers the public key with git-service, overlays the plaintext private
-     * key into the rendered config.json under parameters.dataApp.git['#sshKey'],
-     * and revokes the key when the AppRun reaches a terminal state.
      *
      * @var string|null
      */
     public $repoId = null;
+
+    /**
+     * CredentialType selects the credential format minted for each AppRun.
+     * "http_token" overlays username + #password into config.json.
+     * "ssh_key" generates an Ed25519 keypair and overlays #sshKey (PEM) into config.json.
+     *
+     * @var string|null
+     */
+    public $credentialType = null;
 }

--- a/libs/k8s-client/src/Model/Io/Keboola/Apps/V2/ManagedGitRepoSpec.php
+++ b/libs/k8s-client/src/Model/Io/Keboola/Apps/V2/ManagedGitRepoSpec.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Keboola\K8sClient\Model\Io\Keboola\Apps\V2;
+
+use KubernetesRuntime\AbstractModel;
+
+/**
+ * ManagedGitRepoSpec describes a managed Git repository whose deploy key is minted per AppRun.
+ */
+class ManagedGitRepoSpec extends AbstractModel
+{
+    /**
+     * RepoId is the git-service identifier for the managed repository.
+     * When set, the operator generates an ephemeral SSH keypair per AppRun,
+     * registers the public key with git-service, overlays the plaintext private
+     * key into the rendered config.json under parameters.dataApp.git['#sshKey'],
+     * and revokes the key when the AppRun reaches a terminal state.
+     *
+     * @var string|null
+     */
+    public $repoId = null;
+}

--- a/libs/k8s-client/tests/Model/V2/AppModelTest.php
+++ b/libs/k8s-client/tests/Model/V2/AppModelTest.php
@@ -20,6 +20,7 @@ use Keboola\K8sClient\Model\Io\Keboola\Apps\V2\DataDirMountSpec;
 use Keboola\K8sClient\Model\Io\Keboola\Apps\V2\DataDirSpec;
 use Keboola\K8sClient\Model\Io\Keboola\Apps\V2\DataLoaderSpec;
 use Keboola\K8sClient\Model\Io\Keboola\Apps\V2\E2bSandboxStatus;
+use Keboola\K8sClient\Model\Io\Keboola\Apps\V2\ManagedGitCredentialStatus;
 use Keboola\K8sClient\Model\Io\Keboola\Apps\V2\ManagedGitRepoSpec;
 use Keboola\K8sClient\Model\Io\Keboola\Apps\V2\MountConfigField;
 use Keboola\K8sClient\Model\Io\Keboola\Apps\V2\MountPathSpec;
@@ -72,6 +73,7 @@ class AppModelTest extends TestCase
                 ],
                 'managedGitRepo' => [
                     'repoId' => 'repo-abc-123',
+                    'credentialType' => 'ssh_key',
                 ],
                 'features' => [
                     'storageToken' => [
@@ -218,6 +220,10 @@ class AppModelTest extends TestCase
                     'syncedFileHashes' => ['app.py' => 'abc123'],
                     'templateBuildID' => 'build-xyz',
                 ],
+                'managedGitCredential' => [
+                    'id' => 'cred-xyz-789',
+                    'repoId' => 'repo-abc-123',
+                ],
                 'conditions' => [
                     [
                         'type' => 'Ready',
@@ -272,6 +278,7 @@ class AppModelTest extends TestCase
         self::assertNotNull($app->spec->managedGitRepo);
         self::assertInstanceOf(ManagedGitRepoSpec::class, $app->spec->managedGitRepo);
         self::assertSame('repo-abc-123', $app->spec->managedGitRepo->repoId);
+        self::assertSame('ssh_key', $app->spec->managedGitRepo->credentialType);
 
         // Features
         self::assertNotNull($app->spec->features);
@@ -319,6 +326,12 @@ class AppModelTest extends TestCase
         self::assertSame(0, $app->status->e2bSandbox->startupProbeFailures);
         self::assertSame(['app.py' => 'abc123'], $app->status->e2bSandbox->syncedFileHashes);
         self::assertSame('build-xyz', $app->status->e2bSandbox->templateBuildID);
+
+        // Status - managedGitCredential
+        self::assertNotNull($app->status->managedGitCredential);
+        self::assertInstanceOf(ManagedGitCredentialStatus::class, $app->status->managedGitCredential);
+        self::assertSame('cred-xyz-789', $app->status->managedGitCredential->id);
+        self::assertSame('repo-abc-123', $app->status->managedGitCredential->repoId);
 
         // Status - conditions
         self::assertNotNull($app->status->conditions);
@@ -506,6 +519,7 @@ class AppModelTest extends TestCase
         // Verify managedGitRepo survives round-trip
         self::assertArrayHasKey('managedGitRepo', $serialized['spec']);
         self::assertSame('repo-abc-123', $serialized['spec']['managedGitRepo']['repoId']);
+        self::assertSame('ssh_key', $serialized['spec']['managedGitRepo']['credentialType']);
 
         // Verify containerSpec is present and podSpec is not
         self::assertArrayHasKey('containerSpec', $serialized['spec']);
@@ -525,6 +539,11 @@ class AppModelTest extends TestCase
         self::assertSame('Running', $serialized['status']['currentState']);
         self::assertArrayHasKey('appsProxy', $serialized['status']);
         self::assertArrayHasKey('e2bSandbox', $serialized['status']);
+
+        // Verify managedGitCredential survives round-trip
+        self::assertArrayHasKey('managedGitCredential', $serialized['status']);
+        self::assertSame('cred-xyz-789', $serialized['status']['managedGitCredential']['id']);
+        self::assertSame('repo-abc-123', $serialized['status']['managedGitCredential']['repoId']);
     }
 
     public function testCreateAppWithNestedObjects(): void

--- a/libs/k8s-client/tests/Model/V2/AppModelTest.php
+++ b/libs/k8s-client/tests/Model/V2/AppModelTest.php
@@ -20,6 +20,7 @@ use Keboola\K8sClient\Model\Io\Keboola\Apps\V2\DataDirMountSpec;
 use Keboola\K8sClient\Model\Io\Keboola\Apps\V2\DataDirSpec;
 use Keboola\K8sClient\Model\Io\Keboola\Apps\V2\DataLoaderSpec;
 use Keboola\K8sClient\Model\Io\Keboola\Apps\V2\E2bSandboxStatus;
+use Keboola\K8sClient\Model\Io\Keboola\Apps\V2\ManagedGitRepoSpec;
 use Keboola\K8sClient\Model\Io\Keboola\Apps\V2\MountConfigField;
 use Keboola\K8sClient\Model\Io\Keboola\Apps\V2\MountPathSpec;
 use Keboola\K8sClient\Model\Io\Keboola\Apps\V2\SetEnvSpec;
@@ -68,6 +69,9 @@ class AppModelTest extends TestCase
                     'enabled' => true,
                     'gitPollInterval' => '5s',
                     'autoRunSetupOnDepChange' => false,
+                ],
+                'managedGitRepo' => [
+                    'repoId' => 'repo-abc-123',
                 ],
                 'features' => [
                     'storageToken' => [
@@ -263,6 +267,11 @@ class AppModelTest extends TestCase
         self::assertTrue($app->spec->devMode->enabled);
         self::assertSame('5s', $app->spec->devMode->gitPollInterval);
         self::assertFalse($app->spec->devMode->autoRunSetupOnDepChange);
+
+        // ManagedGitRepo
+        self::assertNotNull($app->spec->managedGitRepo);
+        self::assertInstanceOf(ManagedGitRepoSpec::class, $app->spec->managedGitRepo);
+        self::assertSame('repo-abc-123', $app->spec->managedGitRepo->repoId);
 
         // Features
         self::assertNotNull($app->spec->features);
@@ -493,6 +502,10 @@ class AppModelTest extends TestCase
         self::assertTrue($serialized['spec']['devMode']['enabled']);
         self::assertSame('5s', $serialized['spec']['devMode']['gitPollInterval']);
         self::assertFalse($serialized['spec']['devMode']['autoRunSetupOnDepChange']);
+
+        // Verify managedGitRepo survives round-trip
+        self::assertArrayHasKey('managedGitRepo', $serialized['spec']);
+        self::assertSame('repo-abc-123', $serialized['spec']['managedGitRepo']['repoId']);
 
         // Verify containerSpec is present and podSpec is not
         self::assertArrayHasKey('containerSpec', $serialized['spec']);


### PR DESCRIPTION
## Release Notes
https://linear.app/keboola/issue/PAT-1767/

Mirrors the managed-git fields of the `apps.keboola.com/v2` App CRD in the typed `k8s-client` model so consumers (sandboxes-service) can populate them via the typed model rather than untyped arrays (which `AbstractModel::exchangeArray` silently drops). Since this branch was first opened the CRD shape on keboola-operator `main` evolved — the spec field gained a **required** `credentialType` (`http_token`|`ssh_key`) and the per-AppRun "deploy key" was generalised to a "credential" — so this update brings the model back in line with the current CRD, on both the spec and status sides.

Key changes:
* `ManagedGitRepoSpec` on `AppSpec.managedGitRepo`: `repoId` + new required `credentialType` (`http_token`|`ssh_key`).
* New `ManagedGitCredentialStatus` (`id` + `repoId`) mirrored on `AppStatus.managedGitCredential`.
* `AppModelTest` extended with hydration + serialization round-trip coverage for both the new spec and status fields.

## Plans for customer communication
None.

## Impact analysis
No runtime behavior change. Optional new fields; backward compatible for all existing consumers.

## Change type
New feature

## Justification
Building block for per-AppRun ephemeral git credential support (PAT-1767).

## Deployment
Merge & automatic deploy.

## Rollback plan
Revert of this PR.

## Post release support plan
None.
