### PR TITLE
fix(ci): key-pair workspace login for tests + fast-import-safe tag stripping in split-repo

### DIFF
--- a/bin/split-repo.sh
+++ b/bin/split-repo.sh
@@ -51,14 +51,19 @@ git filter-repo --quiet --subdirectory-filter "${LIB_PATH}" --refname-callback "
 if not refname.startswith(b'refs/tags/'):
   return refname
 
-# tag, but not matching prefix -> SKIP
+# tag, but not matching prefix -> move under a throwaway namespace (deleted below).
+# It must stay UNIQUE per tag (keep the original suffix): collapsing every non-matching
+# tag onto a single ref makes git fast-import abort with
+# 'multiple updates for ref ... not allowed' as soon as two of them are annotated tags
+# (each annotated tag emits its own ref update for the same target ref).
 if not refname.startswith(b'refs/tags/${TAG_PREFIX}'):
-  return b'refs/tags/SKIP'
+  return b'refs/tags/__split_skip__/' + refname[len(b'refs/tags/'):]
 
 # tag, with correct prefix -> strip prefix
 return b'refs/tags/' + refname[len(b'refs/tags/${TAG_PREFIX}'):]
 "
-git update-ref -d refs/tags/SKIP
+# Drop the throwaway tags so they are never pushed.
+git for-each-ref --format='delete %(refname)' 'refs/tags/__split_skip__/' | git update-ref --stdin
 
 echo ">> Push to target repo '${TARGET_REPO_URL}'"
 git remote add origin "${TARGET_REPO_URL}"

--- a/libs/output-mapping/tests/AbstractTestCase.php
+++ b/libs/output-mapping/tests/AbstractTestCase.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Keboola\OutputMapping\Tests;
 
 use InvalidArgumentException;
+use Keboola\KeyGenerator\PemKeyCertificateGenerator;
 use Keboola\OutputMapping\Staging\StrategyFactory;
 use Keboola\OutputMapping\TableLoader;
 use Keboola\OutputMapping\Tests\Needs\TestSatisfyer;
@@ -12,8 +13,10 @@ use Keboola\StagingProvider\Staging\File\FileFormat;
 use Keboola\StagingProvider\Staging\File\FileStagingInterface;
 use Keboola\StagingProvider\Staging\StagingProvider;
 use Keboola\StagingProvider\Staging\StagingType;
+use Keboola\StagingProvider\Workspace\SnowflakeKeypairGenerator;
 use Keboola\StorageApi\ClientException;
 use Keboola\StorageApi\Options\ListFilesOptions;
+use Keboola\StorageApi\WorkspaceLoginType;
 use Keboola\StorageApi\Workspaces;
 use Keboola\StorageApiBranch\ClientWrapper;
 use Keboola\StorageApiBranch\Factory\ClientOptions;
@@ -138,14 +141,25 @@ abstract class AbstractTestCase extends TestCase
 
         $stagingType = StagingType::from('workspace-' . $this->clientWrapper->getToken()->getProjectBackend());
 
-        $workspace = $workspaces->createWorkspace(['backend' => match ($stagingType) {
+        $options = ['backend' => match ($stagingType) {
             StagingType::WorkspaceSnowflake => 'snowflake',
             StagingType::WorkspaceBigquery => 'bigquery',
             default => throw new InvalidArgumentException(sprintf(
                 'Unknown staging %s',
                 $stagingType->value,
             )),
-        }], true);
+        }];
+
+        // Snowflake no longer allows creating workspace users with the legacy service account type, which is
+        // what the empty/default login type maps to. Request a key-pair service login instead and register a
+        // generated public key for it.
+        if ($stagingType === StagingType::WorkspaceSnowflake) {
+            $keyPair = (new SnowflakeKeypairGenerator(new PemKeyCertificateGenerator()))->generateKeyPair();
+            $options['loginType'] = WorkspaceLoginType::SNOWFLAKE_SERVICE_KEYPAIR;
+            $options['publicKey'] = $keyPair->publicKey;
+        }
+
+        $workspace = $workspaces->createWorkspace($options, true);
 
         $this->workspaceId = (string) $workspace['id'];
         $this->workspaceCredentials = $workspace['connection'];

--- a/libs/output-mapping/tests/Needs/TestSatisfyer.php
+++ b/libs/output-mapping/tests/Needs/TestSatisfyer.php
@@ -57,11 +57,11 @@ class TestSatisfyer
     ): string {
         $bucketId = self::getBucketIdByDisplayName($clientWrapper, $bucketName, $stage);
         if ($bucketId !== null) {
-            $tables = $clientWrapper->getTableAndFileStorageClient()->listTables($bucketId, ['include' => '']);
-            foreach ($tables as $table) {
-                $clientWrapper->getTableAndFileStorageClient()->dropTable($table['id']);
-            }
-            return $bucketId;
+            // Force-drop and recreate the bucket instead of emptying it table by table. Dropping the bucket
+            // drops the whole backend schema, which also removes backend objects orphaned by an interrupted
+            // run (e.g. a build cancelled mid-test): those are not tracked as Storage tables, so emptying
+            // would leave them behind and the next table creation would fail with "object already exists".
+            $clientWrapper->getTableAndFileStorageClient()->dropBucket($bucketId, ['force' => true]);
         }
         return $clientWrapper->getTableAndFileStorageClient()->createBucket(
             name: $bucketName,

--- a/libs/query-service-api-client/tests/Functional/BaseFunctionalTestCase.php
+++ b/libs/query-service-api-client/tests/Functional/BaseFunctionalTestCase.php
@@ -9,6 +9,7 @@ use Keboola\QueryApi\Tests\TestEnvVarsTrait;
 use Keboola\StorageApi\BranchAwareClient;
 use Keboola\StorageApi\Client as StorageApiClient;
 use Keboola\StorageApi\DevBranches;
+use Keboola\StorageApi\WorkspaceLoginType;
 use Keboola\StorageApi\Workspaces;
 use PHPUnit\Framework\TestCase;
 use RuntimeException;
@@ -99,13 +100,36 @@ abstract class BaseFunctionalTestCase extends TestCase
     {
         // Create a workspace for testing queries
         $workspaces = new Workspaces($this->branchAwareStorageClient);
+        // Snowflake no longer allows creating workspace users with the legacy service account type (the
+        // empty/default login type). Create the workspace with a key-pair service login so a usable service
+        // user is provisioned; the generated public key is registered with the workspace.
         $workspaceData = $workspaces->createWorkspace([
             'name' => sprintf('query-test-workspace-%d', random_int(1000, 9999)),
             'backend' => 'snowflake',
+            'loginType' => WorkspaceLoginType::SNOWFLAKE_SERVICE_KEYPAIR,
+            'publicKey' => self::generateWorkspacePublicKey(),
         ], true);
 
         /** @var array{id: int|string} $workspaceData */
         $this->testWorkspaceId = (string) $workspaceData['id'];
+    }
+
+    private static function generateWorkspacePublicKey(): string
+    {
+        $key = openssl_pkey_new([
+            'private_key_bits' => 2048,
+            'private_key_type' => OPENSSL_KEYTYPE_RSA,
+        ]);
+        if ($key === false) {
+            throw new RuntimeException('Failed to generate a workspace key pair');
+        }
+
+        $details = openssl_pkey_get_details($key);
+        if ($details === false || !isset($details['key']) || !is_string($details['key'])) {
+            throw new RuntimeException('Failed to extract the workspace public key');
+        }
+
+        return $details['key'];
     }
 
     protected function getTestBranchId(): string

--- a/libs/staging-provider/tests/Workspace/WorkspaceProviderFunctionalTest.php
+++ b/libs/staging-provider/tests/Workspace/WorkspaceProviderFunctionalTest.php
@@ -92,6 +92,15 @@ class WorkspaceProviderFunctionalTest extends TestCase
 
     private function createWorkspace(array $options): array
     {
+        // Snowflake no longer allows creating workspace users with the legacy service account type (the
+        // empty/default login type). Default Snowflake workspaces to a key-pair service login so a usable
+        // service user is created; callers that need a specific login type still set it explicitly.
+        if (($options['backend'] ?? null) === 'snowflake' && !isset($options['loginType'])) {
+            $keyPair = (new SnowflakeKeypairGenerator(new PemKeyCertificateGenerator()))->generateKeyPair();
+            $options['loginType'] = WorkspaceLoginType::SNOWFLAKE_SERVICE_KEYPAIR;
+            $options['publicKey'] = $keyPair->publicKey;
+        }
+
         $workspaceData = $this->workspacesApiClient->createWorkspace($options, async: true);
         $this->createdWorkspaceIds[] = (string) $workspaceData['id'];
         return $workspaceData;


### PR DESCRIPTION
Combined CI/infra fix (folds in #529).

## 1. Test Snowflake workspaces use key-pair login

Snowflake no longer allows creating workspace users with the legacy service account type, which is what the empty/default workspace login type maps to. Every workspace-backed output-mapping functional test failed with:

> Snowflake no longer allows creating workspace users with the legacy service account type ("LEGACY_SERVICE").

`AbstractTestCase::initWorkspace()` now requests `snowflake-service-keypair` for Snowflake test workspaces and registers a generated public key (mirroring the production `WorkspaceProvider`). BigQuery keeps the default login type.

## 2. split-repo.sh: avoid fast-import ref collision when stripping foreign tags

The `publish` job failed for every library with:

```
error: multiple updates for ref 'refs/tags/SKIP' not allowed
```

`split-repo.sh` renamed every tag outside the library's prefix to a single `refs/tags/SKIP` before deleting it. `git fast-import` rejects multiple updates to the same ref, so once two foreign tags are annotated (`k8s-client/4.7.0`, `k8s-client/4.7.1`) the split aborts. Foreign tags are now renamed to a unique throwaway ref (`refs/tags/__split_skip__/<orig>`) and bulk-deleted.

Verified against a fresh mirror of the live monorepo (filter-repo via apt as in CI): old callback fails, new one succeeds and leaves only the prefix-stripped library tags.

## Note

This PR touches `bin/**`, so CI runs all 22 libraries. Other Snowflake-workspace libraries (e.g. staging-provider, query-service-api-client) may still fail on the same legacy-login issue until their test helpers get the same key-pair fix.