### PR TITLE
PAT-1795 Drop default loginType from staging-provider workspace options

### DIFF
--- a/libs/staging-provider/src/Workspace/WorkspaceProvider.php
+++ b/libs/staging-provider/src/Workspace/WorkspaceProvider.php
@@ -11,7 +11,6 @@ use Keboola\StagingProvider\Staging\StagingType;
 use Keboola\StagingProvider\Workspace\Configuration\NewWorkspaceConfig;
 use Keboola\StorageApi\ClientException;
 use Keboola\StorageApi\Components;
-use Keboola\StorageApi\WorkspaceLoginType;
 use Keboola\StorageApi\Workspaces;
 use Keboola\StorageApiBranch\StorageApiToken;
 
@@ -145,13 +144,6 @@ class WorkspaceProvider
      */
     private function prepareNewWorkspaceOptions(StagingType $stagingType, NewWorkspaceConfig $config): array
     {
-        $defaultLoginType = match ($stagingType) {
-// TODO enable once key-pair auth is default for Snowflake
-//            AbstractStrategyFactory::WORKSPACE_SNOWFLAKE => WorkspaceLoginType::SNOWFLAKE_SERVICE_KEYPAIR,
-            default => WorkspaceLoginType::DEFAULT,
-        };
-        $loginType = $config->loginType ?? $defaultLoginType;
-
         $options = [
             'backend' => match ($stagingType) {
                 StagingType::WorkspaceBigquery => 'bigquery',
@@ -162,7 +154,6 @@ class WorkspaceProvider
                 )),
             },
             'networkPolicy' => $config->networkPolicy->value,
-            'loginType' => $loginType,
         ];
 
         if ($config->size !== null) {
@@ -173,8 +164,12 @@ class WorkspaceProvider
             $options['readOnlyStorageAccess'] = $config->useReadonlyRole;
         }
 
+        if ($config->loginType !== null) {
+            $options['loginType'] = $config->loginType;
+        }
+
         $privateKey = null;
-        if ($loginType->isKeyPairLogin()) {
+        if ($config->loginType !== null && $config->loginType->isKeyPairLogin()) {
             $keypair = $this->snowflakeKeypairGenerator->generateKeyPair();
             $options['publicKey'] = $keypair->publicKey;
             $privateKey = $keypair->privateKey;

--- a/libs/staging-provider/tests/Workspace/WorkspaceProviderFunctionalTest.php
+++ b/libs/staging-provider/tests/Workspace/WorkspaceProviderFunctionalTest.php
@@ -113,35 +113,6 @@ class WorkspaceProviderFunctionalTest extends TestCase
         return $configuration;
     }
 
-    public function testCreateNewWorkspaceWithoutConfigId(): void
-    {
-        $config = new NewWorkspaceConfig(
-            stagingType: StagingType::WorkspaceSnowflake,
-            componentId: 'keboola.staging-provider-functional-test',
-            configId: null,
-            size: 'small',
-            useReadonlyRole: null,
-            networkPolicy: NetworkPolicy::USER,
-            loginType: WorkspaceLoginType::DEFAULT,
-        );
-
-        $workspace = $this->workspaceProvider->createNewWorkspace(
-            $this->storageApiToken,
-            $config,
-        );
-        $this->createdWorkspaceIds[] = $workspace->getWorkspaceId();
-
-        self::assertNotEmpty($workspace->getWorkspaceId());
-        self::assertSame('snowflake', $workspace->getBackendType());
-        self::assertSame('small', $workspace->getBackendSize());
-        self::assertNotEmpty($workspace->getCredentials()['host'] ?? null);
-        self::assertNotEmpty($workspace->getCredentials()['user'] ?? null);
-        self::assertNotEmpty($workspace->getCredentials()['password'] ?? null);
-        self::assertNotEmpty($workspace->getCredentials()['database'] ?? null);
-        self::assertNotEmpty($workspace->getCredentials()['schema'] ?? null);
-        self::assertNotEmpty($workspace->getCredentials()['warehouse'] ?? null);
-    }
-
     public function testCreateNewWorkspaceWithConfigId(): void
     {
         $configuration = $this->createConfiguration();
@@ -153,7 +124,7 @@ class WorkspaceProviderFunctionalTest extends TestCase
             'small',
             null,
             NetworkPolicy::USER,
-            WorkspaceLoginType::DEFAULT,
+            WorkspaceLoginType::SNOWFLAKE_SERVICE_KEYPAIR,
         );
 
         $workspace = $this->workspaceProvider->createNewWorkspace(
@@ -165,9 +136,11 @@ class WorkspaceProviderFunctionalTest extends TestCase
         self::assertNotEmpty($workspace->getWorkspaceId());
         self::assertSame('snowflake', $workspace->getBackendType());
         self::assertSame('small', $workspace->getBackendSize());
+        self::assertSame(WorkspaceLoginType::SNOWFLAKE_SERVICE_KEYPAIR, $workspace->getLoginType());
         self::assertNotEmpty($workspace->getCredentials()['host'] ?? null);
         self::assertNotEmpty($workspace->getCredentials()['user'] ?? null);
-        self::assertNotEmpty($workspace->getCredentials()['password'] ?? null);
+        self::assertNotEmpty($workspace->getCredentials()['privateKey'] ?? null);
+        self::assertStringStartsWith('-----BEGIN PRIVATE KEY-----', $workspace->getCredentials()['privateKey']);
         self::assertNotEmpty($workspace->getCredentials()['database'] ?? null);
         self::assertNotEmpty($workspace->getCredentials()['schema'] ?? null);
         self::assertNotEmpty($workspace->getCredentials()['warehouse'] ?? null);
@@ -275,28 +248,6 @@ class WorkspaceProviderFunctionalTest extends TestCase
         // validate private key is present
         self::assertArrayHasKey('privateKey', $workspaceCredentials);
         self::assertStringStartsWith('-----BEGIN PRIVATE KEY-----', $workspaceCredentials['privateKey'] ?? '');
-
-        // validate other connection parameters are present
-        self::assertArrayHasKey('host', $workspaceCredentials);
-        self::assertArrayHasKey('account', $workspaceCredentials);
-    }
-
-    public function testResetWorkspaceCredentialsWithPassword(): void
-    {
-        $workspaceData = $this->createWorkspace([
-            'backend' => 'snowflake',
-            'networkPolicy' => 'system',
-            'loginType' => WorkspaceLoginType::DEFAULT,
-        ]);
-        $workspaceId = (string) $workspaceData['id'];
-        $originalPassword = $workspaceData['connection']['password'];
-
-        $workspace = $this->workspaceProvider->resetWorkspaceCredentials($workspaceId);
-        $workspaceCredentials = $workspace->getCredentials();
-
-        // validate password is present
-        self::assertArrayHasKey('password', $workspaceCredentials);
-        self::assertNotSame($originalPassword, $workspaceCredentials['password']);
 
         // validate other connection parameters are present
         self::assertArrayHasKey('host', $workspaceCredentials);

--- a/libs/staging-provider/tests/Workspace/WorkspaceProviderFunctionalTest.php
+++ b/libs/staging-provider/tests/Workspace/WorkspaceProviderFunctionalTest.php
@@ -122,7 +122,7 @@ class WorkspaceProviderFunctionalTest extends TestCase
             size: 'small',
             useReadonlyRole: null,
             networkPolicy: NetworkPolicy::USER,
-            loginType: null,
+            loginType: WorkspaceLoginType::DEFAULT,
         );
 
         $workspace = $this->workspaceProvider->createNewWorkspace(
@@ -153,7 +153,7 @@ class WorkspaceProviderFunctionalTest extends TestCase
             'small',
             null,
             NetworkPolicy::USER,
-            null,
+            WorkspaceLoginType::DEFAULT,
         );
 
         $workspace = $this->workspaceProvider->createNewWorkspace(
@@ -286,6 +286,7 @@ class WorkspaceProviderFunctionalTest extends TestCase
         $workspaceData = $this->createWorkspace([
             'backend' => 'snowflake',
             'networkPolicy' => 'system',
+            'loginType' => WorkspaceLoginType::DEFAULT,
         ]);
         $workspaceId = (string) $workspaceData['id'];
         $originalPassword = $workspaceData['connection']['password'];

--- a/libs/staging-provider/tests/Workspace/WorkspaceProviderTest.php
+++ b/libs/staging-provider/tests/Workspace/WorkspaceProviderTest.php
@@ -39,9 +39,8 @@ class WorkspaceProviderTest extends TestCase
                 'test-config',
                 [
                     'backend' => 'snowflake',
-                    'backendSize' => $backendSize,
                     'networkPolicy' => 'user',
-                    'loginType' => WorkspaceLoginType::DEFAULT,
+                    'backendSize' => $backendSize,
                 ],
                 true,
             )
@@ -128,10 +127,9 @@ class WorkspaceProviderTest extends TestCase
             ->with(
                 [
                     'backend' => 'snowflake',
+                    'networkPolicy' => 'system',
                     'backendSize' => $backendSize,
                     'readOnlyStorageAccess' => true,
-                    'networkPolicy' => 'system',
-                    'loginType' => WorkspaceLoginType::DEFAULT,
                 ],
                 true,
             )


### PR DESCRIPTION
## Release Notes
https://linear.app/keboola/issue/PAT-1795/switch-job-snowflake-workspace-to-always-use-logintype-snowflake

Stops `WorkspaceProvider::prepareNewWorkspaceOptions()` from injecting `loginType: default` when the caller passes `null`. The `loginType` key is now only present in the Storage API workspace-create options when an explicit value is supplied. This prepares the API for the follow-up `job-queue-job-configuration` change that will start passing `snowflake-service-keypair` unconditionally for Snowflake staging.

`WorkspaceProvider` becomes the canonical place that decides what to send for `loginType`: nothing if the caller didn't ask, otherwise exactly what was asked. Connection treats absence of the key as `default`, so the behavior remains identical for current callers.

## Plans for customer communication
None.

## Impact analysis
No end-user impact. The previous behavior (passing `loginType: default`) and the new behavior (omitting the key) are equivalent on the Storage API side — `default` is what Connection assumes when the key is absent.

## Change type
Refactoring

## Justification
Prepares `staging-provider` API for PAT-1795: switching Snowflake job workspaces to keypair auth unconditionally.

## Deployment
Merge & automatic deploy.

## Rollback plan
Revert of this PR.

## Post release support plan
None.