### PR TITLE
PAT-1680 Add AppRun spec.failureReason to k8s-client

### DIFF
--- a/libs/k8s-client/src/Model/Io/Keboola/Apps/V1/AppRunFailureReason.php
+++ b/libs/k8s-client/src/Model/Io/Keboola/Apps/V1/AppRunFailureReason.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Keboola\K8sClient\Model\Io\Keboola\Apps\V1;
+
+use KubernetesRuntime\AbstractModel;
+
+/**
+ * AppRunFailureReason is the user-facing cause of a Failed run. Only set when state=Failed.
+ *
+ * Populated by the operator at the moment the run transitions to Failed; never updated
+ * afterwards. Downstream consumers SHOULD treat absence as an unclassified failure
+ * (legacy AppRuns predating this field).
+ */
+class AppRunFailureReason extends AbstractModel
+{
+    /**
+     * Reason is a short, stable, machine-readable identifier (UI i18n key).
+     *
+     * @var string
+     */
+    public $reason = null;
+
+    /**
+     * Message is a human-readable description of the failure with no internal
+     * resource names or cluster-internal details.
+     *
+     * @var string
+     */
+    public $message = null;
+}

--- a/libs/k8s-client/src/Model/Io/Keboola/Apps/V1/AppRunSpec.php
+++ b/libs/k8s-client/src/Model/Io/Keboola/Apps/V1/AppRunSpec.php
@@ -12,9 +12,11 @@ use KubernetesRuntime\AbstractModel;
 class AppRunSpec extends AbstractModel
 {
     /**
-     * PodRef is a reference to the Pod this AppRun tracks
+     * PodRef references the Pod or E2B sandbox this AppRun tracks. Optional: the AppRun
+     * may be created before compute exists and is populated once compute is observed;
+     * remains unset if the attempt fails before compute is created.
      *
-     * @var PodReference
+     * @var PodReference|null
      */
     public $podRef = null;
 
@@ -53,6 +55,13 @@ class AppRunSpec extends AbstractModel
      * @var string
      */
     public $state = null;
+
+    /**
+     * FailureReason is the user-facing cause of a Failed run. Only set when state=Failed.
+     *
+     * @var AppRunFailureReason|null
+     */
+    public $failureReason = null;
 
     /**
      * StartupLogs contains the startup logs from the run

--- a/libs/k8s-client/tests/Model/V1/AppRunModelTest.php
+++ b/libs/k8s-client/tests/Model/V1/AppRunModelTest.php
@@ -6,6 +6,7 @@ namespace Keboola\K8sClient\Tests\Model\V1;
 
 use Keboola\K8sClient\Model\Io\Keboola\Apps\V1\AppReference;
 use Keboola\K8sClient\Model\Io\Keboola\Apps\V1\AppRun;
+use Keboola\K8sClient\Model\Io\Keboola\Apps\V1\AppRunFailureReason;
 use Keboola\K8sClient\Model\Io\Keboola\Apps\V1\AppRunSpec;
 use Keboola\K8sClient\Model\Io\Keboola\Apps\V1\AppRunStatus;
 use Keboola\K8sClient\Model\Io\Keboola\Apps\V1\PodReference;
@@ -101,6 +102,37 @@ class AppRunModelTest extends TestCase
         self::assertCount(1, $appRun->status->conditions);
         self::assertSame('Ready', $appRun->status->conditions[0]->type);
         self::assertSame('True', $appRun->status->conditions[0]->status);
+    }
+
+    public function testAppRunFailureReasonHydratesAndSerializes(): void
+    {
+        $data = self::getAppRunTestData();
+        $data['spec']['state'] = 'Failed';
+        $data['spec']['failureReason'] = [
+            'reason' => 'OutOfMemory',
+            'message' => 'The app ran out of memory.',
+        ];
+
+        $appRun = new AppRun($data);
+
+        self::assertNotNull($appRun->spec->failureReason);
+        self::assertInstanceOf(AppRunFailureReason::class, $appRun->spec->failureReason);
+        self::assertSame('OutOfMemory', $appRun->spec->failureReason->reason);
+        self::assertSame('The app ran out of memory.', $appRun->spec->failureReason->message);
+
+        $serialized = $appRun->getArrayCopy();
+        self::assertSame('OutOfMemory', $serialized['spec']['failureReason']['reason']);
+        self::assertSame('The app ran out of memory.', $serialized['spec']['failureReason']['message']);
+    }
+
+    public function testAppRunWithoutFailureReasonHydratesToNull(): void
+    {
+        // Legacy AppRuns predating the failureReason field, and any non-Failed run,
+        // carry no failureReason and must hydrate to null (never serialized back).
+        $appRun = new AppRun(self::getAppRunTestData());
+
+        self::assertNull($appRun->spec->failureReason);
+        self::assertArrayNotHasKey('failureReason', $appRun->getArrayCopy()['spec']);
     }
 
     public function testAppRunModelSerialization(): void


### PR DESCRIPTION
## Release Notes
https://linear.app/keboola/issue/PAT-1680

Mirrors the `AppRun` CRD change for the AppRun lifecycle unification into the `k8s-client` models. `AppRunSpec` gains an optional `failureReason` (`{reason, message}`) — the user-facing cause the operator sets when a run transitions to `Failed` — and `spec.podRef` is now documented as optional, since an `AppRun` may be created before any compute (Pod / E2B sandbox) exists.

The change is additive: a new `AppRunFailureReason` model hydrated from the CRD, plus the `failureReason` property on `AppRunSpec`. Absent `failureReason` (non-failed or legacy `AppRun`s) hydrates to `null` and is never serialized back.

* `sandboxes-service` consumer https://github.com/keboola/sandboxes-service/pull/611

## Plans for customer communication
None.

## Impact analysis
No end-user impact. Additive model field; existing `AppRun` payloads without `failureReason` are unaffected.

## Change type
New feature

## Justification
AppRun lifecycle unification (PAT-1680) — surface the user-facing failure reason in `k8s-client`.

## Deployment
Merge & automatic deploy.

## Rollback plan
Revert of this PR.

## Post release support plan
None.
