### PR TITLE
fix(ci): avoid fast-import ref collision when stripping foreign tags in split-repo

### DIFF
--- a/bin/split-repo.sh
+++ b/bin/split-repo.sh
@@ -51,14 +51,19 @@ git filter-repo --quiet --subdirectory-filter "${LIB_PATH}" --refname-callback "
 if not refname.startswith(b'refs/tags/'):
   return refname
 
-# tag, but not matching prefix -> SKIP
+# tag, but not matching prefix -> move under a throwaway namespace (deleted below).
+# It must stay UNIQUE per tag (keep the original suffix): collapsing every non-matching
+# tag onto a single ref makes git fast-import abort with
+# 'multiple updates for ref ... not allowed' as soon as two of them are annotated tags
+# (each annotated tag emits its own ref update for the same target ref).
 if not refname.startswith(b'refs/tags/${TAG_PREFIX}'):
-  return b'refs/tags/SKIP'
+  return b'refs/tags/__split_skip__/' + refname[len(b'refs/tags/'):]
 
 # tag, with correct prefix -> strip prefix
 return b'refs/tags/' + refname[len(b'refs/tags/${TAG_PREFIX}'):]
 "
-git update-ref -d refs/tags/SKIP
+# Drop the throwaway tags so they are never pushed.
+git for-each-ref --format='delete %(refname)' 'refs/tags/__split_skip__/' | git update-ref --stdin
 
 echo ">> Push to target repo '${TARGET_REPO_URL}'"
 git remote add origin "${TARGET_REPO_URL}"


### PR DESCRIPTION
## Problem

The `publish` job fails for every library with:

```
error: multiple updates for ref 'refs/tags/SKIP' not allowed
Error: fast-import failed; see above.
```

(e.g. [output-mapping publish run](https://github.com/keboola/platform-libraries/actions/runs/27975625821/job/82794944074)).

### Root cause

`bin/split-repo.sh` runs `git filter-repo` with a `--refname-callback` that renames **every** tag outside the published library's prefix to a single `refs/tags/SKIP`, then deletes it:

```python
if not refname.startswith(b'refs/tags/<prefix>'):
  return b'refs/tags/SKIP'
```

`git filter-repo` rewrites history through `git fast-import`, which **refuses multiple updates to the same ref**. Lightweight tags collapsing onto `refs/tags/SKIP` are fine (each is just a `reset`), but an **annotated** tag emits its own ref update — so as soon as **two foreign annotated tags** exist, both target `refs/tags/SKIP` and fast-import aborts.

The monorepo now has two annotated non-library tags (`k8s-client/4.7.0`, `k8s-client/4.7.1`), which is what tipped it over. It was latent before.

## Fix

Rename foreign tags to a **unique** throwaway ref (`refs/tags/__split_skip__/<original>`) so no two collide, then bulk-delete that namespace with `git update-ref --stdin`.

## Verification

Ran both callbacks against a fresh mirror of the live monorepo (in the dev container, `git-filter-repo` installed via apt as CI does):

- **old** callback → `error: multiple updates for ref 'refs/tags/SKIP' not allowed` (exit 1) — reproduces the failure
- **new** callback → success (exit 0); `__split_skip__` namespace cleaned up to 0 refs; library tags correctly prefix-stripped (e.g. `output-mapping/11.1.1` → `11.1.1`, 207 version tags); no foreign `k8s-client` tags leak through

Standalone CI/infra fix, independent of #525 and #528.