### PR TITLE
PAT-1866 Return the response from ApiClient::sendRequest()

### DIFF
--- a/libs/php-api-client-base/src/ApiClient.php
+++ b/libs/php-api-client-base/src/ApiClient.php
@@ -113,9 +113,22 @@ class ApiClient
         ]);
     }
 
-    public function sendRequest(RequestInterface $request): void
+    /**
+     * @param array<string, mixed> $options
+     */
+    public function sendRequest(RequestInterface $request, array $options = []): ResponseInterface
     {
-        $this->doSendRequest($request);
+        try {
+            return $this->httpClient->send($request, $options);
+        } catch (RequestException $e) {
+            throw $this->processRequestException($e);
+        } catch (GuzzleException $e) {
+            throw new $this->exceptionClass($e->getMessage(), 0, $e, null, null);
+        } catch (Throwable $e) {
+            // Non-Guzzle failure bubbling out of the handler stack — e.g. an authenticator
+            // that could not produce credentials (after retries are exhausted).
+            throw new $this->exceptionClass(trim($e->getMessage()), 0, $e, null, null);
+        }
     }
 
     /**
@@ -130,7 +143,7 @@ class ApiClient
         array $options = [],
         bool $isList = false,
     ) {
-        $response = $this->doSendRequest($request, $options);
+        $response = $this->sendRequest($request, $options);
         $body = $response->getBody()->getContents();
 
         try {
@@ -162,24 +175,6 @@ class ApiClient
                 $response->getStatusCode(),
                 $body,
             );
-        }
-    }
-
-    /**
-     * @param array<string, mixed> $options
-     */
-    private function doSendRequest(RequestInterface $request, array $options = []): ResponseInterface
-    {
-        try {
-            return $this->httpClient->send($request, $options);
-        } catch (RequestException $e) {
-            throw $this->processRequestException($e);
-        } catch (GuzzleException $e) {
-            throw new $this->exceptionClass($e->getMessage(), 0, $e, null, null);
-        } catch (Throwable $e) {
-            // Non-Guzzle failure bubbling out of the handler stack — e.g. an authenticator
-            // that could not produce credentials (after retries are exhausted).
-            throw new $this->exceptionClass(trim($e->getMessage()), 0, $e, null, null);
         }
     }
 

--- a/libs/php-api-client-base/tests/ApiClientTest.php
+++ b/libs/php-api-client-base/tests/ApiClientTest.php
@@ -53,6 +53,19 @@ class ApiClientTest extends TestCase
         self::assertSame('secret-token', $last->getHeaderLine('X-KBC-ManageApiToken'));
     }
 
+    public function testSendRequestReturnsResponse(): void
+    {
+        $mock = new MockHandler([new Response(201, [], '{"hello":"world"}')]);
+        $client = new ApiClient('https://example.test', new NoAuthAuthenticator(), new ApiClientOptions(
+            requestHandler: HandlerStack::create($mock),
+        ));
+
+        $response = $client->sendRequest(new Request('GET', 'foo'));
+
+        self::assertSame(201, $response->getStatusCode());
+        self::assertSame('{"hello":"world"}', (string) $response->getBody());
+    }
+
     public function testMapsResponseToModel(): void
     {
         $mock = new MockHandler([new Response(200, [], '{"name":"foo"}')]);


### PR DESCRIPTION
## Release Notes
https://linear.app/keboola/issue/PAT-1866

`ApiClient::sendRequest()` previously returned `void`, discarding the response. This changes it to return the `ResponseInterface` — a backward-compatible widening, so existing callers that ignore the return value are unaffected.

This lets a client decode the raw response body itself when the array-based `sendRequestAndMapResponse()` is unsuitable — e.g. payloads that must preserve the JSON object/array distinction, which an associative-array decode would lose (`{}` collapses to `[]`, integer-keyed objects get renumbered). The first consumer is the `sync-actions-api-php-client` migration.

Now that `sendRequest()` returns the response, the private `doSendRequest()` was a redundant indirection — it is folded into `sendRequest()`, which gains the optional per-request `$options` (already public via `sendRequestAndMapResponse()`).

## Plans for customer communication
None.

## Impact analysis
No end-user impact. Backward-compatible for all existing consumers — a `void` method now returns a value callers may ignore. The four already-migrated clients (vault, sandboxes, git-service, configuration-variables-resolver) are exercised by CI here and are unaffected.

## Change type
Improvement

## Justification
Enable clients to decode raw response bodies, needed by the sync-actions migration (PAT-1866).

## Deployment
Merge & automatic deploy.

## Rollback plan
Revert of this PR.

## Post release support plan
None.
