### PR TITLE
PAT-1792 Add CanManageAppRepoCredentials check to permission-checker

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -132,7 +132,7 @@ services:
       - BIGQUERY_STORAGE_API_URL
 
   dev-permission-checker:
-    <<: *dev81
+    <<: *dev82
     image: keboola/permission-checker
     working_dir: /code/libs/permission-checker
 

--- a/libs/permission-checker/composer.json
+++ b/libs/permission-checker/composer.json
@@ -26,13 +26,13 @@
         }
     },
     "require": {
-        "php": "^8.1",
+        "php": "^8.2",
         "keboola/common-exceptions": "^1.2"
     },
     "require-dev": {
         "infection/infection": "^0.27.0",
         "keboola/coding-standard": "^15.0",
-        "keboola/storage-api-php-client-branch-wrapper": "^5.1",
+        "keboola/storage-api-php-client-branch-wrapper": "^6.0",
         "phpstan/phpstan": "^1.9",
         "phpstan/phpstan-phpunit": "^1.1",
         "phpunit/phpunit": "^9.5",

--- a/libs/permission-checker/src/Check/SandboxesService/CanManageAppRepoCredentials.php
+++ b/libs/permission-checker/src/Check/SandboxesService/CanManageAppRepoCredentials.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Keboola\PermissionChecker\Check\SandboxesService;
+
+use Keboola\PermissionChecker\Exception\PermissionDeniedException;
+use Keboola\PermissionChecker\PermissionCheckInterface;
+use Keboola\PermissionChecker\StorageApiToken;
+
+class CanManageAppRepoCredentials implements PermissionCheckInterface
+{
+    public function __construct(
+        private readonly int $appId,
+        private readonly string $appProjectId,
+    ) {
+    }
+
+    public function checkPermissions(StorageApiToken $token): void
+    {
+        if (!$token->isAdminToken()) {
+            throw new PermissionDeniedException(sprintf(
+                'Token is not authorized to manage credentials of app \'%s\', admin context is required',
+                $this->appId,
+            ));
+        }
+
+        if (!$token->isForProject($this->appProjectId)) {
+            throw new PermissionDeniedException(sprintf(
+                'Token is not authorized to manage credentials of app \'%s\', app is from different project',
+                $this->appId,
+            ));
+        }
+    }
+}

--- a/libs/permission-checker/src/StorageApiToken.php
+++ b/libs/permission-checker/src/StorageApiToken.php
@@ -14,6 +14,7 @@ class StorageApiToken
         private readonly ?array $allowedComponents = null,
         private readonly array $permissions = [],
         private readonly ?string $projectId = null,
+        private readonly bool $isAdminToken = false,
     ) {
     }
 
@@ -25,6 +26,7 @@ class StorageApiToken
             $token->getAllowedComponents(),
             $token->getPermissions(),
             $token->getProjectId(),
+            $token->isAdminToken(),
         );
     }
 
@@ -82,5 +84,10 @@ class StorageApiToken
     public function isForProject(string $projectId): bool
     {
         return $this->projectId === $projectId;
+    }
+
+    public function isAdminToken(): bool
+    {
+        return $this->isAdminToken;
     }
 }

--- a/libs/permission-checker/tests/Check/SandboxesService/CanManageAppRepoCredentialsTest.php
+++ b/libs/permission-checker/tests/Check/SandboxesService/CanManageAppRepoCredentialsTest.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Keboola\PermissionChecker\Tests\Check\SandboxesService;
+
+use Keboola\PermissionChecker\Check\SandboxesService\CanManageAppRepoCredentials;
+use Keboola\PermissionChecker\Exception\PermissionDeniedException;
+use Keboola\PermissionChecker\StorageApiToken;
+use PHPUnit\Framework\TestCase;
+
+class CanManageAppRepoCredentialsTest extends TestCase
+{
+    public function testAllowManageRepoCredentials(): void
+    {
+        $this->expectNotToPerformAssertions();
+
+        $appId = 1;
+        $projectId = '123';
+
+        $checker = new CanManageAppRepoCredentials($appId, $projectId);
+        $checker->checkPermissions(new StorageApiToken(
+            projectId: $projectId,
+            isAdminToken: true,
+        ));
+    }
+
+    public function testDenyNonAdminToken(): void
+    {
+        $appId = 1;
+        $projectId = '123';
+
+        $this->expectExceptionObject(new PermissionDeniedException(
+            'Token is not authorized to manage credentials of app \'1\', admin context is required',
+        ));
+
+        $checker = new CanManageAppRepoCredentials($appId, $projectId);
+        $checker->checkPermissions(new StorageApiToken(
+            projectId: $projectId,
+            isAdminToken: false,
+        ));
+    }
+
+    public function testDenyDifferentProject(): void
+    {
+        $appId = 1;
+        $appProjectId = '456';
+        $tokenProjectId = '123';
+
+        $this->expectExceptionObject(new PermissionDeniedException(
+            'Token is not authorized to manage credentials of app \'1\', app is from different project',
+        ));
+
+        $checker = new CanManageAppRepoCredentials($appId, $appProjectId);
+        $checker->checkPermissions(new StorageApiToken(
+            projectId: $tokenProjectId,
+            isAdminToken: true,
+        ));
+    }
+}

--- a/libs/permission-checker/tests/StorageApiTokenTest.php
+++ b/libs/permission-checker/tests/StorageApiTokenTest.php
@@ -106,6 +106,11 @@ class StorageApiTokenTest extends TestCase
             {
                 return '123';
             }
+
+            public function isAdminToken(): bool
+            {
+                return true;
+            }
         });
 
         self::assertTrue($token->hasFeature(Feature::QUEUE_V2));
@@ -118,6 +123,7 @@ class StorageApiTokenTest extends TestCase
         self::assertSame([TokenPermission::CAN_CREATE_JOBS], $token->getPermissions());
         self::assertTrue($token->isForProject('123'));
         self::assertFalse($token->isForProject('456'));
+        self::assertTrue($token->isAdminToken());
     }
 
     public function testIsForProject(): void
@@ -127,5 +133,17 @@ class StorageApiTokenTest extends TestCase
         );
         self::assertTrue($token->isForProject('123'));
         self::assertFalse($token->isForProject('456'));
+    }
+
+    public function testIsAdminToken(): void
+    {
+        $adminToken = new StorageApiToken(isAdminToken: true);
+        self::assertTrue($adminToken->isAdminToken());
+
+        $nonAdminToken = new StorageApiToken(isAdminToken: false);
+        self::assertFalse($nonAdminToken->isAdminToken());
+
+        $defaultToken = new StorageApiToken();
+        self::assertFalse($defaultToken->isAdminToken());
     }
 }


### PR DESCRIPTION
## Release Notes
https://linear.app/keboola/issue/PAT-1792/move-isadmin-check-to-permission-checker

Adds a new `CanManageAppRepoCredentials` permission check under the SandboxesService namespace. The check requires both an admin-context storage API token and a matching project — letting callers replace the current inline `isAdminToken()` guard + separate `CanManageApp` invocation with a single permission check.

To make `isAdminToken()` reachable through the permission-checker abstraction, the lib's `StorageApiToken` now carries an `isAdminToken` flag and `fromTokenInterface()` propagates it. The dev dependency `keboola/storage-api-php-client-branch-wrapper` is bumped to `^6.0` (first line exposing `isAdminToken()`); since 6.x requires PHP 8.2, the lib's own PHP requirement is bumped to `^8.2` and the docker-compose service moves from the 8.1 to 8.2 image.

* Sandboxes-service consumer: https://github.com/keboola/sandboxes-service (PR coming)

## Plans for customer communication
None.

## Impact analysis
No end-user impact. The new check is additive; existing checks are untouched. The PHP bump only affects consumers still on 8.1 — `api-bundle` (the only in-repo consumer) is already on 8.1+ and runs on 8.2+ in practice.

## Change type
New feature

## Justification
Centralizes the admin-token check inside the permission-checker so sandboxes-service controllers can drop their inline guards.

## Deployment
Merge & automatic deploy.

## Rollback plan
Revert of this PR.

## Post release support plan
None.