### PR TITLE
DMD-1475 Add bootCleanClient() test helper for stubbing auth on a clean container

### DIFF
--- a/libs/api-bundle/README.md
+++ b/libs/api-bundle/README.md
@@ -148,31 +148,86 @@ which the bundle requires directly, so no extra installation is needed.
 ## Testing controllers
 
 `Keboola\ApiBundle\Test\AuthenticatorTestTrait` stubs the authenticators in functional
-(`KernelTestCase`) tests so guarded controllers can be exercised without reaching real
-Storage/Manage APIs:
+(`WebTestCase`) tests so guarded controllers can be exercised without reaching real
+Storage/Manage APIs. It provides four helpers:
+
+| Helper | Stubs auth for | Returns |
+| --- | --- | --- |
+| `setupFakeStorageApiToken(tokenString?, projectId, features, adminId?)` | `#[StorageApiTokenAuth]` via legacy `X-StorageApi-Token` | `StorageApiToken` |
+| `setupFakeConnectionToken(projectId, features, tokenString?, adminId?)` | `#[StorageApiTokenAuth]` via a `kbc_at_`/`kbc_pat_` programmatic token (stubs the exchange resolver client) | `StorageApiToken` |
+| `setupFakeManageApiToken(tokenString, scopes, features)` | `#[ApplicationTokenAuth]` (both the `X-KBC-ManageApiToken` header and the Kubernetes ServiceAccount JWT) | `void` |
+| `bootCleanClient()` | — boots a fresh, reboot-disabled `KernelBrowser` on a clean container | `KernelBrowser` |
+
+### Why `bootCleanClient()`
+
+The `setupFake*Token()` helpers replace services in the test container via
+`getContainer()->set(...)`. That only works while those services are **not yet initialized**: a
+`#[StorageApiTokenAuth]` request initializes `ManageApiClientFactory` (it backs the programmatic-token
+exchange resolver), and an initialized service can no longer be replaced. So whenever a request has
+already run in the test — or you simply want a guaranteed-clean container — call
+`self::bootCleanClient()` first. It boots a fresh kernel, disables client reboot, and returns the
+`KernelBrowser` to use for the request.
+
+> [!IMPORTANT]
+> `bootCleanClient()` **reboots the kernel**, discarding the previous container. Call it before
+> **every** `getContainer()->set(...)` the test relies on — including your own app-specific service
+> mocks, not just the `setupFake*Token()` helpers. Mocks registered *before* `bootCleanClient()` are
+> thrown away by the reboot and will not be seen by the request.
+
+Recommended order: **seed the database → `bootCleanClient()` → register service mocks →
+`setupFake*Token()` → request.**
+
+### Requirements
+
+- The test case must extend Symfony's `WebTestCase` (`bootCleanClient()` uses `bootKernel()` /
+  `getClient()` / the `test.client` service).
+- `symfony/browser-kit` must be installed (dev dependency) for the `KernelBrowser` client.
+
+### Example
 
 ```php
 use Keboola\ApiBundle\Test\AuthenticatorTestTrait;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 
-class MyActionTest extends KernelTestCase
+class MyActionTest extends WebTestCase
 {
     use AuthenticatorTestTrait;
 
-    public function testIt(): void
+    public function testUnauthorized(): void
     {
-        // for #[StorageApiTokenAuth]
-        $token = $this->setupFakeStorageApiToken(projectId: '123', features: ['my-feature']);
+        // A request that doesn't fake a token can use the standard client.
+        $client = static::createClient();
+        $client->request('GET', '/my-endpoint');
 
-        // for #[ApplicationTokenAuth] — works for both the X-KBC-ManageApiToken
-        // header and the Kubernetes ServiceAccount JWT
-        $this->setupFakeManageApiToken('my-token', scopes: ['something:manage']);
+        self::assertResponseStatusCodeSame(401);
+    }
 
-        // for #[StorageApiTokenAuth] with a kbc_at_/kbc_pat_ programmatic token — stubs the
-        // resolver client (returning the token detail), so no Connection/Storage API call is made
-        $token = $this->setupFakeConnectionToken(projectId: '123', features: ['my-feature']);
+    public function testAuthorized(): void
+    {
+        self::setupDatabase([$entity]);          // 1) seed state the controller reads
+
+        $client = self::bootCleanClient();       // 2) clean container BEFORE any ->set()
+
+        $myService = $this->createMock(MyService::class);
+        self::getContainer()->set(MyService::class, $myService);   // 3) app service mocks
+
+        $token = $this->setupFakeStorageApiToken( // 4) stub the authenticator
+            projectId: '123',
+            features: ['my-feature'],
+        );
+
+        $client->request('GET', '/my-endpoint', server: [   // 5) authenticated request
+            'HTTP_X_STORAGEAPI_TOKEN' => $token->getTokenValue(),
+        ]);
+
+        self::assertResponseIsSuccessful();
     }
 }
 ```
+
+Swap `setupFakeStorageApiToken()` for `setupFakeConnectionToken()` (programmatic token) or
+`setupFakeManageApiToken()` (`#[ApplicationTokenAuth]`) depending on the attribute under test; the
+clean-client ordering is the same for all three.
 
 ## License
 

--- a/libs/api-bundle/composer.json
+++ b/libs/api-bundle/composer.json
@@ -23,6 +23,8 @@
         "phpstan/phpstan-phpunit": "^2.0",
         "phpstan/phpstan-symfony": "^2.0",
         "phpunit/phpunit": "^12.0",
+        "symfony/browser-kit": "^6.1|^7.0",
+        "symfony/dom-crawler": "^6.1|^7.0",
         "symfony/framework-bundle": "^6.1|^7.0",
         "symfony/yaml": "^6.1|^7.0"
     },

--- a/libs/api-bundle/phpunit.xml.dist
+++ b/libs/api-bundle/phpunit.xml.dist
@@ -20,6 +20,8 @@
     <server name="SHELL_VERBOSITY" value="-1"/>
     <server name="KERNEL_CLASS" value="\Keboola\ApiBundle\Tests\KeboolaApiBundleTestingKernel"/>
     <env name="APP_ENV" value="test" force="true"/>
+    <env name="APP_DEBUG" value="0" force="true"/>
+    <env name="HOSTNAME_SUFFIX" value="keboola.com" force="true"/>
   </php>
   <testsuites>
     <testsuite name="Project Test Suite">

--- a/libs/api-bundle/src/Test/AuthenticatorTestTrait.php
+++ b/libs/api-bundle/src/Test/AuthenticatorTestTrait.php
@@ -12,13 +12,23 @@ use Keboola\StorageApi\Client as StorageApiClient;
 use Keboola\StorageApiBranch\ClientWrapper;
 use Keboola\StorageApiBranch\Factory\StorageClientRequestFactory;
 use PHPUnit\Framework\MockObject\MockObject;
+use Symfony\Bundle\FrameworkBundle\KernelBrowser;
+use Symfony\Component\BrowserKit\AbstractBrowser;
 use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\HttpKernel\KernelInterface;
 
 /**
- * Helpers for functional (KernelTestCase) tests that stub api-bundle's authenticators, so
+ * Helpers for functional WebTestCase tests that stub api-bundle's authenticators, so
  * controllers guarded by #[StorageApiTokenAuth] / #[ApplicationTokenAuth] can be
  * exercised without reaching real Storage/Manage APIs. The consuming test case provides
- * createMock() and getContainer() (e.g. via KernelTestCase + MockObject).
+ * createMock() and getContainer(); consumers that use {@see bootCleanClient()} must extend
+ * Symfony's WebTestCase (it calls bootKernel()/getClient()).
+ *
+ * The setupFake*Token() helpers register their mocks on the current test container. A
+ * #[StorageApiTokenAuth] request initializes ManageApiClientFactory (it backs the token
+ * exchange resolver), and an initialized service can no longer be replaced via the test
+ * container - so call {@see bootCleanClient()} to get a fresh container/client before
+ * setupFake*Token() whenever a request has already run in the test.
  */
 trait AuthenticatorTestTrait
 {
@@ -28,6 +38,31 @@ trait AuthenticatorTestTrait
     abstract protected function createMock(string $className): MockObject;
 
     abstract protected static function getContainer(): ContainerInterface;
+
+    /**
+     * @param array<string, mixed> $options
+     */
+    abstract protected static function bootKernel(array $options = []): KernelInterface;
+
+    abstract protected static function getClient(?AbstractBrowser $newClient = null): ?AbstractBrowser;
+
+    /**
+     * Boots a fresh kernel and returns its (reboot-disabled) HTTP client, registered for
+     * BrowserKit assertions via getClient(). Use before setupFake*Token() to guarantee a clean
+     * container in which the auth services are not yet initialized and can therefore be replaced.
+     */
+    protected static function bootCleanClient(): KernelBrowser
+    {
+        self::bootKernel();
+
+        $client = self::getContainer()->get('test.client');
+        assert($client instanceof KernelBrowser);
+
+        self::getClient($client);
+        $client->disableReboot();
+
+        return $client;
+    }
 
     /**
      * @param list<string> $features

--- a/libs/api-bundle/src/Test/AuthenticatorTestTrait.php
+++ b/libs/api-bundle/src/Test/AuthenticatorTestTrait.php
@@ -50,6 +50,12 @@ trait AuthenticatorTestTrait
      * Boots a fresh kernel and returns its (reboot-disabled) HTTP client, registered for
      * BrowserKit assertions via getClient(). Use before setupFake*Token() to guarantee a clean
      * container in which the auth services are not yet initialized and can therefore be replaced.
+     *
+     * Because it reboots the kernel (discarding the previous container), it must be called before
+     * ANY getContainer()->set() the test relies on - including app-specific service mocks, not just
+     * the setupFake*Token() helpers. Mocks registered before bootCleanClient() are thrown away by the
+     * reboot and will not be seen by the request. Recommended order: seed the database, then
+     * bootCleanClient(), then register every service mock, then setupFake*Token(), then request.
      */
     protected static function bootCleanClient(): KernelBrowser
     {

--- a/libs/api-bundle/tests/KeboolaApiBundleTestingKernel.php
+++ b/libs/api-bundle/tests/KeboolaApiBundleTestingKernel.php
@@ -4,10 +4,16 @@ declare(strict_types=1);
 
 namespace Keboola\ApiBundle\Tests;
 
+use CuyZ\ValinorBundle\ValinorBundle;
+use Keboola\ApiBundle\DependencyInjection\KeboolaApiExtension;
 use Keboola\ApiBundle\KeboolaApiBundle;
+use Keboola\ApiBundle\Security\ApplicationToken\ManageApiClientFactory;
 use Symfony\Bundle\FrameworkBundle\FrameworkBundle;
 use Symfony\Bundle\MonologBundle\MonologBundle;
 use Symfony\Component\Config\Loader\LoaderInterface;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\Compiler\PassConfig;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Kernel;
 
 class KeboolaApiBundleTestingKernel extends Kernel
@@ -16,7 +22,32 @@ class KeboolaApiBundleTestingKernel extends Kernel
     {
         yield new FrameworkBundle();
         yield new MonologBundle();
+        yield new ValinorBundle();
         yield new KeboolaApiBundle();
+    }
+
+    protected function build(ContainerBuilder $container): void
+    {
+        // This minimal kernel wires no security firewall, so the auth services would otherwise be
+        // private/removed. Keep the ones AuthenticatorTestTrait fetches/replaces public so tests
+        // can initialize ManageApiClientFactory and swap in the fake exchange resolver client.
+        $container->addCompilerPass(
+            new class implements CompilerPassInterface {
+                public function process(ContainerBuilder $container): void
+                {
+                    $publicIds = [
+                        ManageApiClientFactory::class,
+                        KeboolaApiExtension::STORAGE_TOKEN_RESOLVER_CLIENT_ID,
+                    ];
+                    foreach ($publicIds as $id) {
+                        if ($container->hasDefinition($id)) {
+                            $container->getDefinition($id)->setPublic(true);
+                        }
+                    }
+                }
+            },
+            PassConfig::TYPE_BEFORE_REMOVING,
+        );
     }
 
     public function registerContainerConfiguration(LoaderInterface $loader): void

--- a/libs/api-bundle/tests/Test/AuthenticatorTestTraitTest.php
+++ b/libs/api-bundle/tests/Test/AuthenticatorTestTraitTest.php
@@ -9,24 +9,20 @@ use Keboola\ApiBundle\Security\ApplicationToken\ManageApiClientFactory;
 use Keboola\ApiBundle\Test\AuthenticatorTestTrait;
 use Keboola\ManageApi\Client as ManageApiClient;
 use Keboola\StorageApiBranch\Factory\StorageClientRequestFactory;
-use PHPUnit\Framework\TestCase;
-use Symfony\Component\DependencyInjection\Container;
-use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
 
-class AuthenticatorTestTraitTest extends TestCase
+class AuthenticatorTestTraitTest extends WebTestCase
 {
     use AuthenticatorTestTrait;
 
-    private static Container $testContainer;
-
-    protected static function getContainer(): ContainerInterface
+    protected function tearDown(): void
     {
-        return self::$testContainer;
-    }
+        parent::tearDown();
 
-    protected function setUp(): void
-    {
-        self::$testContainer = new Container();
+        // Booting the kernel registers an exception handler that PHPUnit otherwise reports as a
+        // leaked handler ("did not remove its own exception handlers"); restore it here.
+        restore_exception_handler();
     }
 
     public function testSetupFakeStorageApiToken(): void
@@ -44,7 +40,7 @@ class AuthenticatorTestTraitTest extends TestCase
 
         self::assertInstanceOf(
             StorageClientRequestFactory::class,
-            self::$testContainer->get(StorageClientRequestFactory::class),
+            self::getContainer()->get(StorageClientRequestFactory::class),
         );
     }
 
@@ -52,7 +48,7 @@ class AuthenticatorTestTraitTest extends TestCase
     {
         $this->setupFakeManageApiToken('manage-token', ['some:scope'], ['feat-b']);
 
-        $factory = self::$testContainer->get(ManageApiClientFactory::class);
+        $factory = self::getContainer()->get(ManageApiClientFactory::class);
         self::assertInstanceOf(ManageApiClientFactory::class, $factory);
 
         $data = $factory->getClientForManageToken('manage-token')->verifyToken();
@@ -80,7 +76,7 @@ class AuthenticatorTestTraitTest extends TestCase
         self::assertSame(['feat-x'], $token->getFeatures());
 
         // A resolver ManageApiClient mock is registered in the container under the resolver id.
-        $resolverClient = self::$testContainer->get(KeboolaApiExtension::STORAGE_TOKEN_RESOLVER_CLIENT_ID);
+        $resolverClient = self::getContainer()->get(KeboolaApiExtension::STORAGE_TOKEN_RESOLVER_CLIENT_ID);
         self::assertInstanceOf(ManageApiClient::class, $resolverClient);
 
         // The mock resolver client returns the legacy Storage token together with its full
@@ -92,5 +88,35 @@ class AuthenticatorTestTraitTest extends TestCase
         self::assertSame(789, $resolved['projectId']);
         self::assertSame('tok-x', $resolved['storageToken']);
         self::assertSame($token->getTokenInfo(), $resolved['tokenDetail']);
+    }
+
+    public function testStubbingInitializedManageFactoryFailsWithoutCleanClient(): void
+    {
+        // A #[StorageApiTokenAuth] request initializes ManageApiClientFactory (it backs the token
+        // exchange resolver); once initialized the test container can no longer replace it.
+        self::getContainer()->get(ManageApiClientFactory::class);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessageMatches('/already initialized/');
+
+        $this->setupFakeManageApiToken('manage-token');
+    }
+
+    public function testBootCleanClientAllowsStubbingAfterServiceInitialized(): void
+    {
+        // Initialize ManageApiClientFactory on the current container, as a #[StorageApiTokenAuth]
+        // request would.
+        self::getContainer()->get(ManageApiClientFactory::class);
+
+        // A fresh client gives a clean container where the factory can be stubbed again.
+        self::bootCleanClient();
+        $this->setupFakeManageApiToken('manage-token', ['some:scope']);
+
+        $factory = self::getContainer()->get(ManageApiClientFactory::class);
+        self::assertInstanceOf(ManageApiClientFactory::class, $factory);
+        self::assertSame(
+            ['some:scope'],
+            $factory->getClientForManageToken('manage-token')->verifyToken()['scopes'],
+        );
     }
 }

--- a/libs/api-bundle/tests/config.yaml
+++ b/libs/api-bundle/tests/config.yaml
@@ -1,5 +1,10 @@
+parameters:
+    app_name: api-bundle-test
+
 framework:
     test: true
+    secret: test
+    http_method_override: false
 
 monolog:
     handlers:


### PR DESCRIPTION
## Release Notes
https://linear.app/keboola/issue/DMD-1475

TL;DR uprava test traitu aby fungoval i s novou zavislosti na `ManageApiClientFactory`. V testech appek je pak potreba mechanicka uprava viz. https://github.com/keboola/sandboxes-service/pull/612

Adds `AuthenticatorTestTrait::bootCleanClient()` to `api-bundle`. Since the token-exchange work (#507), a `#[StorageApiTokenAuth]` request initializes `ManageApiClientFactory` (it backs the exchange resolver), and Symfony's test container refuses to replace an already-initialized service. So a functional test that performs a Storage-token request and *then* calls `setupFakeManageApiToken()` on the same container (the common `disableReboot()` pattern) fails with *"service is already initialized, you cannot replace it."* `bootCleanClient()` boots a fresh kernel/client, giving a clean container in which `setupFake*Token()` can stub the auth services after a request has run.

The trait now requires a `WebTestCase` host — it declares abstract `bootKernel()`/`getClient()`, and `bootCleanClient()` is `static` to make its global (kernel-level) effect explicit. The existing `setupFake*Token()` helpers are unchanged. api-bundle's own trait test is converted to a `WebTestCase`, which required wiring the minimal kernel so it actually boots.

Key changes:
* `bootCleanClient()` + abstract `bootKernel()`/`getClient()` in `AuthenticatorTestTrait`.
* Test kernel boots for real: registers `ValinorBundle`, keeps `ManageApiClientFactory` + the resolver client public (no firewall to retain them otherwise), sets `app_name`/`secret`/`HOSTNAME_SUFFIX`.
* Adds `symfony/browser-kit` + `symfony/dom-crawler` dev deps.

## Plans for customer communication
None.

## Impact analysis
No runtime/end-user impact — test-support code only (`src/Test`, `tests/`) plus two dev dependencies. Consumers that adopt `bootCleanClient()` must extend Symfony's `WebTestCase` (the trait now declares abstract `bootKernel()`/`getClient()`); existing `setupFake*Token()` usage is unaffected.

## Change type
Improvement

## Justification
Let consuming services stub Manage/Storage auth after a request without the "service already initialized" error introduced by the token-exchange wiring (DMD-1475).

## Deployment
Merge & automatic deploy.

## Rollback plan
Revert of this PR.

## Post release support plan
None.
