### PR TITLE
fix(messenger-bundle): AJDA-2866 apply default REST timeout to all GPS transports

### DIFF
--- a/libs/messenger-bundle/README.md
+++ b/libs/messenger-bundle/README.md
@@ -30,6 +30,11 @@ keboola_messenger:
   connection_audit_log_queue_dsn: "%env(CONNECTION_AUDIT_LOG_QUEUE_DSN)%"
 ```
 
+### Default timeouts for Google Pub/Sub transports
+When installed, the bundle gives every `gps://` transport in the application a default REST client timeout
+(`restOptions.timeout: 120`, `connect_timeout: 10`) — without it, a consumer can hang forever on a dead connection.
+Setting `client_config` explicitly (in transport options or the DSN query) disables the defaults.
+
 ## Development
 Prerequisites:
 * `aws` CLI with configured `Keboola-Dev-Platform-Services-AWSAdministratorAccess` profile

--- a/libs/messenger-bundle/src/DependencyInjection/KeboolaMessengerExtension.php
+++ b/libs/messenger-bundle/src/DependencyInjection/KeboolaMessengerExtension.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Keboola\MessengerBundle\DependencyInjection;
 
 use Keboola\MessengerBundle\Platform;
+use Keboola\MessengerBundle\Transport\GpsTransportFactoryDecorator;
 use Symfony\Bridge\Doctrine\Messenger\DoctrinePingConnectionMiddleware;
 use Symfony\Component\Config\Definition\Configurator\DefinitionConfigurator;
 use Symfony\Component\Config\FileLocator;
@@ -144,10 +145,7 @@ class KeboolaMessengerExtension extends AbstractExtension
 
             Platform::GCP => [
                 'client_config' => [
-                    'restOptions' => [
-                        'timeout' => 120,
-                        'connect_timeout' => 10,
-                    ],
+                    'restOptions' => GpsTransportFactoryDecorator::DEFAULT_REST_OPTIONS,
                 ],
             ],
         };

--- a/libs/messenger-bundle/src/Resources/config/messenger.yaml
+++ b/libs/messenger-bundle/src/Resources/config/messenger.yaml
@@ -22,3 +22,11 @@ services:
         abstract: true
         arguments:
             $eventFactory: !abstract configured in bundle extension
+
+    # ensures every GPS transport in the app gets a default REST timeout, see GpsTransportFactoryDecorator
+    keboola.messenger_bundle.gps_transport_factory_decorator:
+        class: Keboola\MessengerBundle\Transport\GpsTransportFactoryDecorator
+        decorates: PetitPress\GpsMessengerBundle\Transport\GpsTransportFactory
+        decoration_on_invalid: ignore # app may not register GpsMessengerBundle at all
+        arguments:
+            - '@.inner'

--- a/libs/messenger-bundle/src/Transport/GpsTransportFactoryDecorator.php
+++ b/libs/messenger-bundle/src/Transport/GpsTransportFactoryDecorator.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Keboola\MessengerBundle\Transport;
+
+use Symfony\Component\Messenger\Transport\Serialization\SerializerInterface;
+use Symfony\Component\Messenger\Transport\TransportFactoryInterface;
+use Symfony\Component\Messenger\Transport\TransportInterface;
+
+/**
+ * Decorates GpsTransportFactory to inject a default REST client timeout. Without it, the Pub/Sub long-poll
+ * pull() has no client-side timeout and a half-open TCP connection blocks the consumer forever (AJDA-2866).
+ *
+ * @implements TransportFactoryInterface<TransportInterface>
+ */
+final class GpsTransportFactoryDecorator implements TransportFactoryInterface
+{
+    // 120s > the ~90s Pub/Sub server-side long-poll hold, so a healthy poll is never cut short
+    public const DEFAULT_REST_OPTIONS = [
+        'timeout' => 120,
+        'connect_timeout' => 10,
+    ];
+
+    /**
+     * @param TransportFactoryInterface<TransportInterface> $inner
+     */
+    public function __construct(
+        private readonly TransportFactoryInterface $inner,
+    ) {
+    }
+
+    public function supports(string $dsn, array $options): bool
+    {
+        return $this->inner->supports($dsn, $options);
+    }
+
+    public function createTransport(string $dsn, array $options, SerializerInterface $serializer): TransportInterface
+    {
+        // GpsConfigurationResolver merges DSN query options with $options, so an injected client_config would
+        // override one configured in the DSN. Back off on any explicit client_config (whole key, not just
+        // restOptions - injecting restOptions would shadow e.g. an app-configured requestTimeout).
+        parse_str(parse_url($dsn, PHP_URL_QUERY) ?: '', $dsnOptions);
+        if (!isset($options['client_config']) && !isset($dsnOptions['client_config'])) {
+            $options['client_config'] = ['restOptions' => self::DEFAULT_REST_OPTIONS];
+        }
+
+        return $this->inner->createTransport($dsn, $options, $serializer);
+    }
+}

--- a/libs/messenger-bundle/tests/DependencyInjection/GpsTransportFactoryDecorationTest.php
+++ b/libs/messenger-bundle/tests/DependencyInjection/GpsTransportFactoryDecorationTest.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Keboola\MessengerBundle\Tests\DependencyInjection;
+
+use Keboola\MessengerBundle\KeboolaMessengerBundle;
+use Keboola\MessengerBundle\Transport\GpsTransportFactoryDecorator;
+use PetitPress\GpsMessengerBundle\Transport\GpsTransportFactory;
+use Symfony\Bundle\FrameworkBundle\FrameworkBundle;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\Config\Loader\LoaderInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\HttpKernel\Kernel;
+
+class GpsTransportFactoryDecorationTest extends KernelTestCase
+{
+    public function testGpsTransportFactoryIsDecoratedWhenGpsMessengerBundleIsRegistered(): void
+    {
+        self::bootKernel();
+
+        $factory = self::getContainer()->get(GpsTransportFactory::class);
+        self::assertInstanceOf(GpsTransportFactoryDecorator::class, $factory);
+    }
+
+    public function testContainerCompilesWhenGpsMessengerBundleIsNotRegistered(): void
+    {
+        $kernel = new class('test', true) extends Kernel {
+            public function registerBundles(): iterable
+            {
+                yield new FrameworkBundle();
+                yield new KeboolaMessengerBundle();
+            }
+
+            public function registerContainerConfiguration(LoaderInterface $loader): void
+            {
+                $loader->load(function (ContainerBuilder $container): void {
+                    $container->loadFromExtension('framework', [
+                        'test' => true,
+                        'http_method_override' => false,
+                    ]);
+                });
+            }
+        };
+
+        $kernel->boot();
+        $container = $kernel->getContainer();
+
+        self::assertFalse($container->has(GpsTransportFactory::class));
+        self::assertFalse($container->has('keboola.messenger_bundle.gps_transport_factory_decorator'));
+
+        $kernel->shutdown();
+    }
+}

--- a/libs/messenger-bundle/tests/Transport/GpsTransportFactoryDecoratorTest.php
+++ b/libs/messenger-bundle/tests/Transport/GpsTransportFactoryDecoratorTest.php
@@ -1,0 +1,104 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Keboola\MessengerBundle\Tests\Transport;
+
+use Keboola\MessengerBundle\Transport\GpsTransportFactoryDecorator;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Messenger\Transport\Serialization\SerializerInterface;
+use Symfony\Component\Messenger\Transport\TransportFactoryInterface;
+use Symfony\Component\Messenger\Transport\TransportInterface;
+
+class GpsTransportFactoryDecoratorTest extends TestCase
+{
+    public function testSupportsDelegatesToInnerFactory(): void
+    {
+        $inner = $this->createMock(TransportFactoryInterface::class);
+        $inner->expects(self::once())
+            ->method('supports')
+            ->with('gps://default/topic', ['foo' => 'bar'])
+            ->willReturn(true);
+
+        $decorator = new GpsTransportFactoryDecorator($inner);
+
+        self::assertTrue($decorator->supports('gps://default/topic', ['foo' => 'bar']));
+    }
+
+    public function testCreateTransportInjectsDefaultClientConfigWhenNotConfigured(): void
+    {
+        $serializer = $this->createMock(SerializerInterface::class);
+        $transport = $this->createMock(TransportInterface::class);
+
+        $inner = $this->createMock(TransportFactoryInterface::class);
+        $inner->expects(self::once())
+            ->method('createTransport')
+            ->with(
+                'gps://default/topic',
+                [
+                    'transport_name' => 'messages',
+                    'client_config' => [
+                        'restOptions' => [
+                            'timeout' => 120,
+                            'connect_timeout' => 10,
+                        ],
+                    ],
+                ],
+                $serializer,
+            )
+            ->willReturn($transport);
+
+        $decorator = new GpsTransportFactoryDecorator($inner);
+
+        self::assertSame(
+            $transport,
+            $decorator->createTransport('gps://default/topic', ['transport_name' => 'messages'], $serializer),
+        );
+    }
+
+    public function testCreateTransportKeepsClientConfigFromOptions(): void
+    {
+        $serializer = $this->createMock(SerializerInterface::class);
+        $transport = $this->createMock(TransportInterface::class);
+
+        $options = [
+            'client_config' => [
+                'requestTimeout' => 60,
+            ],
+        ];
+
+        $inner = $this->createMock(TransportFactoryInterface::class);
+        $inner->expects(self::once())
+            ->method('createTransport')
+            ->with('gps://default/topic', $options, $serializer)
+            ->willReturn($transport);
+
+        $decorator = new GpsTransportFactoryDecorator($inner);
+
+        self::assertSame(
+            $transport,
+            $decorator->createTransport('gps://default/topic', $options, $serializer),
+        );
+    }
+
+    public function testCreateTransportKeepsClientConfigFromDsn(): void
+    {
+        $serializer = $this->createMock(SerializerInterface::class);
+        $transport = $this->createMock(TransportInterface::class);
+
+        $dsn = 'gps://default/topic?client_config[restOptions][timeout]=30';
+
+        $inner = $this->createMock(TransportFactoryInterface::class);
+        $inner->expects(self::once())
+            ->method('createTransport')
+            ->with($dsn, [], $serializer)
+            ->willReturn($transport);
+
+        $decorator = new GpsTransportFactoryDecorator($inner);
+
+        self::assertSame(
+            $transport,
+            $decorator->createTransport($dsn, [], $serializer),
+        );
+    }
+}


### PR DESCRIPTION
### Link to issue

https://linear.app/keboola/issue/AJDA-2866/notification-service-consumer-can-hang-indefinitely-on-blocking

### Description

A Pub/Sub consumer using the REST connection has no client-side timeout on the long-poll `pull()` — a half-open TCP connection blocks `curl_exec()` forever, and neither `--time-limit` nor SIGTERM can interrupt it (16.5h outage on `com-keboola-gcp-us-east4`). The bundle already injects `client_config.restOptions` timeouts for the transports it creates itself, but app-defined `gps://` transports (like notification-service's `messages`) got nothing.

This adds `GpsTransportFactoryDecorator`, which decorates the petitpress `GpsTransportFactory` (registered unconditionally, with `decoration_on_invalid: ignore` for apps without `GpsMessengerBundle`), injecting `restOptions: {timeout: 120, connect_timeout: 10}` into every GPS transport. 120s exceeds the ~90s Pub/Sub server-side long-poll hold, so healthy polls are never cut short.

Non-obvious decisions:
- The decorator backs off when `client_config` is set explicitly — checking **both** `$options` and the DSN query, because `GpsConfigurationResolver` merges them with `$options` taking precedence, so an injected value would silently override a DSN-configured one.
- It backs off on the whole `client_config`, not just `restOptions`, to avoid shadowing an app-configured `requestTimeout` (Google's `RequestWrapper` gives `restOptions` precedence).
- `KeboolaMessengerExtension` GCP defaults now reference the decorator's constant instead of duplicating the literals.

### Justification

See the linked issue — on timeout the worker now exits with `TransportException` and the container restarts, making stuck consumers self-healing.

### Plans for Customer Communication

None — internal infrastructure change.

### Impact Analysis

Affects all apps using this bundle on GCP once they upgrade. Behavior change only for `gps://` transports with no explicit `client_config`: requests now fail after 120s instead of hanging forever. A timeout mid-pull surfaces as a `TransportException` that crashes the worker — which is the intended recovery path. Apps with explicit `client_config` are untouched. No feature flag.

### Deployment Plan

Release a tagged version.

### Rollback Plan

Revert this PR.

### Post-Release Support Plan

None.