### PR TITLE
PAT-1786 [Apps DEV mode] Admin removed event

### DIFF
--- a/libs/messenger-bundle/src/ConnectionEvent/ApplicationEvent/Admin/AdminRemovedFromProjectEvent.php
+++ b/libs/messenger-bundle/src/ConnectionEvent/ApplicationEvent/Admin/AdminRemovedFromProjectEvent.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Keboola\MessengerBundle\ConnectionEvent\ApplicationEvent\Admin;
+
+use InvalidArgumentException;
+use Keboola\MessengerBundle\ConnectionEvent\EventInterface;
+
+class AdminRemovedFromProjectEvent implements EventInterface
+{
+    public const NAME = 'admin.adminRemovedFromProject';
+
+    public function __construct(
+        public readonly string $uuid,
+        public readonly int $projectId,
+        public readonly int $adminId,
+
+        public readonly string|int $objectId,
+        public readonly string $objectType,
+        public readonly string $objectName,
+
+        public readonly array $params,
+    ) {
+    }
+
+    public static function fromArray(array $data): self
+    {
+        if ($data['name'] !== self::NAME) {
+            throw new InvalidArgumentException(sprintf(
+                '%s expects event name "%s" but is "%s"',
+                static::class,
+                self::NAME,
+                $data['name'],
+            ));
+        }
+
+        return new self(
+            $data['uuid'],
+            $data['idProject'],
+            $data['idAdmin'],
+            $data['objectId'],
+            $data['objectType'],
+            $data['objectName'],
+            $data['params'],
+        );
+    }
+
+    public function toArray(): array
+    {
+        return [
+            'name' => self::NAME,
+            'uuid' => $this->uuid,
+            'idProject' => $this->projectId,
+            'idAdmin' => $this->adminId,
+            'objectId' => $this->objectId,
+            'objectType' => $this->objectType,
+            'objectName' => $this->objectName,
+            'params' => $this->params,
+        ];
+    }
+
+    public function getId(): string
+    {
+        return $this->uuid;
+    }
+
+    public function getEventName(): string
+    {
+        return self::NAME;
+    }
+}

--- a/libs/messenger-bundle/src/ConnectionEvent/ApplicationEvent/ApplicationEventFactory.php
+++ b/libs/messenger-bundle/src/ConnectionEvent/ApplicationEvent/ApplicationEventFactory.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Keboola\MessengerBundle\ConnectionEvent\ApplicationEvent;
 
+use Keboola\MessengerBundle\ConnectionEvent\ApplicationEvent\Admin\AdminRemovedFromProjectEvent;
 use Keboola\MessengerBundle\ConnectionEvent\ApplicationEvent\Storage\ComponentConfigurationDeletedEvent;
 use Keboola\MessengerBundle\ConnectionEvent\ApplicationEvent\Storage\ComponentConfigurationPurgedEvent;
 use Keboola\MessengerBundle\ConnectionEvent\ApplicationEvent\Storage\DevBranchCreatedEvent;
@@ -17,6 +18,7 @@ class ApplicationEventFactory implements EventFactoryInterface
 {
     /** @var array<string, class-string<EventInterface>> */
     private const EVENTS = [
+        AdminRemovedFromProjectEvent::NAME => AdminRemovedFromProjectEvent::class,
         ComponentConfigurationDeletedEvent::NAME => ComponentConfigurationDeletedEvent::class,
         ComponentConfigurationPurgedEvent::NAME => ComponentConfigurationPurgedEvent::class,
         DevBranchCreatedEvent::NAME => DevBranchCreatedEvent::class,

--- a/libs/messenger-bundle/tests/ConnectionEvent/ApplicationEvent/Admin/AdminRemovedFromProjectEventTest.php
+++ b/libs/messenger-bundle/tests/ConnectionEvent/ApplicationEvent/Admin/AdminRemovedFromProjectEventTest.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Keboola\MessengerBundle\Tests\ConnectionEvent\ApplicationEvent\Admin;
+
+use InvalidArgumentException;
+use Keboola\MessengerBundle\ConnectionEvent\ApplicationEvent\Admin\AdminRemovedFromProjectEvent;
+use Keboola\MessengerBundle\ConnectionEvent\ApplicationEvent\ApplicationEventFactory;
+use PHPUnit\Framework\TestCase;
+
+class AdminRemovedFromProjectEventTest extends TestCase
+{
+    private const EVENT_MESSAGE_DATA = [
+        'data' => [
+            'name' => 'admin.adminRemovedFromProject',
+            'uuid' => '01958fcb-6cf6-778b-ac16-fb7cd4f9ab3d',
+            'idProject' => 456,
+            'idAdmin' => 123,
+            'objectId' => 789,
+            'objectType' => 'admin',
+            'objectName' => 'removed@example.com',
+            'params' => ['project' => 'My Project'],
+        ],
+    ];
+
+    public function testDecodeFromEvent(): void
+    {
+        $eventFactory = new ApplicationEventFactory();
+        $event = $eventFactory->createEventFromArray(self::EVENT_MESSAGE_DATA);
+
+        self::assertInstanceOf(AdminRemovedFromProjectEvent::class, $event);
+        self::assertSame('01958fcb-6cf6-778b-ac16-fb7cd4f9ab3d', $event->uuid);
+    }
+
+    public function testCreateFromArray(): void
+    {
+        $event = AdminRemovedFromProjectEvent::fromArray(self::EVENT_MESSAGE_DATA['data']);
+
+        self::assertSame('01958fcb-6cf6-778b-ac16-fb7cd4f9ab3d', $event->uuid);
+        self::assertSame(456, $event->projectId);
+        self::assertSame(123, $event->adminId);
+        self::assertSame(789, $event->objectId);
+        self::assertSame('admin', $event->objectType);
+        self::assertSame('removed@example.com', $event->objectName);
+        self::assertSame(['project' => 'My Project'], $event->params);
+    }
+
+    public function testCreateFromArrayWithInvalidName(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(
+            'Keboola\MessengerBundle\ConnectionEvent\ApplicationEvent\Admin\AdminRemovedFromProjectEvent expects' .
+            ' event name "admin.adminRemovedFromProject" but is "foo"',
+        );
+
+        AdminRemovedFromProjectEvent::fromArray([
+            'name' => 'foo',
+        ]);
+    }
+
+    public function testToArray(): void
+    {
+        $event = new AdminRemovedFromProjectEvent(
+            uuid: '01958fcb-6cf6-778b-ac16-fb7cd4f9ab3d',
+            projectId: 456,
+            adminId: 123,
+            objectId: 789,
+            objectType: 'admin',
+            objectName: 'removed@example.com',
+            params: ['project' => 'My Project'],
+        );
+
+        self::assertSame([
+            'name' => 'admin.adminRemovedFromProject',
+            'uuid' => '01958fcb-6cf6-778b-ac16-fb7cd4f9ab3d',
+            'idProject' => 456,
+            'idAdmin' => 123,
+            'objectId' => 789,
+            'objectType' => 'admin',
+            'objectName' => 'removed@example.com',
+            'params' => ['project' => 'My Project'],
+        ], $event->toArray());
+    }
+
+    public function testGetters(): void
+    {
+        $event = AdminRemovedFromProjectEvent::fromArray(self::EVENT_MESSAGE_DATA['data']);
+
+        self::assertSame('01958fcb-6cf6-778b-ac16-fb7cd4f9ab3d', $event->getId());
+        self::assertSame('admin.adminRemovedFromProject', $event->getEventName());
+    }
+}


### PR DESCRIPTION
## Release Notes
https://linear.app/keboola/issue/PAT-1786

Adds a typed application event class `AdminRemovedFromProjectEvent` for the connection `admin.adminRemovedFromProject` event.

## Plans for customer communication
None.

## Impact analysis
No end-user impact. Existing consumers that didn't reference the event name continue to work; consumers that handle `admin.adminRemovedFromProject` will now receive a typed `AdminRemovedFromProjectEvent` instead of `GenericApplicationEvent`.

## Change type
New feature

## Justification
Enable typed consumption of the admin-removed-from-project event in downstream services.

## Deployment
Merge & automatic deploy.

## Rollback plan
Revert of this PR.

## Post release support plan
None.