### PR TITLE
PAT-1866 Split-publish php-api-client-base library

### DIFF
--- a/azure-pipelines.tags.yml
+++ b/azure-pipelines.tags.yml
@@ -30,6 +30,10 @@ resources:
       type: github
       endpoint: keboola
       name: keboola/git-service-php-api-client
+    - repository: php-api-client-base
+      type: github
+      endpoint: keboola
+      name: keboola/php-api-client-base
     - repository: input-mapping
       type: github
       endpoint: keboola
@@ -143,6 +147,14 @@ jobs:
       targetRepo: git-service-php-api-client
       libraryPath: libs/git-service-api-client
       tagPrefix: git-service-api-client/
+
+  - template: azure-pipelines/jobs/split-library.yml
+    parameters:
+      condition: startsWith(variables['Build.SourceBranch'], 'refs/tags/php-api-client-base/')
+      sourceRepo: platform-libraries
+      targetRepo: php-api-client-base
+      libraryPath: libs/php-api-client-base
+      tagPrefix: php-api-client-base/
 
   - template: azure-pipelines/jobs/split-library.yml
     parameters:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -30,6 +30,10 @@ resources:
       type: github
       endpoint: keboola
       name: keboola/git-service-php-api-client
+    - repository: php-api-client-base
+      type: github
+      endpoint: keboola
+      name: keboola/php-api-client-base
     - repository: input-mapping
       type: github
       endpoint: keboola
@@ -438,6 +442,14 @@ stages:
           targetRepo: git-service-php-api-client
           libraryPath: libs/git-service-api-client
           tagPrefix: git-service-api-client/
+
+      - template: azure-pipelines/jobs/split-library.yml
+        parameters:
+          condition: and(succeeded(), stageDependencies.build.checkChanges.outputs['findChanges.changedProjects_phpApiClientBase'])
+          sourceRepo: platform-libraries
+          targetRepo: php-api-client-base
+          libraryPath: libs/php-api-client-base
+          tagPrefix: php-api-client-base/
 
       - template: azure-pipelines/jobs/split-library.yml
         parameters:


### PR DESCRIPTION
## Release Notes
https://linear.app/keboola/issue/PAT-1866/unified-api-client-base

> [!NOTE]
> Registrace base API client lib, aby se po buildu splitovala do vlasntiho repa a dala se vypublikovat jako package

The new `keboola/php-api-client-base` library (added to the monorepo in #513) is the shared HTTP/auth/retry/JSON base that the migrated Keboola service clients (`vault-api-client`, `sandboxes-service-api-client`, `git-service-api-client`, and the remaining ones) now depend on. For those clients to require it from Packagist, the library has to be split-published from `platform-libraries` to the read-only `keboola/php-api-client-base` repo — same mechanism as every other split library here.

This wires that up: a `php-api-client-base` GitHub repository resource plus a `split-library.yml` job in both pipelines. In `azure-pipelines.yml` the split runs on `main` gated by the existing `changedProjects_phpApiClientBase` change-detection flag (already added in #513); in `azure-pipelines.tags.yml` it runs on `php-api-client-base/*` tags. `targetRepo`, `libraryPath`, and `tagPrefix` are all `php-api-client-base` (unlike `git-service`, whose lib dir and target repo names differ).

## Plans for customer communication
None.

## Impact analysis
No end-user impact. CI/release tooling only — adds a publish target for a single library.

## Change type
Maintenance

## Justification
Publish the new `php-api-client-base` library so dependent Keboola service clients can require it from Packagist.

## Deployment
Merge & automatic deploy.

## Rollback plan
Revert of this PR.

## Post release support plan
None.
