### PR TITLE
feat(git-service-api-client): add listCommits and listRefs endpoints (PAT-1890)

### DIFF
--- a/libs/git-service-api-client/src/GitServiceApiClient.php
+++ b/libs/git-service-api-client/src/GitServiceApiClient.php
@@ -13,9 +13,12 @@ use Keboola\ApiClientBase\Auth\KeboolaServiceAccountAuthenticator;
 use Keboola\ApiClientBase\Auth\ManageApiTokenAuthenticator;
 use Keboola\ApiClientBase\Json;
 use Keboola\GitServiceApiClient\Exception\GitServiceClientException;
+use Keboola\GitServiceApiClient\Model\CommitList;
 use Keboola\GitServiceApiClient\Model\CreatedCredential;
 use Keboola\GitServiceApiClient\Model\Credential;
 use Keboola\GitServiceApiClient\Model\CredentialListWrapper;
+use Keboola\GitServiceApiClient\Model\GitRef;
+use Keboola\GitServiceApiClient\Model\GitRefListWrapper;
 use Keboola\GitServiceApiClient\Model\Repository;
 use Psr\Log\LoggerInterface;
 
@@ -137,5 +140,37 @@ class GitServiceApiClient
                 'repos/' . rawurlencode($repo) . '/credentials/' . rawurlencode($credentialId),
             ),
         );
+    }
+
+    /**
+     * List the commit history of a branch or tag, most recent first.
+     *
+     * @param int<1, max> $page  1-based page number
+     * @param int<1, 50> $limit  page size (git-service caps this at 50)
+     */
+    public function listCommits(string $repo, string $ref, int $page = 1, int $limit = 30): CommitList
+    {
+        $query = http_build_query(['page' => $page, 'limit' => $limit]);
+        return $this->apiClient->sendRequestAndMapResponse(
+            new Request(
+                'GET',
+                'repos/' . rawurlencode($repo) . '/refs/' . rawurlencode($ref) . '/commits?' . $query,
+            ),
+            CommitList::class,
+        );
+    }
+
+    /**
+     * List all git references (branches and tags) of a repository.
+     *
+     * @return list<GitRef>
+     */
+    public function listRefs(string $repo): array
+    {
+        $wrapper = $this->apiClient->sendRequestAndMapResponse(
+            new Request('GET', 'repos/' . rawurlencode($repo) . '/refs'),
+            GitRefListWrapper::class,
+        );
+        return $wrapper->refs;
     }
 }

--- a/libs/git-service-api-client/src/Model/Commit.php
+++ b/libs/git-service-api-client/src/Model/Commit.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Keboola\GitServiceApiClient\Model;
+
+use Keboola\ApiClientBase\ResponseModelInterface;
+use Webmozart\Assert\Assert;
+
+final readonly class Commit implements ResponseModelInterface
+{
+    public function __construct(
+        public string $sha,
+        public string $created,
+        public string $message,
+        public CommitAuthor $author,
+    ) {
+    }
+
+    public static function fromResponseData(array $data): static
+    {
+        Assert::keyExists($data, 'sha');
+        Assert::keyExists($data, 'created');
+        Assert::keyExists($data, 'message');
+        Assert::keyExists($data, 'author');
+        Assert::string($data['sha']);
+        Assert::string($data['created']);
+        Assert::string($data['message']);
+        Assert::isArray($data['author']);
+
+        return new self(
+            $data['sha'],
+            $data['created'],
+            $data['message'],
+            CommitAuthor::fromResponseData($data['author']),
+        );
+    }
+}

--- a/libs/git-service-api-client/src/Model/CommitAuthor.php
+++ b/libs/git-service-api-client/src/Model/CommitAuthor.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Keboola\GitServiceApiClient\Model;
+
+use Keboola\ApiClientBase\ResponseModelInterface;
+use Webmozart\Assert\Assert;
+
+/**
+ * Git-level author of a commit (name/email/date), as exposed by git-service.
+ * This is the git author, not the Forgejo user object.
+ */
+final readonly class CommitAuthor implements ResponseModelInterface
+{
+    public function __construct(
+        public string $name,
+        public string $email,
+        public string $date,
+    ) {
+    }
+
+    public static function fromResponseData(array $data): static
+    {
+        Assert::keyExists($data, 'name');
+        Assert::keyExists($data, 'email');
+        Assert::keyExists($data, 'date');
+        Assert::string($data['name']);
+        Assert::string($data['email']);
+        Assert::string($data['date']);
+
+        return new self(
+            $data['name'],
+            $data['email'],
+            $data['date'],
+        );
+    }
+}

--- a/libs/git-service-api-client/src/Model/CommitList.php
+++ b/libs/git-service-api-client/src/Model/CommitList.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Keboola\GitServiceApiClient\Model;
+
+use Keboola\ApiClientBase\ResponseModelInterface;
+use Webmozart\Assert\Assert;
+
+/**
+ * Wrapper for `GET /repos/{name}/refs/{ref}/commits` which returns `{commits: [...], total: N}`.
+ *
+ * `total` is the total number of commits reachable from the requested ref (the full history
+ * length), not the size of the returned page.
+ */
+final readonly class CommitList implements ResponseModelInterface
+{
+    /**
+     * @param list<Commit> $commits
+     */
+    public function __construct(
+        public array $commits,
+        public int $total,
+    ) {
+    }
+
+    public static function fromResponseData(array $data): static
+    {
+        Assert::keyExists($data, 'commits');
+        Assert::keyExists($data, 'total');
+        Assert::isArray($data['commits']);
+        Assert::integer($data['total']);
+
+        $commits = [];
+        foreach ($data['commits'] as $item) {
+            Assert::isArray($item);
+            $commits[] = Commit::fromResponseData($item);
+        }
+
+        return new self($commits, $data['total']);
+    }
+}

--- a/libs/git-service-api-client/src/Model/GitRef.php
+++ b/libs/git-service-api-client/src/Model/GitRef.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Keboola\GitServiceApiClient\Model;
+
+use Keboola\ApiClientBase\ResponseModelInterface;
+use Webmozart\Assert\Assert;
+
+final readonly class GitRef implements ResponseModelInterface
+{
+    public function __construct(
+        public string $ref,
+        public string $sha,
+        public string $type,
+    ) {
+    }
+
+    public static function fromResponseData(array $data): static
+    {
+        Assert::keyExists($data, 'ref');
+        Assert::keyExists($data, 'sha');
+        Assert::keyExists($data, 'type');
+        Assert::string($data['ref']);
+        Assert::string($data['sha']);
+        Assert::string($data['type']);
+
+        return new self(
+            $data['ref'],
+            $data['sha'],
+            $data['type'],
+        );
+    }
+}

--- a/libs/git-service-api-client/src/Model/GitRefListWrapper.php
+++ b/libs/git-service-api-client/src/Model/GitRefListWrapper.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Keboola\GitServiceApiClient\Model;
+
+use Keboola\ApiClientBase\ResponseModelInterface;
+use Webmozart\Assert\Assert;
+
+/**
+ * Internal wrapper for `GET /repos/{name}/refs` which returns `{refs: [...]}`.
+ * Not part of the public client surface — callers receive `list<GitRef>`.
+ *
+ * @internal
+ */
+final readonly class GitRefListWrapper implements ResponseModelInterface
+{
+    /**
+     * @param list<GitRef> $refs
+     */
+    public function __construct(public array $refs)
+    {
+    }
+
+    public static function fromResponseData(array $data): static
+    {
+        Assert::keyExists($data, 'refs');
+        Assert::isArray($data['refs']);
+
+        $refs = [];
+        foreach ($data['refs'] as $item) {
+            Assert::isArray($item);
+            $refs[] = GitRef::fromResponseData($item);
+        }
+
+        return new self($refs);
+    }
+}

--- a/libs/git-service-api-client/tests/GitServiceApiClientTest.php
+++ b/libs/git-service-api-client/tests/GitServiceApiClientTest.php
@@ -8,6 +8,7 @@ use GuzzleHttp\Handler\MockHandler;
 use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Psr7\Response;
 use Keboola\GitServiceApiClient\CredentialType;
+use Keboola\GitServiceApiClient\Exception\GitServiceClientException;
 use Keboola\GitServiceApiClient\GitServiceApiClient;
 use Keboola\GitServiceApiClient\KeyPermission;
 use Keboola\GitServiceApiClient\NewCredential;
@@ -252,5 +253,133 @@ class GitServiceApiClientTest extends TestCase
         self::assertNotNull($request);
         self::assertSame('DELETE', $request->getMethod());
         self::assertSame('https://example.test/repos/app-1/credentials/42', (string) $request->getUri());
+    }
+
+    public function testListCommits(): void
+    {
+        $mock = new MockHandler([new Response(200, [], (string) json_encode([
+            'commits' => [
+                [
+                    'sha' => 'abc123',
+                    'created' => '2026-06-01T10:00:00Z',
+                    'message' => 'first commit',
+                    'author' => [
+                        'name' => 'Alice',
+                        'email' => 'alice@example.com',
+                        'date' => '2026-06-01T10:00:00Z',
+                    ],
+                ],
+                [
+                    'sha' => 'def456',
+                    'created' => '2026-06-02T10:00:00Z',
+                    'message' => 'second commit',
+                    'author' => [
+                        'name' => 'Bob',
+                        'email' => 'bob@example.com',
+                        'date' => '2026-06-02T10:00:00Z',
+                    ],
+                ],
+            ],
+            'total' => 25,
+        ]))]);
+        $client = $this->buildClient($mock);
+
+        $list = $client->listCommits('app-1', 'main');
+
+        self::assertCount(2, $list->commits);
+        self::assertSame(25, $list->total);
+        self::assertSame('abc123', $list->commits[0]->sha);
+        self::assertSame('first commit', $list->commits[0]->message);
+        self::assertSame('Alice', $list->commits[0]->author->name);
+        self::assertSame('alice@example.com', $list->commits[0]->author->email);
+        self::assertSame('2026-06-01T10:00:00Z', $list->commits[0]->author->date);
+        $request = $mock->getLastRequest();
+        self::assertNotNull($request);
+        self::assertSame('GET', $request->getMethod());
+        self::assertSame(
+            'https://example.test/repos/app-1/refs/main/commits?page=1&limit=30',
+            (string) $request->getUri(),
+        );
+    }
+
+    public function testListCommitsWithPaginationAndEncodedRef(): void
+    {
+        $mock = new MockHandler([new Response(200, [], (string) json_encode([
+            'commits' => [],
+            'total' => 0,
+        ]))]);
+        $client = $this->buildClient($mock);
+
+        $list = $client->listCommits('app/1', 'feature/foo', 2, 10);
+
+        self::assertSame([], $list->commits);
+        self::assertSame(0, $list->total);
+        $request = $mock->getLastRequest();
+        self::assertNotNull($request);
+        self::assertSame(
+            'https://example.test/repos/app%2F1/refs/feature%2Ffoo/commits?page=2&limit=10',
+            (string) $request->getUri(),
+        );
+    }
+
+    public function testListCommitsNotFound(): void
+    {
+        $mock = new MockHandler([
+            new Response(404, [], '{"code":"repository.notFound","error":"repo or ref not found"}'),
+        ]);
+        $client = $this->buildClient($mock);
+
+        $this->expectException(GitServiceClientException::class);
+        $this->expectExceptionCode(404);
+        $client->listCommits('app-1', 'main');
+    }
+
+    public function testListRefs(): void
+    {
+        $mock = new MockHandler([new Response(200, [], (string) json_encode([
+            'refs' => [
+                ['ref' => 'refs/heads/main', 'sha' => 'abc123', 'type' => 'commit'],
+                ['ref' => 'refs/tags/v1.0.0', 'sha' => 'def456', 'type' => 'tag'],
+            ],
+        ]))]);
+        $client = $this->buildClient($mock);
+
+        $refs = $client->listRefs('app-1');
+
+        self::assertCount(2, $refs);
+        self::assertSame('refs/heads/main', $refs[0]->ref);
+        self::assertSame('abc123', $refs[0]->sha);
+        self::assertSame('commit', $refs[0]->type);
+        self::assertSame('refs/tags/v1.0.0', $refs[1]->ref);
+        self::assertSame('tag', $refs[1]->type);
+        $request = $mock->getLastRequest();
+        self::assertNotNull($request);
+        self::assertSame('GET', $request->getMethod());
+        self::assertSame('https://example.test/repos/app-1/refs', (string) $request->getUri());
+    }
+
+    public function testListRefsEncodesName(): void
+    {
+        $mock = new MockHandler([new Response(200, [], (string) json_encode(['refs' => []]))]);
+        $client = $this->buildClient($mock);
+
+        $refs = $client->listRefs('app/1');
+
+        self::assertSame([], $refs);
+        $request = $mock->getLastRequest();
+        self::assertNotNull($request);
+        self::assertSame('https://example.test/repos/app%2F1/refs', (string) $request->getUri());
+    }
+
+    public function testListRefsNotFound(): void
+    {
+        $mock = new MockHandler([
+            new Response(404, [], '{"code":"repository.notFound","error":"repo not found"}'),
+        ]);
+        $client = $this->buildClient($mock);
+
+        $this->expectException(GitServiceClientException::class);
+        $this->expectExceptionCode(404);
+        $client->listRefs('app-1');
     }
 }

--- a/libs/git-service-api-client/tests/Model/CommitListTest.php
+++ b/libs/git-service-api-client/tests/Model/CommitListTest.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Keboola\GitServiceApiClient\Tests\Model;
+
+use Keboola\GitServiceApiClient\Model\CommitList;
+use PHPUnit\Framework\TestCase;
+use Webmozart\Assert\InvalidArgumentException;
+
+class CommitListTest extends TestCase
+{
+    public function testFromResponseData(): void
+    {
+        $list = CommitList::fromResponseData([
+            'commits' => [
+                [
+                    'sha' => 'abc123',
+                    'created' => 't',
+                    'message' => 'm',
+                    'author' => ['name' => 'A', 'email' => 'a@b.c', 'date' => 't'],
+                ],
+            ],
+            'total' => 42,
+        ]);
+
+        self::assertCount(1, $list->commits);
+        self::assertSame('abc123', $list->commits[0]->sha);
+        self::assertSame(42, $list->total);
+    }
+
+    public function testFromResponseDataEmpty(): void
+    {
+        $list = CommitList::fromResponseData([
+            'commits' => [],
+            'total' => 0,
+        ]);
+
+        self::assertSame([], $list->commits);
+        self::assertSame(0, $list->total);
+    }
+
+    public function testFromResponseDataMissingTotal(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        CommitList::fromResponseData([
+            'commits' => [],
+        ]);
+    }
+
+    public function testFromResponseDataTotalWrongType(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        CommitList::fromResponseData([
+            'commits' => [],
+            'total' => '42',
+        ]);
+    }
+}

--- a/libs/git-service-api-client/tests/Model/CommitTest.php
+++ b/libs/git-service-api-client/tests/Model/CommitTest.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Keboola\GitServiceApiClient\Tests\Model;
+
+use Keboola\GitServiceApiClient\Model\Commit;
+use PHPUnit\Framework\TestCase;
+use Webmozart\Assert\InvalidArgumentException;
+
+class CommitTest extends TestCase
+{
+    public function testFromResponseData(): void
+    {
+        $commit = Commit::fromResponseData([
+            'sha' => 'abc123',
+            'created' => '2026-06-01T10:00:00Z',
+            'message' => 'commit message',
+            'author' => [
+                'name' => 'Alice',
+                'email' => 'alice@example.com',
+                'date' => '2026-06-01T10:00:00Z',
+            ],
+        ]);
+
+        self::assertSame('abc123', $commit->sha);
+        self::assertSame('2026-06-01T10:00:00Z', $commit->created);
+        self::assertSame('commit message', $commit->message);
+        self::assertSame('Alice', $commit->author->name);
+        self::assertSame('alice@example.com', $commit->author->email);
+        self::assertSame('2026-06-01T10:00:00Z', $commit->author->date);
+    }
+
+    public function testFromResponseDataMissingField(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        Commit::fromResponseData([
+            'sha' => 'abc123',
+            'created' => '2026-06-01T10:00:00Z',
+            'message' => 'commit message',
+            // author missing
+        ]);
+    }
+
+    public function testFromResponseDataAuthorWrongType(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        Commit::fromResponseData([
+            'sha' => 'abc123',
+            'created' => '2026-06-01T10:00:00Z',
+            'message' => 'commit message',
+            'author' => 'not-an-array',
+        ]);
+    }
+
+    public function testFromResponseDataWrongType(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        Commit::fromResponseData([
+            'sha' => 123,
+            'created' => '2026-06-01T10:00:00Z',
+            'message' => 'commit message',
+            'author' => ['name' => 'Alice', 'email' => 'a@b.c', 'date' => 't'],
+        ]);
+    }
+}

--- a/libs/git-service-api-client/tests/Model/GitRefListWrapperTest.php
+++ b/libs/git-service-api-client/tests/Model/GitRefListWrapperTest.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Keboola\GitServiceApiClient\Tests\Model;
+
+use Keboola\GitServiceApiClient\Model\GitRefListWrapper;
+use PHPUnit\Framework\TestCase;
+use Webmozart\Assert\InvalidArgumentException;
+
+class GitRefListWrapperTest extends TestCase
+{
+    public function testFromResponseData(): void
+    {
+        $wrapper = GitRefListWrapper::fromResponseData([
+            'refs' => [
+                ['ref' => 'refs/heads/main', 'sha' => 'abc', 'type' => 'commit'],
+                ['ref' => 'refs/tags/v1', 'sha' => 'def', 'type' => 'tag'],
+            ],
+        ]);
+
+        self::assertCount(2, $wrapper->refs);
+        self::assertSame('refs/heads/main', $wrapper->refs[0]->ref);
+        self::assertSame('tag', $wrapper->refs[1]->type);
+    }
+
+    public function testFromResponseDataEmpty(): void
+    {
+        $wrapper = GitRefListWrapper::fromResponseData(['refs' => []]);
+
+        self::assertSame([], $wrapper->refs);
+    }
+
+    public function testFromResponseDataMissingRefs(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        GitRefListWrapper::fromResponseData([]);
+    }
+}

--- a/libs/git-service-api-client/tests/Model/GitRefTest.php
+++ b/libs/git-service-api-client/tests/Model/GitRefTest.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Keboola\GitServiceApiClient\Tests\Model;
+
+use Keboola\GitServiceApiClient\Model\GitRef;
+use PHPUnit\Framework\TestCase;
+use Webmozart\Assert\InvalidArgumentException;
+
+class GitRefTest extends TestCase
+{
+    public function testFromResponseData(): void
+    {
+        $ref = GitRef::fromResponseData([
+            'ref' => 'refs/heads/main',
+            'sha' => 'abc123',
+            'type' => 'commit',
+        ]);
+
+        self::assertSame('refs/heads/main', $ref->ref);
+        self::assertSame('abc123', $ref->sha);
+        self::assertSame('commit', $ref->type);
+    }
+
+    public function testFromResponseDataMissingField(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        GitRef::fromResponseData([
+            'ref' => 'refs/heads/main',
+            'sha' => 'abc123',
+            // type missing
+        ]);
+    }
+
+    public function testFromResponseDataWrongType(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        GitRef::fromResponseData([
+            'ref' => 'refs/heads/main',
+            'sha' => 123,
+            'type' => 'commit',
+        ]);
+    }
+}


### PR DESCRIPTION
## What

Adds two read-only client methods to `git-service-api-client`, mirroring the new git-service (Go) endpoints shipped in `production-git-service-v1.7.0`:

- `listCommits(string $repo, string $ref, int $page = 1, int $limit = 30): CommitList` — `GET /repos/{repo}/refs/{ref}/commits?page=&limit=`
- `listRefs(string $repo): list<GitRef>` — `GET /repos/{repo}/refs`

New response models: `Commit`, `CommitAuthor`, `CommitList`, `GitRef`, `GitRefListWrapper` (curated DTOs, no raw Forgejo internals leaked). Follows the existing `listCredentials` / `CredentialListWrapper` / `Repository` patterns.

## Why

The Data Apps UI needs "N unpublished changes" for managed-git Data Apps. git-service v1.7.0 exposes the Forgejo commit-history & git-refs proxies; the `data-science` service (sandboxes-service) consumes this client to proxy them to the UI. See [PAT-1890](https://linear.app/keboola/issue/PAT-1890).

## Tests

`composer ci` green in `dev-git-service-api-client`: phpcs + phpstan (level max, no errors) + phpunit (65 tests, 184 assertions). Unit tests cover the two methods (incl. pagination, encoded slash refs, 404) and all new models.

## Release / downstream

After merge, tag `git-service-api-client/4.1.0` to split to the read-only `git-service-php-api-client` as `4.1.0`. Consumer `keboola/sandboxes-service` then bumps to `^4.1` (PR pending).