### PR TITLE
PAT-1866 Per-client exception types and HTTP context on the base client

### DIFF
--- a/libs/php-api-client-base/src/ApiClient.php
+++ b/libs/php-api-client-base/src/ApiClient.php
@@ -25,9 +25,17 @@ class ApiClient
     private readonly GuzzleClient $httpClient;
     private readonly ErrorMessageResolverInterface $errorMessageResolver;
 
+    /** @var class-string<ClientException> */
+    private readonly string $exceptionClass;
+
     /**
      * @param non-empty-string|null $baseUrl
      * @param list<int> $retryableStatusCodes Non-5xx status codes to also retry (e.g. [429]).
+     * @param class-string<ClientException> $exceptionClass Exception class thrown on failure; a
+     *     ClientException subclass lets callers identify the failing service. It is instantiated
+     *     inline at each throw site so the exception originates there (clean stack trace). A
+     *     subclass that wants richer construction does it in its own constructor, which receives
+     *     ($message, $code, $previous, $statusCode, $responseBody).
      */
     public function __construct(
         ?string $baseUrl,
@@ -35,9 +43,11 @@ class ApiClient
         ?ApiClientOptions $options = null,
         ?ErrorMessageResolverInterface $errorMessageResolver = null,
         array $retryableStatusCodes = [],
+        string $exceptionClass = ClientException::class,
     ) {
         $options ??= new ApiClientOptions();
         $this->errorMessageResolver = $errorMessageResolver ?? new DefaultErrorMessageResolver();
+        $this->exceptionClass = $exceptionClass;
         $logger = $options->logger ?? new NullLogger();
 
         $stack = $options->requestHandler instanceof HandlerStack
@@ -121,11 +131,18 @@ class ApiClient
         bool $isList = false,
     ) {
         $response = $this->doSendRequest($request, $options);
+        $body = $response->getBody()->getContents();
 
         try {
-            $data = Json::decodeArray($response->getBody()->getContents());
+            $data = Json::decodeArray($body);
         } catch (JsonException $e) {
-            throw new ClientException('Response is not valid JSON: ' . $e->getMessage(), 0, $e);
+            throw new $this->exceptionClass(
+                'Response is not valid JSON: ' . $e->getMessage(),
+                0,
+                $e,
+                $response->getStatusCode(),
+                $body,
+            );
         }
 
         try {
@@ -138,7 +155,13 @@ class ApiClient
             }
             return $responseClass::fromResponseData($data);
         } catch (Throwable $e) {
-            throw new ClientException('Failed to map response data: ' . $e->getMessage(), 0, $e);
+            throw new $this->exceptionClass(
+                'Failed to map response data: ' . $e->getMessage(),
+                0,
+                $e,
+                $response->getStatusCode(),
+                $body,
+            );
         }
     }
 
@@ -152,11 +175,11 @@ class ApiClient
         } catch (RequestException $e) {
             throw $this->processRequestException($e);
         } catch (GuzzleException $e) {
-            throw new ClientException($e->getMessage(), 0, $e);
+            throw new $this->exceptionClass($e->getMessage(), 0, $e, null, null);
         } catch (Throwable $e) {
             // Non-Guzzle failure bubbling out of the handler stack — e.g. an authenticator
             // that could not produce credentials (after retries are exhausted).
-            throw new ClientException(trim($e->getMessage()), 0, $e);
+            throw new $this->exceptionClass(trim($e->getMessage()), 0, $e, null, null);
         }
     }
 
@@ -164,13 +187,13 @@ class ApiClient
     {
         $response = $e->getResponse();
         if ($response === null) {
-            return new ClientException(trim($e->getMessage()), 0, $e);
+            return new $this->exceptionClass(trim($e->getMessage()), 0, $e, null, null);
         }
 
         $statusCode = $response->getStatusCode();
         $body = (string) $response->getBody();
 
         $message = ($this->errorMessageResolver)($body, $statusCode);
-        return new ClientException($message ?? trim($e->getMessage()), $statusCode, $e);
+        return new $this->exceptionClass($message ?? trim($e->getMessage()), $statusCode, $e, $statusCode, $body);
     }
 }

--- a/libs/php-api-client-base/src/Exception/ClientException.php
+++ b/libs/php-api-client-base/src/Exception/ClientException.php
@@ -5,7 +5,34 @@ declare(strict_types=1);
 namespace Keboola\ApiClientBase\Exception;
 
 use RuntimeException;
+use Throwable;
 
 class ClientException extends RuntimeException
 {
+    public function __construct(
+        string $message = '',
+        int $code = 0,
+        ?Throwable $previous = null,
+        private readonly ?int $statusCode = null,
+        private readonly ?string $responseBody = null,
+    ) {
+        parent::__construct($message, $code, $previous);
+    }
+
+    /**
+     * HTTP status code of the failing response, or null when there was no response
+     * (transport/connection/authenticator failure).
+     */
+    public function getStatusCode(): ?int
+    {
+        return $this->statusCode;
+    }
+
+    /**
+     * Raw response body when available, otherwise null.
+     */
+    public function getResponseBody(): ?string
+    {
+        return $this->responseBody;
+    }
 }

--- a/libs/php-api-client-base/tests/ApiClientTest.php
+++ b/libs/php-api-client-base/tests/ApiClientTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Keboola\ApiClientBase\Tests;
 
+use GuzzleHttp\Exception\ConnectException;
 use GuzzleHttp\Handler\MockHandler;
 use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Psr7\Request;
@@ -15,6 +16,7 @@ use Keboola\ApiClientBase\Auth\NoAuthAuthenticator;
 use Keboola\ApiClientBase\Auth\RequestAuthenticatorInterface;
 use Keboola\ApiClientBase\ErrorMessageResolverInterface;
 use Keboola\ApiClientBase\Exception\ClientException;
+use Keboola\ApiClientBase\Tests\Fixtures\DummyClientException;
 use Keboola\ApiClientBase\Tests\Fixtures\DummyModel;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\RequestInterface;
@@ -202,5 +204,121 @@ class ApiClientTest extends TestCase
 
         // initial attempt + one retry — the auth failure went through RetryDecider
         self::assertSame(2, $authenticator->calls);
+    }
+
+    public function testThrowsConfiguredExceptionClass(): void
+    {
+        $mock = new MockHandler([new Response(400, [], '{"error":"bad"}')]);
+        $client = new ApiClient(
+            'https://example.test',
+            new NoAuthAuthenticator(),
+            new ApiClientOptions(requestHandler: HandlerStack::create($mock)),
+            exceptionClass: DummyClientException::class,
+        );
+
+        try {
+            $client->sendRequest(new Request('GET', 'foo'));
+            self::fail('Expected exception');
+        } catch (ClientException $e) {
+            self::assertInstanceOf(DummyClientException::class, $e);
+        }
+    }
+
+    public function testPopulatesStatusCodeAndResponseBodyOnHttpError(): void
+    {
+        $mock = new MockHandler([new Response(409, [], '{"error":"conflict"}')]);
+        $client = new ApiClient(
+            'https://example.test',
+            new NoAuthAuthenticator(),
+            new ApiClientOptions(requestHandler: HandlerStack::create($mock)),
+        );
+
+        try {
+            $client->sendRequest(new Request('GET', 'foo'));
+            self::fail('Expected exception');
+        } catch (ClientException $e) {
+            self::assertSame(409, $e->getStatusCode());
+            self::assertSame('{"error":"conflict"}', $e->getResponseBody());
+        }
+    }
+
+    public function testStatusCodeNullOnTransportError(): void
+    {
+        $mock = new MockHandler([
+            new ConnectException('Connection refused', new Request('GET', 'foo')),
+        ]);
+        $client = new ApiClient(
+            'https://example.test',
+            new NoAuthAuthenticator(),
+            new ApiClientOptions(backoffMaxTries: 0, requestHandler: HandlerStack::create($mock)),
+        );
+
+        try {
+            $client->sendRequest(new Request('GET', 'foo'));
+            self::fail('Expected exception');
+        } catch (ClientException $e) {
+            self::assertNull($e->getStatusCode());
+            self::assertNull($e->getResponseBody());
+        }
+    }
+
+    public function testDefaultExceptionOriginatesInApiClient(): void
+    {
+        // Clean-trace guard: the exception is constructed inline at the throw site, so its
+        // origin stays in ApiClient rather than in a factory/builder frame.
+        $mock = new MockHandler([new Response(400, [], 'bad')]);
+        $client = new ApiClient(
+            'https://example.test',
+            new NoAuthAuthenticator(),
+            new ApiClientOptions(requestHandler: HandlerStack::create($mock)),
+        );
+
+        try {
+            $client->sendRequest(new Request('GET', 'foo'));
+            self::fail('Expected exception');
+        } catch (ClientException $e) {
+            self::assertStringContainsString('ApiClient.php', $e->getFile());
+        }
+    }
+
+    public function testPopulatesContextOnInvalidJsonResponse(): void
+    {
+        $mock = new MockHandler([new Response(200, [], 'not json')]);
+        $client = new ApiClient(
+            'https://example.test',
+            new NoAuthAuthenticator(),
+            new ApiClientOptions(requestHandler: HandlerStack::create($mock)),
+        );
+
+        try {
+            $client->sendRequestAndMapResponse(new Request('GET', 'foo'), DummyModel::class);
+            self::fail('Expected exception');
+        } catch (ClientException $e) {
+            self::assertStringContainsString('Response is not valid JSON', $e->getMessage());
+            self::assertSame(200, $e->getStatusCode());
+            self::assertSame('not json', $e->getResponseBody());
+        }
+    }
+
+    public function testPopulatesContextOnMappingFailure(): void
+    {
+        // DummyModel::fromResponseData asserts is_string($data['name']); passing an integer
+        // triggers AssertionError (a Throwable), exercising the mapping-failure branch.
+        $body = '{"name":123}';
+        $mock = new MockHandler([new Response(200, [], $body)]);
+        $client = new ApiClient(
+            'https://example.test',
+            new NoAuthAuthenticator(),
+            new ApiClientOptions(requestHandler: HandlerStack::create($mock)),
+        );
+
+        try {
+            $client->sendRequestAndMapResponse(new Request('GET', 'foo'), DummyModel::class);
+            self::fail('Expected exception');
+        } catch (ClientException $e) {
+            self::assertStringContainsString('Failed to map response data', $e->getMessage());
+            self::assertSame(200, $e->getStatusCode());
+            self::assertSame($body, $e->getResponseBody());
+        }
     }
 }

--- a/libs/php-api-client-base/tests/Exception/ClientExceptionTest.php
+++ b/libs/php-api-client-base/tests/Exception/ClientExceptionTest.php
@@ -10,11 +10,27 @@ use RuntimeException;
 
 class ClientExceptionTest extends TestCase
 {
-    public function testIsRuntimeException(): void
+    public function testDefaults(): void
     {
-        $e = new ClientException('boom', 500);
+        $e = new ClientException('boom');
+
         self::assertInstanceOf(RuntimeException::class, $e);
         self::assertSame('boom', $e->getMessage());
+        self::assertSame(0, $e->getCode());
+        self::assertNull($e->getPrevious());
+        self::assertNull($e->getStatusCode());
+        self::assertNull($e->getResponseBody());
+    }
+
+    public function testCarriesContext(): void
+    {
+        $previous = new RuntimeException('prev');
+        $e = new ClientException('boom', 500, $previous, 404, '{"error":"not found"}');
+
+        self::assertSame('boom', $e->getMessage());
         self::assertSame(500, $e->getCode());
+        self::assertSame($previous, $e->getPrevious());
+        self::assertSame(404, $e->getStatusCode());
+        self::assertSame('{"error":"not found"}', $e->getResponseBody());
     }
 }

--- a/libs/php-api-client-base/tests/Fixtures/DummyClientException.php
+++ b/libs/php-api-client-base/tests/Fixtures/DummyClientException.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Keboola\ApiClientBase\Tests\Fixtures;
+
+use Keboola\ApiClientBase\Exception\ClientException;
+
+final class DummyClientException extends ClientException
+{
+}


### PR DESCRIPTION
## Release Notes
https://linear.app/keboola/issue/PAT-1866/unified-api-client-base

> [!NOTE]
> Diky tomuhle se vsechny chyby neslijou do jendoho univerzalniho `ClientException`, ale kazdy klient si zachova svuj exception scope (dokazes rozlisit, ze kteryho klienta exception vystrelila)

When the Keboola service clients were migrated onto the shared `keboola/php-api-client-base`, they all began throwing the single base `ClientException`, so a caller using several clients could no longer tell *which* client failed — previously each client shipped its own exception type and the class alone identified the source. This change restores per-client identification and, while we're here, gives the base exception structured HTTP context.

`ApiClient` gains a facade-supplied `exceptionClass` argument — a `class-string<ClientException>`, default `ClientException::class`. The base instantiates it **inline at each throw site**, so each service client can have the base throw its own `XClientException extends ClientException`: consumers `catch (VaultClientException)` for one client or `catch (ClientException)` for any Keboola client, and the stack trace is unchanged from before (inline `new`, no factory/helper frame — a subclass that wants richer construction does it in its own constructor, which receives `($message, $code, $previous, $statusCode, $responseBody)`). `ClientException` now also carries `getStatusCode()` / `getResponseBody()`, populated at every throw site (null for transport-level failures with no response). Everything is additive and back-compatible — the default path behaves exactly as before.

Key changes:
* `ApiClient`: new optional last ctor arg `exceptionClass` (`class-string<ClientException>`, default `ClientException::class`), instantiated **inline** at each throw site.
* `ClientException`: optional `statusCode`/`responseBody` (4th/5th ctor args) + `getStatusCode(): ?int` / `getResponseBody(): ?string`; `code` still equals the HTTP status for back-compat.
* Clean trace preserved by inline instantiation — no factory, closure, `makeException()` helper, or static named constructor (any of which would move the origin into themselves and add a trace frame). Customization is via the client's own subclass constructor.
* Per-client exception subclasses (e.g. `VaultClientException`) are intentionally **not** in this PR — they land in each client's own PR.

Design: `docs/superpowers/specs/2026-06-16-client-exception-model-design.md` (kept on the `pepa/common-api-lib-docs` branch, out of this PR).

## Plans for customer communication
None.

## Impact analysis
No end-user impact. Additive and fully back-compatible: existing callers keep receiving `ClientException`, and clients opt in by adding their own subclass and passing it. Base-lib minor release.

## Change type
Improvement

## Justification
Restore per-client exception identification that was lost when clients migrated onto the shared base, and expose HTTP status/body for programmatic error handling.

## Deployment
Merge & automatic deploy. Tag `php-api-client-base/1.1.0` to publish to Packagist.

## Rollback plan
Revert of this PR.

## Post release support plan
None.
