### PR TITLE
test(output-mapping,query-service-api-client,staging-provider): AJDA-2820 use loginType none for test workspaces

### DIFF
--- a/libs/output-mapping/tests/AbstractTestCase.php
+++ b/libs/output-mapping/tests/AbstractTestCase.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Keboola\OutputMapping\Tests;
 
 use InvalidArgumentException;
-use Keboola\KeyGenerator\PemKeyCertificateGenerator;
 use Keboola\OutputMapping\Staging\StrategyFactory;
 use Keboola\OutputMapping\TableLoader;
 use Keboola\OutputMapping\Tests\Needs\TestSatisfyer;
@@ -13,7 +12,6 @@ use Keboola\StagingProvider\Staging\File\FileFormat;
 use Keboola\StagingProvider\Staging\File\FileStagingInterface;
 use Keboola\StagingProvider\Staging\StagingProvider;
 use Keboola\StagingProvider\Staging\StagingType;
-use Keboola\StagingProvider\Workspace\SnowflakeKeypairGenerator;
 use Keboola\StorageApi\ClientException;
 use Keboola\StorageApi\Options\ListFilesOptions;
 use Keboola\StorageApi\WorkspaceLoginType;
@@ -151,12 +149,10 @@ abstract class AbstractTestCase extends TestCase
         }];
 
         // Snowflake no longer allows creating workspace users with the legacy service account type, which is
-        // what the empty/default login type maps to. Request a key-pair service login instead and register a
-        // generated public key for it.
+        // what the empty/default login type maps to. These tests never connect to the workspace directly (data
+        // is loaded server-side via the Storage API), so create it without any login.
         if ($stagingType === StagingType::WorkspaceSnowflake) {
-            $keyPair = (new SnowflakeKeypairGenerator(new PemKeyCertificateGenerator()))->generateKeyPair();
-            $options['loginType'] = WorkspaceLoginType::SNOWFLAKE_SERVICE_KEYPAIR;
-            $options['publicKey'] = $keyPair->publicKey;
+            $options['loginType'] = WorkspaceLoginType::NONE;
         }
 
         $workspace = $workspaces->createWorkspace($options, true);

--- a/libs/query-service-api-client/tests/Functional/BaseFunctionalTestCase.php
+++ b/libs/query-service-api-client/tests/Functional/BaseFunctionalTestCase.php
@@ -101,35 +101,16 @@ abstract class BaseFunctionalTestCase extends TestCase
         // Create a workspace for testing queries
         $workspaces = new Workspaces($this->branchAwareStorageClient);
         // Snowflake no longer allows creating workspace users with the legacy service account type (the
-        // empty/default login type). Create the workspace with a key-pair service login so a usable service
-        // user is provisioned; the generated public key is registered with the workspace.
+        // empty/default login type). The Query Service executes SQL against the workspace on the server side,
+        // so the test never connects with workspace credentials and the workspace needs no login of its own.
         $workspaceData = $workspaces->createWorkspace([
             'name' => sprintf('query-test-workspace-%d', random_int(1000, 9999)),
             'backend' => 'snowflake',
-            'loginType' => WorkspaceLoginType::SNOWFLAKE_SERVICE_KEYPAIR,
-            'publicKey' => self::generateWorkspacePublicKey(),
+            'loginType' => WorkspaceLoginType::NONE,
         ], true);
 
         /** @var array{id: int|string} $workspaceData */
         $this->testWorkspaceId = (string) $workspaceData['id'];
-    }
-
-    private static function generateWorkspacePublicKey(): string
-    {
-        $key = openssl_pkey_new([
-            'private_key_bits' => 2048,
-            'private_key_type' => OPENSSL_KEYTYPE_RSA,
-        ]);
-        if ($key === false) {
-            throw new RuntimeException('Failed to generate a workspace key pair');
-        }
-
-        $details = openssl_pkey_get_details($key);
-        if ($details === false || !isset($details['key']) || !is_string($details['key'])) {
-            throw new RuntimeException('Failed to extract the workspace public key');
-        }
-
-        return $details['key'];
     }
 
     protected function getTestBranchId(): string

--- a/libs/staging-provider/tests/Workspace/WorkspaceProviderFunctionalTest.php
+++ b/libs/staging-provider/tests/Workspace/WorkspaceProviderFunctionalTest.php
@@ -93,12 +93,11 @@ class WorkspaceProviderFunctionalTest extends TestCase
     private function createWorkspace(array $options): array
     {
         // Snowflake no longer allows creating workspace users with the legacy service account type (the
-        // empty/default login type). Default Snowflake workspaces to a key-pair service login so a usable
-        // service user is created; callers that need a specific login type still set it explicitly.
+        // empty/default login type). The tests using this helper only inspect workspace metadata and never
+        // connect to it, so default Snowflake workspaces to no login; callers that need a specific login type
+        // (e.g. the key-pair credential-reset test) still set it explicitly.
         if (($options['backend'] ?? null) === 'snowflake' && !isset($options['loginType'])) {
-            $keyPair = (new SnowflakeKeypairGenerator(new PemKeyCertificateGenerator()))->generateKeyPair();
-            $options['loginType'] = WorkspaceLoginType::SNOWFLAKE_SERVICE_KEYPAIR;
-            $options['publicKey'] = $keyPair->publicKey;
+            $options['loginType'] = WorkspaceLoginType::NONE;
         }
 
         $workspaceData = $this->workspacesApiClient->createWorkspace($options, async: true);


### PR DESCRIPTION
## Link to issue

https://linear.app/keboola/issue/AJDA-2820/update-job-runner

## Description
Trošku jsem poleštil tady to https://github.com/keboola/platform-libraries/pull/528/changes#diff-97d65c973832a3c296970b648078c6c8251b01e8c35ee84af2d611a0bc680aa9R158

[#528](https://github.com/keboola/platform-libraries/pull/528) reworked the Snowflake test-workspace setup because Snowflake no longer allows creating workspace users with the legacy service-account type (the empty/default `loginType`). It worked around this by requesting a `SNOWFLAKE_SERVICE_KEYPAIR` login and registering a generated public key.

That heavier approach isn't needed in these three test setups — none of them ever connects to the workspace with its own credentials:

- **output-mapping** `AbstractTestCase` — `workspaceCredentials` is never read; data is loaded/cloned server-side via the Storage API by workspace ID.
- **query-service** `BaseFunctionalTestCase` — SQL runs through the Query Service broker (`submitQueryJob`); the test never opens a workspace connection.
- **staging-provider** `WorkspaceProviderFunctionalTest::createWorkspace` (default branch) — used only by tests that inspect workspace metadata or exercise cleanup. The explicit key-pair credential-reset test sets `loginType` itself and is unaffected.

So all three now create the workspace with `WorkspaceLoginType::NONE` (a schema with no Snowflake login), matching the pattern already in use by `input-mapping`, and the now-unnecessary key-pair generation is dropped.

## Justification

Simplifies the merged #528 test setup and aligns it with `input-mapping`. See the linked Linear issue.

## Plans for Customer Communication

None.

## Impact Analysis

Test-only changes. The `query-service` case is the only behavioral assumption worth watching: it relies on the Query Service being able to execute SQL against a `none`-login workspace via its own privileged connection. Confirmed green by the functional CI suite for these libraries.

## Deployment Plan

Release a tagged version (libraries).

## Rollback Plan

Revert this PR.

## Post-Release Support Plan

None.
