### PR TITLE
refactor(input-mapping): use split TableExporter API in Local strategy (AJDA-2841)

### DIFF
--- a/libs/input-mapping/composer.json
+++ b/libs/input-mapping/composer.json
@@ -21,7 +21,7 @@
         "keboola/php-file-storage-utils": "^0.2",
         "keboola/key-generator": "*@dev",
         "keboola/staging-provider": "*@dev",
-        "keboola/storage-api-client": "^18.3.0",
+        "keboola/storage-api-client": "dev-odin/AJDA-2841 as 18.9.0",
         "keboola/storage-api-php-client-branch-wrapper": "^6.0",
         "symfony/config": "^5.4|^6.0|^7.0",
         "symfony/finder": "^5.4|^6.0|^7.0",

--- a/libs/input-mapping/src/Table/Strategy/Local.php
+++ b/libs/input-mapping/src/Table/Strategy/Local.php
@@ -57,8 +57,14 @@ class Local extends AbstractFileStrategy
 
     public function handleExports(array $exports, bool $preserve): array
     {
-        $tableExporter = new TableExporter($this->clientWrapper->getTableAndFileStorageClient());
+        $storageClient = $this->clientWrapper->getTableAndFileStorageClient();
+        $tableExporter = new TableExporter($storageClient);
         $this->logger->info('Processing ' . count($exports) . ' local table exports.');
-        return $tableExporter->exportTables($exports);
+
+        $exportJobs = $tableExporter->queueTableExports($exports);
+        $jobResults = $storageClient->handleAsyncTasks(array_keys($exportJobs));
+        $tableExporter->downloadExportedFiles($jobResults, $exportJobs);
+
+        return $jobResults;
     }
 }


### PR DESCRIPTION
## Link to issue

https://linear.app/keboola/issue/AJDA-2841/input-mapping-refactor-before-removal-of-the-load-decider

## Description

Smoke-tests the new split `TableExporter` API from `keboola/storage-api-client` branch `odin/AJDA-2841`. `Local::handleExports()` now calls the two halves explicitly — `queueTableExports()` → `handleAsyncTasks()` → `downloadExportedFiles()` — instead of the monolithic `exportTables()`. Behavior and the return contract (job results → metrics) are unchanged; the wait step is now the visible seam where the upcoming phase-1/phase-3 split of the strategy interface will cut.

**Draft on purpose:** `composer.json` pins `keboola/storage-api-client` to `dev-odin/AJDA-2841 as 18.9.0`. Do not merge until the client change is released and the constraint is bumped to a stable version.

Verified: phpcs ✅, phpstan ✅, `DownloadTablesBigQueryTest` (Local strategy, exercises the changed path) ✅. `DownloadTablesDefaultTest` not run — requires a Snowflake-backend project, local credentials point at the BQ/GCS CI project.

## Justification

See the linked Linear issue — first step of unifying input-mapping on the two-phase load contract.

## Plans for Customer Communication

None.

## Impact Analysis

No behavior change intended; same export jobs, same downloads, same results. Risk is limited to the Local table staging path and the dev-branch client dependency (which is why this stays draft).

## Deployment Plan

Release a tagged version — only after the storage-api-client release replaces the dev-branch constraint.

## Rollback Plan

Revert this PR.

## Post-Release Support Plan

None.
