### PR TITLE
PAT-1791 git-service-api-client: Kubernetes SA / JWT auth strategies

### DIFF
--- a/libs/git-service-api-client/README.md
+++ b/libs/git-service-api-client/README.md
@@ -1,9 +1,42 @@
 # Git Service API Client
 
 ## Installation
+
 ```bash
 composer require keboola/git-service-api-client
 ```
+
+## Usage
+
+```php
+use Keboola\GitServiceApiClient\ApiClientConfiguration;
+use Keboola\GitServiceApiClient\Auth\KeboolaServiceAccountAuth;
+use Keboola\GitServiceApiClient\Auth\ManageApiTokenAuth;
+use Keboola\GitServiceApiClient\GitServiceApiClient;
+
+// Default: projected Kubernetes ServiceAccount token from
+// /var/run/secrets/connection.keboola.com/serviceaccount/token, re-read on
+// every request so kubelet-rotated tokens are picked up automatically.
+$client = new GitServiceApiClient('https://git-service.example.com');
+
+// Manage API token (legacy)
+$client = new GitServiceApiClient(
+    'https://git-service.example.com',
+    new ApiClientConfiguration(auth: new ManageApiTokenAuth($manageApiToken)),
+);
+
+// SA token from a non-default mount path
+$client = new GitServiceApiClient(
+    'https://git-service.example.com',
+    new ApiClientConfiguration(
+        auth: new KeboolaServiceAccountAuth('/var/run/secrets/tokens/connection-token'),
+    ),
+);
+```
+
+`KeboolaServiceAccountAuth` sends the bearer token in
+`X-Kubernetes-Authorization`; `ManageApiTokenAuth` sends the legacy
+`X-KBC-ManageApiToken` header.
 
 ## License
 

--- a/libs/git-service-api-client/src/ApiClient.php
+++ b/libs/git-service-api-client/src/ApiClient.php
@@ -14,7 +14,6 @@ use JsonException;
 use Keboola\GitServiceApiClient\Exception\ClientException;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
-use SensitiveParameter;
 use Throwable;
 
 class ApiClient
@@ -25,21 +24,30 @@ class ApiClient
 
     /**
      * @param non-empty-string $baseUrl
-     * @param non-empty-string $token
+     *
+     * Authentication is taken from {@see ApiClientConfiguration::$auth}, which
+     * defaults to a {@see Auth\KeboolaServiceAccountAuth} reading the
+     * projected SA token mounted by the kbc-stacks chart.
      */
     public function __construct(
         string $baseUrl,
-        #[SensitiveParameter] string $token,
         ?ApiClientConfiguration $configuration = null,
     ) {
         $configuration ??= new ApiClientConfiguration();
+        $auth = $configuration->auth;
 
         $stack = $configuration->requestHandler instanceof HandlerStack
             ? $configuration->requestHandler
             : HandlerStack::create($configuration->requestHandler);
+        // Resolve headers per request so file-backed auth (e.g. the projected
+        // Kubernetes SA token) can pick up rotated tokens on every call.
         $stack->push(Middleware::mapRequest(
-            fn (RequestInterface $request): RequestInterface
-                => $request->withHeader('X-KBC-ManageApiToken', $token),
+            function (RequestInterface $request) use ($auth): RequestInterface {
+                foreach ($auth->getAuthenticationHeaders() as $name => $value) {
+                    $request = $request->withHeader($name, $value);
+                }
+                return $request;
+            },
         ));
 
         if ($configuration->backoffMaxTries > 0) {

--- a/libs/git-service-api-client/src/ApiClientConfiguration.php
+++ b/libs/git-service-api-client/src/ApiClientConfiguration.php
@@ -6,6 +6,8 @@ namespace Keboola\GitServiceApiClient;
 
 use Closure;
 use GuzzleHttp\HandlerStack;
+use Keboola\GitServiceApiClient\Auth\AuthInterface;
+use Keboola\GitServiceApiClient\Auth\KeboolaServiceAccountAuth;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
 
@@ -15,8 +17,17 @@ class ApiClientConfiguration
 
     /**
      * @param int<0, max> $backoffMaxTries
+     * @param AuthInterface $auth
+     *   How the client authenticates against git-service. Defaults to a
+     *   {@see KeboolaServiceAccountAuth} pointing at the standard
+     *   in-cluster SA token path, which reads (and re-reads) the file on
+     *   every request and throws if the file is missing or empty. Pass
+     *   {@see Auth\ManageApiTokenAuth} for a Manage API token, or
+     *   {@see KeboolaServiceAccountAuth} with a custom path for a
+     *   non-default projected-token mount.
      */
     public function __construct(
+        public readonly AuthInterface $auth = new KeboolaServiceAccountAuth(),
         public readonly ?string $userAgent = null,
         public readonly int $backoffMaxTries = self::DEFAULT_BACKOFF_RETRIES,
         public readonly null|Closure|HandlerStack $requestHandler = null,

--- a/libs/git-service-api-client/src/Auth/AuthInterface.php
+++ b/libs/git-service-api-client/src/Auth/AuthInterface.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Keboola\GitServiceApiClient\Auth;
+
+interface AuthInterface
+{
+    /**
+     * @return array<string, string>
+     */
+    public function getAuthenticationHeaders(): array;
+}

--- a/libs/git-service-api-client/src/Auth/KeboolaServiceAccountAuth.php
+++ b/libs/git-service-api-client/src/Auth/KeboolaServiceAccountAuth.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Keboola\GitServiceApiClient\Auth;
+
+use RuntimeException;
+use Webmozart\Assert\Assert;
+
+/**
+ * Authenticates against git-service via a projected Kubernetes ServiceAccount
+ * token mounted by the kbc-stacks chart at {@see self::DEFAULT_TOKEN_PATH}.
+ * The file is re-read on every request so kubelet-rotated tokens are picked up
+ * automatically.
+ */
+final readonly class KeboolaServiceAccountAuth implements AuthInterface
+{
+    public const DEFAULT_TOKEN_PATH = '/var/run/secrets/connection.keboola.com/serviceaccount/token';
+
+    /**
+     * @param non-empty-string $tokenPath
+     */
+    public function __construct(private string $tokenPath = self::DEFAULT_TOKEN_PATH)
+    {
+        Assert::stringNotEmpty($tokenPath, 'Service account token path must not be empty');
+    }
+
+    public function getAuthenticationHeaders(): array
+    {
+        if (!is_readable($this->tokenPath)) {
+            throw new RuntimeException(sprintf(
+                'Service account token file "%s" is not readable',
+                $this->tokenPath,
+            ));
+        }
+
+        $token = file_get_contents($this->tokenPath);
+        if ($token === false) {
+            throw new RuntimeException(sprintf(
+                'Failed to read service account token file "%s"',
+                $this->tokenPath,
+            ));
+        }
+
+        $token = trim($token);
+        if ($token === '') {
+            throw new RuntimeException(sprintf(
+                'Service account token file is empty: "%s"',
+                $this->tokenPath,
+            ));
+        }
+
+        return [
+            'X-Kubernetes-Authorization' => 'Bearer ' . $token,
+        ];
+    }
+}

--- a/libs/git-service-api-client/src/Auth/ManageApiTokenAuth.php
+++ b/libs/git-service-api-client/src/Auth/ManageApiTokenAuth.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Keboola\GitServiceApiClient\Auth;
+
+use SensitiveParameter;
+use Webmozart\Assert\Assert;
+
+final readonly class ManageApiTokenAuth implements AuthInterface
+{
+    /**
+     * @param non-empty-string $token
+     */
+    public function __construct(
+        #[SensitiveParameter]
+        private string $token,
+    ) {
+        Assert::stringNotEmpty($token, 'Manage API token must not be empty');
+    }
+
+    public function getAuthenticationHeaders(): array
+    {
+        return [
+            'X-KBC-ManageApiToken' => $this->token,
+        ];
+    }
+}

--- a/libs/git-service-api-client/src/GitServiceApiClient.php
+++ b/libs/git-service-api-client/src/GitServiceApiClient.php
@@ -9,7 +9,6 @@ use Keboola\GitServiceApiClient\Model\CreatedCredential;
 use Keboola\GitServiceApiClient\Model\Credential;
 use Keboola\GitServiceApiClient\Model\CredentialListWrapper;
 use Keboola\GitServiceApiClient\Model\Repository;
-use SensitiveParameter;
 
 class GitServiceApiClient
 {
@@ -19,14 +18,15 @@ class GitServiceApiClient
 
     /**
      * @param non-empty-string $baseUrl
-     * @param non-empty-string $token
+     *
+     * Authentication and all other client options come from
+     * {@see ApiClientConfiguration}. See {@see ApiClient::__construct()}.
      */
     public function __construct(
         string $baseUrl,
-        #[SensitiveParameter] string $token,
         ?ApiClientConfiguration $configuration = null,
     ) {
-        $this->apiClient = new ApiClient($baseUrl, $token, $configuration);
+        $this->apiClient = new ApiClient($baseUrl, $configuration);
     }
 
     public function createRepository(string $name): Repository

--- a/libs/git-service-api-client/tests/ApiClientConfigurationTest.php
+++ b/libs/git-service-api-client/tests/ApiClientConfigurationTest.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Keboola\GitServiceApiClient\Tests;
+
+use Keboola\GitServiceApiClient\ApiClientConfiguration;
+use Keboola\GitServiceApiClient\Auth\KeboolaServiceAccountAuth;
+use PHPUnit\Framework\TestCase;
+
+class ApiClientConfigurationTest extends TestCase
+{
+    public function testDefaultAuthIsKeboolaServiceAccount(): void
+    {
+        $config = new ApiClientConfiguration();
+
+        self::assertInstanceOf(KeboolaServiceAccountAuth::class, $config->auth);
+    }
+}

--- a/libs/git-service-api-client/tests/ApiClientTest.php
+++ b/libs/git-service-api-client/tests/ApiClientTest.php
@@ -10,12 +10,37 @@ use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
 use Keboola\GitServiceApiClient\ApiClient;
 use Keboola\GitServiceApiClient\ApiClientConfiguration;
+use Keboola\GitServiceApiClient\Auth\KeboolaServiceAccountAuth;
+use Keboola\GitServiceApiClient\Auth\ManageApiTokenAuth;
 use Keboola\GitServiceApiClient\Exception\ClientException;
 use Keboola\GitServiceApiClient\Model\Repository;
 use PHPUnit\Framework\TestCase;
+use RuntimeException;
 
 class ApiClientTest extends TestCase
 {
+    public function testDefaultAuthThrowsOnFirstRequestWhenNoSaTokenFileExists(): void
+    {
+        // Assumes the test container is NOT running with a projected
+        // connection-token at the Keboola SA path (true in CI).
+        $defaultPath = KeboolaServiceAccountAuth::DEFAULT_TOKEN_PATH;
+        if (is_readable($defaultPath)) {
+            self::markTestSkipped(sprintf(
+                'Keboola SA token at "%s" is mounted in this environment; '
+                    . 'cannot exercise the default-auth failure path.',
+                $defaultPath,
+            ));
+        }
+
+        // Construction succeeds (the default auth is lazy); the first outbound
+        // request triggers the file read and the resulting failure.
+        $client = new ApiClient('https://example.test');
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage($defaultPath);
+        $client->sendRequest(new Request('GET', 'foo'));
+    }
+
     public function testAddsAuthHeader(): void
     {
         $mock = new MockHandler([new Response(200, [], '{}')]);
@@ -23,14 +48,61 @@ class ApiClientTest extends TestCase
 
         $client = new ApiClient(
             'https://example.test',
-            'secret-token',
-            new ApiClientConfiguration(requestHandler: $stack),
+            new ApiClientConfiguration(
+                auth: new ManageApiTokenAuth('secret-token'),
+                requestHandler: $stack,
+            ),
         );
         $client->sendRequest(new Request('GET', 'foo'));
 
         $lastRequest = $mock->getLastRequest();
         self::assertNotNull($lastRequest);
         self::assertSame('secret-token', $lastRequest->getHeader('X-KBC-ManageApiToken')[0]);
+        self::assertSame([], $lastRequest->getHeader('X-Kubernetes-Authorization'));
+    }
+
+    public function testKeboolaSaAuthRereadsTokenEachRequest(): void
+    {
+        $tokenPath = (string) tempnam(sys_get_temp_dir(), 'kbla-sa-token-');
+        self::assertNotSame('', $tokenPath);
+        try {
+            file_put_contents($tokenPath, "first-token\n");
+
+            $mock = new MockHandler([
+                new Response(200, [], '{}'),
+                new Response(200, [], '{}'),
+            ]);
+            $stack = HandlerStack::create($mock);
+
+            $client = new ApiClient(
+                'https://example.test',
+                new ApiClientConfiguration(
+                    requestHandler: $stack,
+                    auth: new KeboolaServiceAccountAuth($tokenPath),
+                ),
+            );
+
+            $client->sendRequest(new Request('GET', 'foo'));
+            $lastRequest = $mock->getLastRequest();
+            self::assertNotNull($lastRequest);
+            self::assertSame(
+                'Bearer first-token',
+                $lastRequest->getHeader('X-Kubernetes-Authorization')[0],
+            );
+
+            // Simulate kubelet rotating the projected token file.
+            file_put_contents($tokenPath, "second-token\n");
+
+            $client->sendRequest(new Request('GET', 'foo'));
+            $lastRequest = $mock->getLastRequest();
+            self::assertNotNull($lastRequest);
+            self::assertSame(
+                'Bearer second-token',
+                $lastRequest->getHeader('X-Kubernetes-Authorization')[0],
+            );
+        } finally {
+            @unlink($tokenPath);
+        }
     }
 
     public function testRetriesOn5xx(): void
@@ -44,8 +116,11 @@ class ApiClientTest extends TestCase
 
         $client = new ApiClient(
             'https://example.test',
-            'token',
-            new ApiClientConfiguration(backoffMaxTries: 3, requestHandler: $stack),
+            new ApiClientConfiguration(
+                auth: new ManageApiTokenAuth('token'),
+                backoffMaxTries: 3,
+                requestHandler: $stack,
+            ),
         );
         $client->sendRequest(new Request('GET', 'foo'));
 
@@ -62,8 +137,10 @@ class ApiClientTest extends TestCase
 
         $client = new ApiClient(
             'https://example.test',
-            'token',
-            new ApiClientConfiguration(requestHandler: $stack),
+            new ApiClientConfiguration(
+                auth: new ManageApiTokenAuth('token'),
+                requestHandler: $stack,
+            ),
         );
 
         $this->expectException(ClientException::class);
@@ -79,8 +156,10 @@ class ApiClientTest extends TestCase
 
         $client = new ApiClient(
             'https://example.test',
-            'token',
-            new ApiClientConfiguration(requestHandler: $stack),
+            new ApiClientConfiguration(
+                auth: new ManageApiTokenAuth('token'),
+                requestHandler: $stack,
+            ),
         );
 
         $this->expectException(ClientException::class);
@@ -101,8 +180,10 @@ class ApiClientTest extends TestCase
 
         $client = new ApiClient(
             'https://example.test',
-            'token',
-            new ApiClientConfiguration(requestHandler: $stack),
+            new ApiClientConfiguration(
+                auth: new ManageApiTokenAuth('token'),
+                requestHandler: $stack,
+            ),
         );
 
         $repo = $client->sendRequestAndMapResponse(
@@ -123,8 +204,10 @@ class ApiClientTest extends TestCase
 
         $client = new ApiClient(
             'https://example.test',
-            'token',
-            new ApiClientConfiguration(requestHandler: $stack),
+            new ApiClientConfiguration(
+                auth: new ManageApiTokenAuth('token'),
+                requestHandler: $stack,
+            ),
         );
 
         $repos = $client->sendRequestAndMapResponse(
@@ -144,8 +227,10 @@ class ApiClientTest extends TestCase
 
         $client = new ApiClient(
             'https://example.test',
-            'token',
-            new ApiClientConfiguration(requestHandler: $stack),
+            new ApiClientConfiguration(
+                auth: new ManageApiTokenAuth('token'),
+                requestHandler: $stack,
+            ),
         );
 
         $this->expectException(ClientException::class);

--- a/libs/git-service-api-client/tests/Auth/KeboolaServiceAccountAuthTest.php
+++ b/libs/git-service-api-client/tests/Auth/KeboolaServiceAccountAuthTest.php
@@ -1,0 +1,135 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Keboola\GitServiceApiClient\Tests\Auth;
+
+use InvalidArgumentException;
+use Keboola\GitServiceApiClient\Auth\KeboolaServiceAccountAuth;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+
+class KeboolaServiceAccountAuthTest extends TestCase
+{
+    public function testRejectsEmptyTokenPath(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('token path must not be empty');
+        /** @phpstan-ignore-next-line argument.type — exercising the runtime guard */
+        new KeboolaServiceAccountAuth('');
+    }
+
+    public function testDefaultTokenPathPointsAtKeboolaProjectedMount(): void
+    {
+        self::assertSame(
+            '/var/run/secrets/connection.keboola.com/serviceaccount/token',
+            KeboolaServiceAccountAuth::DEFAULT_TOKEN_PATH,
+        );
+    }
+
+    public function testReturnsBearerHeaderFromFile(): void
+    {
+        $tokenPath = $this->makeTempFile('jwt-from-file');
+        try {
+            $auth = new KeboolaServiceAccountAuth($tokenPath);
+
+            self::assertSame(
+                ['X-Kubernetes-Authorization' => 'Bearer jwt-from-file'],
+                $auth->getAuthenticationHeaders(),
+            );
+        } finally {
+            @unlink($tokenPath);
+        }
+    }
+
+    public function testTrimsTrailingWhitespaceFromFileContents(): void
+    {
+        // Projected SA tokens are usually written without a trailing newline,
+        // but be defensive — `kubectl create token` and similar tools add one.
+        $tokenPath = $this->makeTempFile("jwt-from-file\n");
+        try {
+            $auth = new KeboolaServiceAccountAuth($tokenPath);
+
+            self::assertSame(
+                ['X-Kubernetes-Authorization' => 'Bearer jwt-from-file'],
+                $auth->getAuthenticationHeaders(),
+            );
+        } finally {
+            @unlink($tokenPath);
+        }
+    }
+
+    public function testRereadsFileOnEveryCall(): void
+    {
+        $tokenPath = $this->makeTempFile('first-token');
+        try {
+            $auth = new KeboolaServiceAccountAuth($tokenPath);
+
+            self::assertSame(
+                ['X-Kubernetes-Authorization' => 'Bearer first-token'],
+                $auth->getAuthenticationHeaders(),
+            );
+
+            // Simulate kubelet rotating the projected token file.
+            file_put_contents($tokenPath, 'second-token');
+
+            self::assertSame(
+                ['X-Kubernetes-Authorization' => 'Bearer second-token'],
+                $auth->getAuthenticationHeaders(),
+            );
+        } finally {
+            @unlink($tokenPath);
+        }
+    }
+
+    public function testThrowsWhenFileIsNotReadable(): void
+    {
+        $missingPath = sys_get_temp_dir() . '/does-not-exist-' . bin2hex(random_bytes(8));
+        $auth = new KeboolaServiceAccountAuth($missingPath);
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('is not readable');
+        $this->expectExceptionMessage($missingPath);
+        $auth->getAuthenticationHeaders();
+    }
+
+    public function testThrowsWhenFileIsEmpty(): void
+    {
+        $tokenPath = $this->makeTempFile('');
+        try {
+            $auth = new KeboolaServiceAccountAuth($tokenPath);
+
+            $this->expectException(RuntimeException::class);
+            $this->expectExceptionMessage('is empty');
+            $this->expectExceptionMessage($tokenPath);
+            $auth->getAuthenticationHeaders();
+        } finally {
+            @unlink($tokenPath);
+        }
+    }
+
+    public function testThrowsWhenFileContainsOnlyWhitespace(): void
+    {
+        $tokenPath = $this->makeTempFile("\n\t ");
+        try {
+            $auth = new KeboolaServiceAccountAuth($tokenPath);
+
+            $this->expectException(RuntimeException::class);
+            $this->expectExceptionMessage('is empty');
+            $auth->getAuthenticationHeaders();
+        } finally {
+            @unlink($tokenPath);
+        }
+    }
+
+    /**
+     * @return non-empty-string
+     */
+    private function makeTempFile(string $contents): string
+    {
+        $path = (string) tempnam(sys_get_temp_dir(), 'kbla-sa-auth-');
+        self::assertNotSame('', $path);
+        file_put_contents($path, $contents);
+        return $path;
+    }
+}

--- a/libs/git-service-api-client/tests/Auth/ManageApiTokenAuthTest.php
+++ b/libs/git-service-api-client/tests/Auth/ManageApiTokenAuthTest.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Keboola\GitServiceApiClient\Tests\Auth;
+
+use InvalidArgumentException;
+use Keboola\GitServiceApiClient\Auth\ManageApiTokenAuth;
+use PHPUnit\Framework\TestCase;
+
+class ManageApiTokenAuthTest extends TestCase
+{
+    public function testReturnsManageApiTokenHeader(): void
+    {
+        $auth = new ManageApiTokenAuth('secret-token');
+
+        self::assertSame(
+            ['X-KBC-ManageApiToken' => 'secret-token'],
+            $auth->getAuthenticationHeaders(),
+        );
+    }
+
+    public function testRejectsEmptyToken(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Manage API token must not be empty');
+        /** @phpstan-ignore-next-line argument.type — exercising the runtime guard */
+        new ManageApiTokenAuth('');
+    }
+}

--- a/libs/git-service-api-client/tests/GitServiceApiClientTest.php
+++ b/libs/git-service-api-client/tests/GitServiceApiClientTest.php
@@ -8,6 +8,7 @@ use GuzzleHttp\Handler\MockHandler;
 use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Psr7\Response;
 use Keboola\GitServiceApiClient\ApiClientConfiguration;
+use Keboola\GitServiceApiClient\Auth\ManageApiTokenAuth;
 use Keboola\GitServiceApiClient\CredentialType;
 use Keboola\GitServiceApiClient\GitServiceApiClient;
 use Keboola\GitServiceApiClient\KeyPermission;
@@ -21,8 +22,10 @@ class GitServiceApiClientTest extends TestCase
         $stack = HandlerStack::create($mock);
         return new GitServiceApiClient(
             'https://example.test',
-            'token',
-            new ApiClientConfiguration(requestHandler: $stack),
+            new ApiClientConfiguration(
+                auth: new ManageApiTokenAuth('token'),
+                requestHandler: $stack,
+            ),
         );
     }
 


### PR DESCRIPTION
## Release Notes
https://linear.app/keboola/issue/PAT-1791

Adds an \`AuthenticationStrategyInterface\` to \`keboola/git-service-api-client\` mirroring the one shipped in \`keboola/kbc-manage-api-php-client\` master, so in-cluster callers — initially \`sandboxes-service\` — can authenticate to git-service with a projected Kubernetes ServiceAccount JWT instead of a static Manage.

Three strategies are included: \`ManageApiTokenAuthenticationStrategy\` (existing \`X-KBC-ManageApiToken\` path; bare-string tokens still work via the constructor for backwards compatibility), \`StaticJwtAuthenticationStrategy\` (sends \`X-Kubernetes-Authorization: Bearer <jwt>\`), and \`KubernetesServiceAccountTokenAuthenticationStrategy\` (same header but reads the JWT from a projected-token file on every request so kubelet-rotated tokens are picked up automatically). \`ApiClient\` / \`GitServiceApiClient\` constructors accept either a non-empty string (legacy) or an \`AuthenticationStrategyInterface\`; the Guzzle \`mapRequest\` middleware resolves headers per request instead of capturing them once.

## Plans for customer communication
None.

## Impact analysis
No end-user impact. Existing string-token callers compile and behave identically (the \`string\` constructor path wraps the value in \`ManageApiTokenAuthenticationStrategy\`). The new strategies are opt-in.

## Change type
New feature

## Justification
Lets sandboxes-service authenticate to git-service with a projected SA token instead of a long-lived static manage-token.

## Deployment
Merge & automatic deploy.

## Rollback plan
Revert of this PR.

## Post release support plan
None.