### PR TITLE
PAT-1786 Require `httpsUrl` on Repository model

### DIFF
--- a/libs/git-service-api-client/src/Model/Repository.php
+++ b/libs/git-service-api-client/src/Model/Repository.php
@@ -14,6 +14,7 @@ final readonly class Repository implements ResponseModelInterface
         public string $createdAt,
         public string $defaultBranch,
         public string $sshUrl,
+        public string $httpsUrl,
     ) {
     }
 
@@ -23,16 +24,19 @@ final readonly class Repository implements ResponseModelInterface
         Assert::keyExists($data, 'createdAt');
         Assert::keyExists($data, 'defaultBranch');
         Assert::keyExists($data, 'sshUrl');
+        Assert::keyExists($data, 'httpsUrl');
         Assert::string($data['name']);
         Assert::string($data['createdAt']);
         Assert::string($data['defaultBranch']);
         Assert::string($data['sshUrl']);
+        Assert::string($data['httpsUrl']);
 
         return new self(
             $data['name'],
             $data['createdAt'],
             $data['defaultBranch'],
             $data['sshUrl'],
+            $data['httpsUrl'],
         );
     }
 }

--- a/libs/git-service-api-client/tests/ApiClientTest.php
+++ b/libs/git-service-api-client/tests/ApiClientTest.php
@@ -95,6 +95,7 @@ class ApiClientTest extends TestCase
             'createdAt' => 'now',
             'defaultBranch' => 'main',
             'sshUrl' => 'ssh://git/app-1',
+            'httpsUrl' => 'https://git/app-1.git',
         ]))]);
         $stack = HandlerStack::create($mock);
 
@@ -115,8 +116,8 @@ class ApiClientTest extends TestCase
     public function testMapsResponseIntoListOfModels(): void
     {
         $mock = new MockHandler([new Response(200, [], (string) json_encode([
-            ['name' => 'a1', 'createdAt' => 't', 'defaultBranch' => 'main', 'sshUrl' => 's1'],
-            ['name' => 'a2', 'createdAt' => 't', 'defaultBranch' => 'main', 'sshUrl' => 's2'],
+            ['name' => 'a1', 'createdAt' => 't', 'defaultBranch' => 'main', 'sshUrl' => 's1', 'httpsUrl' => 'h1'],
+            ['name' => 'a2', 'createdAt' => 't', 'defaultBranch' => 'main', 'sshUrl' => 's2', 'httpsUrl' => 'h2'],
         ]))]);
         $stack = HandlerStack::create($mock);
 

--- a/libs/git-service-api-client/tests/GitServiceApiClientTest.php
+++ b/libs/git-service-api-client/tests/GitServiceApiClientTest.php
@@ -33,12 +33,14 @@ class GitServiceApiClientTest extends TestCase
             'createdAt' => '2026-04-28T10:00:00Z',
             'defaultBranch' => 'main',
             'sshUrl' => 'ssh://git/app-1',
+            'httpsUrl' => 'https://git/app-1.git',
         ]))]);
         $client = $this->buildClient($mock);
 
         $repo = $client->createRepository('app-1');
 
         self::assertSame('app-1', $repo->name);
+        self::assertSame('https://git/app-1.git', $repo->httpsUrl);
         $request = $mock->getLastRequest();
         self::assertNotNull($request);
         self::assertSame('POST', $request->getMethod());
@@ -53,12 +55,14 @@ class GitServiceApiClientTest extends TestCase
             'createdAt' => 't',
             'defaultBranch' => 'main',
             'sshUrl' => 's',
+            'httpsUrl' => 'https://git/app-1.git',
         ]))]);
         $client = $this->buildClient($mock);
 
         $repo = $client->getRepository('app-1');
 
         self::assertSame('app-1', $repo->name);
+        self::assertSame('https://git/app-1.git', $repo->httpsUrl);
         $request = $mock->getLastRequest();
         self::assertNotNull($request);
         self::assertSame('GET', $request->getMethod());
@@ -68,7 +72,7 @@ class GitServiceApiClientTest extends TestCase
     public function testGetRepositoryEncodesName(): void
     {
         $mock = new MockHandler([new Response(200, [], (string) json_encode([
-            'name' => 'app/1', 'createdAt' => 't', 'defaultBranch' => 'main', 'sshUrl' => 's',
+            'name' => 'app/1', 'createdAt' => 't', 'defaultBranch' => 'main', 'sshUrl' => 's', 'httpsUrl' => 'h',
         ]))]);
         $client = $this->buildClient($mock);
 

--- a/libs/git-service-api-client/tests/Model/RepositoryTest.php
+++ b/libs/git-service-api-client/tests/Model/RepositoryTest.php
@@ -17,12 +17,38 @@ class RepositoryTest extends TestCase
             'createdAt' => '2026-04-28T10:00:00Z',
             'defaultBranch' => 'main',
             'sshUrl' => 'ssh://git@git-service/app-123.git',
+            'httpsUrl' => 'https://git-service/app-123.git',
         ]);
 
         self::assertSame('app-123', $repo->name);
         self::assertSame('2026-04-28T10:00:00Z', $repo->createdAt);
         self::assertSame('main', $repo->defaultBranch);
         self::assertSame('ssh://git@git-service/app-123.git', $repo->sshUrl);
+        self::assertSame('https://git-service/app-123.git', $repo->httpsUrl);
+    }
+
+    public function testFromResponseDataMissingHttpsUrl(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        Repository::fromResponseData([
+            'name' => 'app-123',
+            'createdAt' => '2026-04-28T10:00:00Z',
+            'defaultBranch' => 'main',
+            'sshUrl' => 'ssh://git@git-service/app-123.git',
+            // httpsUrl missing
+        ]);
+    }
+
+    public function testFromResponseDataHttpsUrlWrongType(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        Repository::fromResponseData([
+            'name' => 'app-123',
+            'createdAt' => '2026-04-28T10:00:00Z',
+            'defaultBranch' => 'main',
+            'sshUrl' => 'ssh://git@git-service/app-123.git',
+            'httpsUrl' => 123,
+        ]);
     }
 
     public function testFromResponseDataMissingField(): void


### PR DESCRIPTION
## Release Notes
https://linear.app/keboola/issue/PAT-1786

The git-service `Repository` payload now always carries `httpsUrl` alongside `sshUrl`. This change makes `httpsUrl` a required field on the client-side `Repository` model and asserts its presence in `fromResponseData`.

Tests covering both `Repository::fromResponseData` and the `GitServiceApiClient` request/response paths are updated to include `httpsUrl` in their fixtures.

## Plans for customer communication
None.

## Impact analysis
Breaking change for callers that construct `Repository` directly or build response fixtures without `httpsUrl`. Consumed by `sandboxes-service` only; the coordinated update lives in https://github.com/keboola/sandboxes-service/pull/<follow-up>.

## Change type
Improvement

## Justification
Surface the new `httpsUrl` field returned by `git-service` so downstream services can publish it on their APIs.

## Deployment
Merge & automatic deploy.

## Rollback plan
Revert of this PR.

## Post release support plan
None.