### PR TITLE
[AJDA-2322] Fix affected-libraries detection after force-push/rebase

### DIFF
--- a/bin/ci/affected-libraries.php
+++ b/bin/ci/affected-libraries.php
@@ -8,7 +8,6 @@ use Keboola\PlatformLibrariesCi\AffectedLibrariesResolver;
 require __DIR__ . '/vendor/autoload.php';
 
 $repoRoot = dirname(__DIR__, 2);
-$base = $argv[1] ?? '';
 
 /**
  * @return array<string, array{name: string, devDeps: list<string>}>
@@ -53,28 +52,94 @@ function gitChangedPaths(string $repoRoot, string $base): array
     return array_values(array_filter(array_map('trim', $output), static fn (string $l): bool => $l !== ''));
 }
 
-try {
+function gitCommitExists(string $repoRoot, string $ref): bool
+{
+    $cmd = sprintf(
+        'git -C %s cat-file -e %s 2>/dev/null',
+        escapeshellarg($repoRoot),
+        escapeshellarg($ref . '^{commit}'),
+    );
+    exec($cmd, $output, $exitCode);
+    return $exitCode === 0;
+}
+
+function gitSingleLine(string $repoRoot, string $subcommand): ?string
+{
+    $cmd = sprintf('git -C %s %s 2>/dev/null', escapeshellarg($repoRoot), $subcommand);
+    exec($cmd, $output, $exitCode);
+    if ($exitCode !== 0 || $output === []) {
+        return null;
+    }
+    $line = trim($output[0]);
+    return $line !== '' ? $line : null;
+}
+
+/**
+ * Decide which commit to diff HEAD against.
+ *
+ * Normally this is github.event.before (the ref tip before the push). After a
+ * force-push/rebase — or on a branch's first push — that SHA is zero or points to
+ * an orphaned commit absent from the checkout, so before..HEAD cannot be computed.
+ * Fall back to the merge-base with main to capture the branch's real changes instead
+ * of retesting the whole monorepo. Returns null when no usable base exists (e.g. on
+ * main itself), letting the caller test everything.
+ */
+function resolveBase(string $repoRoot, string $before): ?string
+{
+    $isZeroOrEmpty = $before === '' || preg_match('/^0{40}$/', $before) === 1;
+    if (!$isZeroOrEmpty && gitCommitExists($repoRoot, $before)) {
+        return $before;
+    }
+
+    $mainRef = null;
+    foreach (['origin/main', 'main'] as $ref) {
+        if (gitCommitExists($repoRoot, $ref)) {
+            $mainRef = $ref;
+            break;
+        }
+    }
+    if ($mainRef === null) {
+        return null;
+    }
+
+    $mergeBase = gitSingleLine($repoRoot, sprintf('merge-base %s HEAD', escapeshellarg($mainRef)));
+    $head = gitSingleLine($repoRoot, 'rev-parse HEAD');
+    if ($mergeBase === null || $mergeBase === $head) {
+        return null;
+    }
+    return $mergeBase;
+}
+
+/**
+ * @return list<string> affected library dirs (sorted), or all dirs on fallback
+ */
+function resolveAffected(string $repoRoot, string $before): array
+{
     $packages = loadPackages($repoRoot);
     $resolver = new AffectedLibrariesResolver($packages);
 
-    // Zero SHA / empty base / first commit -> test everything.
-    if ($base === '' || preg_match('/^0{40}$/', $base) === 1) {
-        echo json_encode($resolver->allDirs()), "\n";
-        exit(0);
+    try {
+        $base = resolveBase($repoRoot, $before);
+        if ($base === null) {
+            // No usable base (push to main itself, no main ancestry, ...) -> test everything.
+            return $resolver->allDirs();
+        }
+
+        $changed = gitChangedPaths($repoRoot, $base);
+
+        if ($resolver->isFallbackToAll($changed)) {
+            return $resolver->allDirs();
+        }
+
+        return $resolver->resolve($changed);
+    } catch (Throwable $e) {
+        fwrite(STDERR, 'affected-libraries failed, falling back to all: ' . $e->getMessage() . "\n");
+        return $resolver->allDirs();
     }
+}
 
-    $changed = gitChangedPaths($repoRoot, $base);
-
-    if ($resolver->isFallbackToAll($changed)) {
-        echo json_encode($resolver->allDirs()), "\n";
-        exit(0);
-    }
-
-    echo json_encode($resolver->resolve($changed)), "\n";
-    exit(0);
-} catch (Throwable $e) {
-    fwrite(STDERR, 'affected-libraries failed, falling back to all: ' . $e->getMessage() . "\n");
-    $packages = loadPackages($repoRoot);
-    echo json_encode((new AffectedLibrariesResolver($packages))->allDirs()), "\n";
+// Run only when executed directly as a CLI script (not when included by tests).
+if (isset($argv[0]) && realpath($argv[0]) === realpath(__FILE__)) {
+    echo json_encode(resolveAffected($repoRoot, $argv[1] ?? '')), "\n";
     exit(0);
 }

--- a/bin/ci/tests/AffectedLibrariesScriptTest.php
+++ b/bin/ci/tests/AffectedLibrariesScriptTest.php
@@ -1,0 +1,129 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Keboola\PlatformLibrariesCi\Tests;
+
+use PHPUnit\Framework\TestCase;
+use function ob_get_clean;
+use function ob_start;
+use function resolveAffected;
+
+// Load the script's functions without executing its CLI entrypoint (guarded by the
+// realpath check at the bottom of the file). The shebang line is swallowed by ob_*.
+ob_start();
+require_once dirname(__DIR__) . '/affected-libraries.php';
+ob_get_clean();
+
+class AffectedLibrariesScriptTest extends TestCase
+{
+    /** @var list<string> */
+    private array $repos = [];
+
+    protected function tearDown(): void
+    {
+        foreach ($this->repos as $repo) {
+            exec(sprintf('rm -rf %s', escapeshellarg($repo)));
+        }
+        $this->repos = [];
+        parent::tearDown();
+    }
+
+    public function testValidBeforeDiffsOnlyThatPush(): void
+    {
+        $repo = $this->initRepo();
+        $mainTip = $this->git($repo, 'rev-parse HEAD');
+        $this->git($repo, 'checkout -q -b feature');
+        $this->commitChange($repo, 'libs/lib-b/src/X.php', 'change-b', 'change b');
+
+        self::assertSame(['lib-b'], resolveAffected($repo, $mainTip));
+    }
+
+    public function testOrphanBeforeFallsBackToMergeBase(): void
+    {
+        // Reproduces the force-push/rebase bug: `before` points to a commit that is not
+        // present in the checkout, so before..HEAD is impossible -> diff against main.
+        $repo = $this->initRepo();
+        $this->git($repo, 'checkout -q -b feature');
+        $this->commitChange($repo, 'libs/lib-b/src/X.php', 'change-b', 'change b');
+
+        $orphan = '21b5f3b7950cc9fe16df59e3ab0398647e0a9554';
+        self::assertSame(['lib-b'], resolveAffected($repo, $orphan));
+    }
+
+    public function testZeroBeforeFallsBackToMergeBase(): void
+    {
+        $repo = $this->initRepo();
+        $this->git($repo, 'checkout -q -b feature');
+        $this->commitChange($repo, 'libs/lib-a/src/X.php', 'change-a', 'change a');
+
+        // lib-b depends on lib-a, so changing lib-a affects both.
+        self::assertSame(['lib-a', 'lib-b'], resolveAffected($repo, str_repeat('0', 40)));
+    }
+
+    public function testOnMainTestsEverything(): void
+    {
+        // On main the merge-base equals HEAD -> no usable base -> test everything.
+        $repo = $this->initRepo();
+        self::assertSame(['lib-a', 'lib-b'], resolveAffected($repo, str_repeat('0', 40)));
+    }
+
+    public function testInfraChangeTestsEverything(): void
+    {
+        $repo = $this->initRepo();
+        $mainTip = $this->git($repo, 'rev-parse HEAD');
+        $this->git($repo, 'checkout -q -b feature');
+        $this->commitChange($repo, 'composer.json', '{}', 'touch root composer.json');
+
+        self::assertSame(['lib-a', 'lib-b'], resolveAffected($repo, $mainTip));
+    }
+
+    private function initRepo(): string
+    {
+        $repo = sys_get_temp_dir() . '/aff-' . bin2hex(random_bytes(6));
+        mkdir($repo, 0777, true);
+        $this->repos[] = $repo;
+
+        $this->git($repo, 'init -q -b main');
+        $this->git($repo, 'config user.email test@example.com');
+        $this->git($repo, 'config user.name Test');
+        $this->git($repo, 'config commit.gpgsign false');
+
+        $this->writeComposer($repo, 'lib-a', ['name' => 'keboola/lib-a']);
+        $this->writeComposer($repo, 'lib-b', ['name' => 'keboola/lib-b', 'require' => ['keboola/lib-a' => '*@dev']]);
+        $this->git($repo, 'add -A');
+        $this->git($repo, 'commit -q -m init');
+
+        return $repo;
+    }
+
+    /**
+     * @param array<string, mixed> $json
+     */
+    private function writeComposer(string $repo, string $lib, array $json): void
+    {
+        $dir = $repo . '/libs/' . $lib;
+        mkdir($dir, 0777, true);
+        file_put_contents($dir . '/composer.json', (string) json_encode($json));
+    }
+
+    private function commitChange(string $repo, string $path, string $content, string $message): void
+    {
+        $full = $repo . '/' . $path;
+        $dir = dirname($full);
+        if (!is_dir($dir)) {
+            mkdir($dir, 0777, true);
+        }
+        file_put_contents($full, $content);
+        $this->git($repo, 'add -A');
+        $this->git($repo, 'commit -q -m ' . escapeshellarg($message));
+    }
+
+    private function git(string $repo, string $args): string
+    {
+        $command = sprintf('git -C %s %s 2>&1', escapeshellarg($repo), $args);
+        exec($command, $output, $exitCode);
+        self::assertSame(0, $exitCode, sprintf('git %s failed: %s', $args, implode("\n", $output)));
+        return trim(implode("\n", $output));
+    }
+}


### PR DESCRIPTION
## Problem

When a branch is force-pushed (e.g. after a rebase), `github.event.before` points to the pre-rewrite tip, which becomes an orphaned commit not reachable from any ref. `actions/checkout` (even with `fetch-depth: 0`) only fetches ref-reachable history, so that SHA is absent from the runner's clone:

```
fatal: bad object 21b5f3b7...
affected-libraries failed, falling back to all: git diff failed (exit 128)
```

The `detect-changes` step then fell back to testing **all 22 libraries**, even when the branch only touched one (observed on PR #511, which changed only `libs/input-mapping/**`).

## Fix

`bin/ci/affected-libraries.php` now resolves the diff base more robustly:

- `github.event.before` stays the primary base — a normal push still diffs only its own commits (base-branch agnostic).
- When `before` is empty / all-zeros / **not present** in the checkout (force-push, rebase, first push), fall back to `merge-base origin/main HEAD` (tries `origin/main`, then `main`) and diff against that — so only the branch's real changes are resolved, not the whole monorepo.
- A `merge-base == HEAD` guard returns "no usable base" (→ test everything), which keeps pushes to `main` correct.
- Diffing against `main` only ever over-includes for branches stacked on another branch; it never under-tests.

The runner is wrapped in `resolveAffected()` behind a CLI guard so the logic is unit-testable.

## Tests

New `bin/ci/tests/AffectedLibrariesScriptTest.php` runs against real temporary git repos and covers: valid `before`, orphan/bad `before` (the reproduced bug), zero `before`, push to `main`, and infra changes. `composer ci` (phpcs + phpstan max + phpunit) passes.