### PR TITLE
PAT-1767 Move managedGitRepo under spec.features in the App CRD model

### DIFF
--- a/libs/k8s-client/src/Model/Io/Keboola/Apps/V2/AppFeatures.php
+++ b/libs/k8s-client/src/Model/Io/Keboola/Apps/V2/AppFeatures.php
@@ -45,4 +45,13 @@ class AppFeatures extends AbstractModel
      * @var WorkspaceSpec
      */
     public $workspace = null;
+
+    /**
+     * ManagedGitRepo, when set, signals that the operator should mint per-AppRun
+     * ephemeral git credentials (HTTP token or SSH key) and overlay them into the
+     * rendered config.json Secret. Requires mountConfig to be set.
+     *
+     * @var ManagedGitRepoSpec|null
+     */
+    public $managedGitRepo = null;
 }

--- a/libs/k8s-client/src/Model/Io/Keboola/Apps/V2/AppSpec.php
+++ b/libs/k8s-client/src/Model/Io/Keboola/Apps/V2/AppSpec.php
@@ -91,13 +91,4 @@ class AppSpec extends AbstractModel
      * @var AppDevModeSpec|null
      */
     public $devMode = null;
-
-    /**
-     * ManagedGitRepo, when set, signals that the operator should mint per-AppRun
-     * ephemeral git credentials (HTTP token or SSH key) and overlay them into the
-     * rendered config.json Secret. Requires mountConfig to be set.
-     *
-     * @var ManagedGitRepoSpec|null
-     */
-    public $managedGitRepo = null;
 }

--- a/libs/k8s-client/tests/Model/V2/AppModelTest.php
+++ b/libs/k8s-client/tests/Model/V2/AppModelTest.php
@@ -71,11 +71,11 @@ class AppModelTest extends TestCase
                     'gitPollInterval' => '5s',
                     'autoRunSetupOnDepChange' => false,
                 ],
-                'managedGitRepo' => [
-                    'repoId' => 'repo-abc-123',
-                    'credentialType' => 'ssh_key',
-                ],
                 'features' => [
+                    'managedGitRepo' => [
+                        'repoId' => 'repo-abc-123',
+                        'credentialType' => 'ssh_key',
+                    ],
                     'storageToken' => [
                         'description' => '[_internal][app] App 12345',
                         'expiresIn' => 86400,
@@ -274,11 +274,12 @@ class AppModelTest extends TestCase
         self::assertSame('5s', $app->spec->devMode->gitPollInterval);
         self::assertFalse($app->spec->devMode->autoRunSetupOnDepChange);
 
-        // ManagedGitRepo
-        self::assertNotNull($app->spec->managedGitRepo);
-        self::assertInstanceOf(ManagedGitRepoSpec::class, $app->spec->managedGitRepo);
-        self::assertSame('repo-abc-123', $app->spec->managedGitRepo->repoId);
-        self::assertSame('ssh_key', $app->spec->managedGitRepo->credentialType);
+        // ManagedGitRepo (under features)
+        self::assertInstanceOf(AppFeatures::class, $app->spec->features);
+        self::assertNotNull($app->spec->features->managedGitRepo);
+        self::assertInstanceOf(ManagedGitRepoSpec::class, $app->spec->features->managedGitRepo);
+        self::assertSame('repo-abc-123', $app->spec->features->managedGitRepo->repoId);
+        self::assertSame('ssh_key', $app->spec->features->managedGitRepo->credentialType);
 
         // Features
         self::assertNotNull($app->spec->features);
@@ -516,10 +517,10 @@ class AppModelTest extends TestCase
         self::assertSame('5s', $serialized['spec']['devMode']['gitPollInterval']);
         self::assertFalse($serialized['spec']['devMode']['autoRunSetupOnDepChange']);
 
-        // Verify managedGitRepo survives round-trip
-        self::assertArrayHasKey('managedGitRepo', $serialized['spec']);
-        self::assertSame('repo-abc-123', $serialized['spec']['managedGitRepo']['repoId']);
-        self::assertSame('ssh_key', $serialized['spec']['managedGitRepo']['credentialType']);
+        // Verify managedGitRepo survives round-trip (under features)
+        self::assertArrayHasKey('managedGitRepo', $serialized['spec']['features']);
+        self::assertSame('repo-abc-123', $serialized['spec']['features']['managedGitRepo']['repoId']);
+        self::assertSame('ssh_key', $serialized['spec']['features']['managedGitRepo']['credentialType']);
 
         // Verify containerSpec is present and podSpec is not
         self::assertArrayHasKey('containerSpec', $serialized['spec']);


### PR DESCRIPTION
## Release Notes
https://linear.app/keboola/issue/PAT-1767/

> [!NOTE]
> Oprava umisteni `managedGitRepo`. Jsem si nevsiml, ze to puvodne Claude hodil do rootu, misto `features`

Corrects the placement of `managedGitRepo` in the typed `k8s-client` App CRD model. The operator's CRD declares it under `spec.features` (a field of the `Features` struct, alongside `mountConfig`), but `4.7.0` mistakenly added it to `AppSpec` (top level). A structural CRD schema prunes unknown top-level spec fields, so a manifest built from the `4.7.0` model would have `managedGitRepo` silently dropped — the operator would never see it and never mint the credential.

This moves `managedGitRepo` from `AppSpec` to `AppFeatures` (the `ManagedGitRepoSpec` class is unchanged; only its parent). The status side (`AppStatus.managedGitCredential`) was already at the correct level and is untouched. `AppModelTest` now nests the fixture under `features` and asserts the corrected path.

Cross-repo:
* sandboxes-service https://github.com/keboola/sandboxes-service/pull/579 — consumer; will bump to this release and set `features.managedGitRepo`.

## Plans for customer communication
None.

## Impact analysis
No runtime impact for current consumers — `managedGitRepo` was added only in `4.7.0` and is not yet used by any released service. This prevents a would-be-silent breakage of the managed-git feature.

## Change type
Fix

## Justification
`4.7.0` placed `managedGitRepo` at the wrong CRD level (`spec` instead of `spec.features`); the operator never reads it there.

## Deployment
Merge & automatic deploy. Tag `k8s-client/4.7.1` after merge to publish the corrected model.

## Rollback plan
Revert of this PR.

## Post release support plan
None.
