### PR TITLE
fix(php-test-utils): AJDA-2733 use STRING type in StorageTablesFixture for cross-backend compatibility

### DIFF
--- a/libs/php-test-utils/src/Fixtures/Dynamic/StorageTablesFixture.php
+++ b/libs/php-test-utils/src/Fixtures/Dynamic/StorageTablesFixture.php
@@ -30,15 +30,15 @@ class StorageTablesFixture implements FixtureInterface
                 ],
                 [
                     'name' => 'name',
-                    'definition' => ['type' => 'NVARCHAR'],
+                    'definition' => ['type' => 'STRING'],
                 ],
                 [
                     'name' => 'email',
-                    'definition' => ['type' => 'NVARCHAR'],
+                    'definition' => ['type' => 'STRING'],
                 ],
                 [
                     'name' => 'address',
-                    'definition' => ['type' => 'NVARCHAR', 'nullable' => true],
+                    'definition' => ['type' => 'STRING', 'nullable' => true],
                 ],
             ],
         ]);


### PR DESCRIPTION
## Link to issue
https://linear.app/keboola/issue/AJDA-2733

## Description
The shared `StorageTablesFixture` hardcoded `NVARCHAR` for the `name`, `email`, and `address` columns, which is a Snowflake-only type. Although `php-test-utils` swaps the SAPI token by backend, the fixture body did not, so consumers running on BigQuery hit a type-not-supported error when creating the table.

Switched the three text columns to `STRING`, which Snowflake accepts as a `VARCHAR` synonym and BigQuery accepts natively. `id` stays `INT` (also accepted by both). No other behavioral change.

## Justification
See linked Linear issue.

## Plans for Customer Communication
None.

## Impact Analysis
Consumers of `StorageTablesFixture` will get `STRING` (= `VARCHAR`) columns on Snowflake instead of `NVARCHAR`. For the data this fixture writes (ASCII customer records) the storage representation is equivalent. No feature flag.

## Deployment Plan
Release a tagged version.

## Rollback Plan
Revert this PR.

## Post-Release Support Plan
None.