### PR TITLE
test(doctrine-retry-bundle): AJDA-2222 load test env via dotenv and document setup

### DIFF
--- a/libs/doctrine-retry-bundle/README.md
+++ b/libs/doctrine-retry-bundle/README.md
@@ -16,6 +16,19 @@ doctrine:
 ```            
             
 ## Environment
+The tests connect to MySQL through a [Toxiproxy](https://github.com/Shopify/toxiproxy) instance
+(used to simulate connection failures). Both are provided by the `dev-doctrine-retry-bundle`
+Docker Compose service, so the simplest way to run them is:
+```bash
+docker compose run --rm dev-doctrine-retry-bundle composer ci
 ```
-TEST_DATABASE_URL - database connection URL (mysql://user:secret@localhost/mydb)
+
+The following variables are required:
+```
+TEST_DATABASE_HOST     - MySQL host (e.g. mysql)
+TEST_DATABASE_PORT     - MySQL port (e.g. 3306)
+TEST_DATABASE_USER     - MySQL user (e.g. root)
+TEST_DATABASE_PASSWORD - MySQL password
+TEST_DATABASE_DB       - MySQL database name (e.g. testdatabase)
+TEST_PROXY_HOST        - Toxiproxy host (e.g. toxiproxy); its API is reached at http://<host>:8474
 ```

--- a/libs/doctrine-retry-bundle/composer.json
+++ b/libs/doctrine-retry-bundle/composer.json
@@ -24,7 +24,8 @@
         "monolog/monolog": "^3.9",
         "phpstan/phpstan": "^2.1",
         "phpstan/phpstan-phpunit": "^2.0",
-        "phpunit/phpunit": "^12.1"
+        "phpunit/phpunit": "^12.1",
+        "symfony/dotenv": "^6.0|^7.0"
     },
     "autoload": {
         "psr-4": {

--- a/libs/doctrine-retry-bundle/tests/bootstrap.php
+++ b/libs/doctrine-retry-bundle/tests/bootstrap.php
@@ -6,7 +6,9 @@ use Symfony\Component\Dotenv\Dotenv;
 
 require __DIR__ . '/../vendor/autoload.php';
 
-(new Dotenv())->usePutenv()->bootEnv(dirname(__DIR__).'/.env', 'dev', []);
+if (file_exists(dirname(__DIR__).'/.env.local')) {
+    (new Dotenv())->usePutenv()->bootEnv(dirname(__DIR__).'/.env.local', 'dev', []);
+}
 
 $requiredEnvs = [
     'TEST_DATABASE_HOST',

--- a/libs/doctrine-retry-bundle/tests/bootstrap.php
+++ b/libs/doctrine-retry-bundle/tests/bootstrap.php
@@ -2,4 +2,22 @@
 
 declare(strict_types=1);
 
-require_once __DIR__ . '/../vendor/autoload.php';
+use Symfony\Component\Dotenv\Dotenv;
+
+require __DIR__ . '/../vendor/autoload.php';
+
+(new Dotenv())->usePutenv()->bootEnv(dirname(__DIR__).'/.env', 'dev', []);
+
+$requiredEnvs = [
+    'TEST_DATABASE_HOST',
+    'TEST_DATABASE_PORT',
+    'TEST_DATABASE_USER',
+    'TEST_DATABASE_PASSWORD',
+    'TEST_DATABASE_DB',
+    'TEST_PROXY_HOST',
+];
+foreach ($requiredEnvs as $env) {
+    if (empty(getenv($env))) {
+        throw new Exception(sprintf('Environment variable "%s" is empty', $env));
+    }
+}


### PR DESCRIPTION
## Link to issue
https://linear.app/keboola/issue/AJDA-2222/update-doctrine-in-editor-service

## Description
Reworks the doctrine-retry-bundle test setup to load configuration from a `.env` file via `symfony/dotenv` and fail fast when required variables are missing. The test bootstrap now boots the env and asserts that `TEST_DATABASE_HOST`, `TEST_DATABASE_PORT`, `TEST_DATABASE_USER`, `TEST_DATABASE_PASSWORD`, `TEST_DATABASE_DB` and `TEST_PROXY_HOST` are present, replacing the single `TEST_DATABASE_URL`. The README documents the new variables and the `docker compose run --rm dev-doctrine-retry-bundle composer ci` flow (MySQL + Toxiproxy).

## Justification
See the linked Linear issue — needed to align the bundle's test setup while updating Doctrine in the editor service.

## Plans for Customer Communication
None.

## Impact Analysis
Test-only change. No runtime/production code is affected and there is no behavior change for consumers of the bundle. Adds `symfony/dotenv` as a dev dependency.

## Deployment Plan
Release a tagged version.

## Rollback Plan
Revert this PR.

## Post-Release Support Plan
None.