### PR TITLE
chore(settle): AJDA-2222 upgrade to PHP 8.4 and dependency stack

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -179,7 +179,7 @@ services:
     working_dir: /code/libs/service-client
 
   dev-settle:
-    <<: *dev
+    <<: *dev84
     image: keboola/settle
     working_dir: /code/libs/settle
 

--- a/libs/settle/composer.json
+++ b/libs/settle/composer.json
@@ -25,19 +25,20 @@
         }
     },
     "require": {
-        "php": ">=7.4",
+        "php": "^8.2",
         "ext-json": "*",
         "keboola/common-exceptions": "^1.1",
         "psr/log": "^1.1|^2.0|^3.0",
         "symfony/config": "^5.2|^6.2|^7.0"
     },
     "require-dev": {
-        "infection/infection": "^0.26",
-        "keboola/coding-standard": ">=14.0.0",
+        "infection/infection": "^0.34",
+        "keboola/coding-standard": "^16.0",
         "monolog/monolog": "^2.1",
-        "phpstan/phpstan": "^1.9",
-        "phpunit/phpunit": "^9.5",
-        "sempro/phpunit-pretty-print": "^1.4",
+        "phpstan/phpstan": "^2.1",
+        "phpstan/phpstan-phpunit": "^2.0",
+        "phpstan/phpstan-symfony": "^2.0",
+        "phpunit/phpunit": "^10.5",
         "symfony/dotenv": "^6.2|^7.0"
     },
     "scripts": {
@@ -45,7 +46,7 @@
             "@putenv XDEBUG_MODE=coverage",
             "phpunit --coverage-clover build/logs/clover.xml --coverage-xml=build/logs/coverage-xml --log-junit=build/logs/phpunit.junit.xml"
         ],
-        "phpstan": "phpstan analyse --no-progress -c phpstan.neon",
+        "phpstan": "phpstan analyse --no-progress",
         "phpcs": "phpcs --extensions=php src tests",
         "phpcbf": "phpcbf --extensions=php src tests",
         "infection": "infection --threads=2 --min-covered-msi=90 --coverage=build/logs",

--- a/libs/settle/phpstan.neon
+++ b/libs/settle/phpstan.neon
@@ -1,7 +1,0 @@
-parameters:
-    level: max
-    checkMissingIterableValueType: false
-    paths:
-        - src
-        - tests
-    ignoreErrors:

--- a/libs/settle/phpstan.neon.dist
+++ b/libs/settle/phpstan.neon.dist
@@ -1,0 +1,9 @@
+parameters:
+	level: max
+	paths:
+		- src
+		- tests
+
+includes:
+	- vendor/phpstan/phpstan-phpunit/extension.neon
+	- vendor/phpstan/phpstan-symfony/extension.neon

--- a/libs/settle/phpunit.xml.dist
+++ b/libs/settle/phpunit.xml.dist
@@ -1,20 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
+    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd"
     stopOnFailure="false"
     bootstrap="tests/bootstrap.php"
 >
-  <coverage processUncoveredFiles="true">
-    <include>
-      <directory suffix=".php">src</directory>
-      <directory suffix=".php">tests</directory>
-    </include>
-    <exclude>
-      <directory suffix=".php">vendor</directory>
-    </exclude>
-  </coverage>
   <testsuite name="Tests">
     <directory>tests/</directory>
   </testsuite>
+  <source><include>
+      <directory suffix=".php">src</directory>
+      <directory suffix=".php">tests</directory>
+    </include>
+        <exclude>
+      <directory suffix=".php">vendor</directory>
+    </exclude></source>
 </phpunit>

--- a/libs/settle/src/Comparator/InArray.php
+++ b/libs/settle/src/Comparator/InArray.php
@@ -10,17 +10,12 @@ namespace Keboola\Settle\Comparator;
  */
 class InArray implements ComparatorInterface
 {
-    private array $targetValues;
-    private bool $strict;
-
     /**
      * @phpstan-param TValue[] $targetValues
-     * @param mixed $targetValues
+     * @param array $targetValues
      */
-    public function __construct(array $targetValues, bool $strict)
+    public function __construct(private readonly array $targetValues, private readonly bool $strict)
     {
-        $this->targetValues = $targetValues;
-        $this->strict = $strict;
     }
 
     /**

--- a/libs/settle/src/Comparator/IsSame.php
+++ b/libs/settle/src/Comparator/IsSame.php
@@ -10,16 +10,12 @@ namespace Keboola\Settle\Comparator;
  */
 class IsSame implements ComparatorInterface
 {
-    /** @var TValue */
-    private $targetValue;
-
     /**
      * @phpstan-param TValue $targetValue
      * @param mixed $targetValue
      */
-    public function __construct($targetValue)
+    public function __construct(private readonly mixed $targetValue)
     {
-        $this->targetValue = $targetValue;
     }
 
     /**

--- a/libs/settle/src/Settle.php
+++ b/libs/settle/src/Settle.php
@@ -9,15 +9,11 @@ use RuntimeException;
 
 class Settle
 {
-    private LoggerInterface $logger;
-    private int $maxAttempts;
-    private int $maxAttemptsDelay;
-
-    public function __construct(LoggerInterface $logger, int $maxAttempts, int $maxAttemptsDelay)
-    {
-        $this->logger = $logger;
-        $this->maxAttempts = $maxAttempts;
-        $this->maxAttemptsDelay = $maxAttemptsDelay;
+    public function __construct(
+        private readonly LoggerInterface $logger,
+        private readonly int $maxAttempts,
+        private readonly int $maxAttemptsDelay,
+    ) {
     }
 
     /**

--- a/libs/settle/src/SettleFactory.php
+++ b/libs/settle/src/SettleFactory.php
@@ -8,11 +8,8 @@ use Psr\Log\LoggerInterface;
 
 class SettleFactory
 {
-    private LoggerInterface $logger;
-
-    public function __construct(LoggerInterface $logger)
+    public function __construct(private readonly LoggerInterface $logger)
     {
-        $this->logger = $logger;
     }
 
     public function createSettle(int $maxAttempts, int $maxAttemptsDelay): Settle

--- a/libs/settle/tests/Comparator/InArrayTest.php
+++ b/libs/settle/tests/Comparator/InArrayTest.php
@@ -11,6 +11,7 @@ class InArrayTest extends TestCase
 {
     /**
      * @dataProvider provideInvokeStrictTestData
+     * @param list<mixed> $targetValue
      * @param mixed $currentValue
      */
     public function testInvokeStrict(array $targetValue, $currentValue, bool $expectedResult): void
@@ -18,7 +19,10 @@ class InArrayTest extends TestCase
         self::assertSame($expectedResult, (new InArray($targetValue, true))($currentValue));
     }
 
-    public function provideInvokeStrictTestData(): iterable
+    /**
+     * @return iterable<string, array{target: list<mixed>, current: mixed, result: bool}>
+     */
+    public static function provideInvokeStrictTestData(): iterable
     {
         yield 'empty array' => [
             'target' => [],
@@ -47,6 +51,7 @@ class InArrayTest extends TestCase
 
     /**
      * @dataProvider provideInvokeNotStrictTestData
+     * @param list<mixed> $targetValue
      * @param mixed $currentValue
      */
     public function testInvokeNotStrict(array $targetValue, $currentValue, bool $expectedResult): void
@@ -54,7 +59,10 @@ class InArrayTest extends TestCase
         self::assertSame($expectedResult, (new InArray($targetValue, false))($currentValue));
     }
 
-    public function provideInvokeNotStrictTestData(): iterable
+    /**
+     * @return iterable<string, array{target: list<mixed>, current: mixed, result: bool}>
+     */
+    public static function provideInvokeNotStrictTestData(): iterable
     {
         yield 'empty array' => [
             'target' => [],

--- a/libs/settle/tests/Comparator/IsSameTest.php
+++ b/libs/settle/tests/Comparator/IsSameTest.php
@@ -19,7 +19,10 @@ class IsSameTest extends TestCase
         self::assertSame($expectedResult, (new IsSame($targetValue))($currentValue));
     }
 
-    public function provideInvokeTestData(): iterable
+    /**
+     * @return iterable<string, array{target: mixed, current: mixed, result: bool}>
+     */
+    public static function provideInvokeTestData(): iterable
     {
         yield 'matching string' => [
             'target' => 'a',

--- a/libs/settle/tests/Comparator/IsTrueTest.php
+++ b/libs/settle/tests/Comparator/IsTrueTest.php
@@ -18,7 +18,10 @@ class IsTrueTest extends TestCase
         self::assertSame($expectedResult, (new IsTrue())($currentValue)); // @phpstan-ignore-line
     }
 
-    public function provideInvokeTestData(): iterable
+    /**
+     * @return iterable<string, array{current: mixed, result: bool}>
+     */
+    public static function provideInvokeTestData(): iterable
     {
         yield 'true' => [
             'current' => true,

--- a/libs/settle/tests/SettleFactoryTest.php
+++ b/libs/settle/tests/SettleFactoryTest.php
@@ -21,9 +21,11 @@ class SettleFactoryTest extends TestCase
         $settle = $factory->createSettle(2, 1);
 
         try {
+            /** @var mixed $expectedConditionValue */
+            $expectedConditionValue = true;
             $settle->settle(
-                fn($v) => $v === true,
-                fn() => false,
+                fn($v): bool => $v === $expectedConditionValue,
+                fn(): bool => false,
             );
 
             self::fail('Settle is expected to fail');
@@ -36,12 +38,12 @@ class SettleFactoryTest extends TestCase
 
         $checks = array_filter(
             $logsHandler->getRecords(),
-            fn(array $log) => $log['message'] === 'Checking current value',
+            fn(array $log): bool => $log['message'] === 'Checking current value',
         );
 
         $fails = array_filter(
             $logsHandler->getRecords(),
-            fn(array $log) => $log['message'] === 'Current value does not match expectation',
+            fn(array $log): bool => $log['message'] === 'Current value does not match expectation',
         );
 
         // check logs contains 2 value checks and 2 compare failures

--- a/libs/settle/tests/SettleTest.php
+++ b/libs/settle/tests/SettleTest.php
@@ -10,7 +10,6 @@ use Monolog\Handler\TestHandler;
 use Monolog\Logger;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
-use Psr\Log\NullLogger;
 use RuntimeException;
 
 class SettleTest extends TestCase
@@ -28,13 +27,17 @@ class SettleTest extends TestCase
 
     public function testSettleImmediately(): void
     {
-        $logger = new NullLogger();
-        $factory = new SettleFactory($logger);
+        $settle = (new SettleFactory($this->logger))->createSettle(1, 1);
 
-        $settle = new Settle($this->logger, 1, 1);
+        $currentValue = function (): int {
+            /** @var int $i */
+            static $i = 1;
+            return $i;
+        };
+
         $result = $settle->settle(
-            fn($v) => $v === 1,
-            fn() => 1,
+            fn($v): bool => $v === 1,
+            $currentValue,
         );
 
         self::assertSame(1, $result);
@@ -48,32 +51,33 @@ class SettleTest extends TestCase
         $settle = new Settle($this->logger, 5, 1);
 
         $currentValue = function (): int {
+            /** @var int $i */
             static $i = 0;
             return [1, 1, 1, 2][$i++];
         };
 
         $result = $settle->settle(
-            fn($v) => $v === 2,
+            fn($v): bool => $v === 2,
             $currentValue,
         );
 
         self::assertSame(2, $result);
         self::assertLogsCount(4, 'Checking current value');
         self::assertTrue(self::$logsHandler->hasRecordThatPasses(
-            fn ($v) => $v['message'] === 'Checking current value' &&
+            fn ($v): bool => $v['message'] === 'Checking current value' &&
                 $v['context']['attempt'] === 1,
             Logger::DEBUG,
         ));
         self::assertLogsCount(1, 'Condition settled');
         self::assertTrue(self::$logsHandler->hasRecordThatPasses(
-            fn ($v) => $v['message'] === 'Condition settled' &&
+            fn ($v): bool => $v['message'] === 'Condition settled' &&
                 $v['context']['currentValue'] === '2' &&
                 $v['context']['attempts'] === 4,
             Logger::DEBUG,
         ));
         self::assertLogsCount(3, 'Current value does not match expectation');
         self::assertTrue(self::$logsHandler->hasRecordThatPasses(
-            fn ($v) => $v['message'] === 'Current value does not match expectation' &&
+            fn ($v): bool => $v['message'] === 'Current value does not match expectation' &&
                 $v['context']['currentValue'] === '1' &&
                 $v['context']['attempts'] === 1,
             Logger::DEBUG,
@@ -85,9 +89,11 @@ class SettleTest extends TestCase
         $settle = new Settle($this->logger, 3, 1);
 
         try {
+            /** @var mixed $expectedConditionValue */
+            $expectedConditionValue = 2;
             $settle->settle(
-                fn($v) => $v === 2,
-                fn() => 1,
+                fn($v): bool => $v === $expectedConditionValue,
+                fn(): int => 1,
             );
             self::fail('Settle was expected to fail');
         } catch (RuntimeException $e) {
@@ -108,6 +114,7 @@ class SettleTest extends TestCase
         $settle = new Settle($this->logger, 4, 60);
 
         $currentValue = function (): int {
+            /** @var int $i */
             static $i = 0;
             return [1, 1, 1, 2][$i++];
         };
@@ -115,7 +122,7 @@ class SettleTest extends TestCase
         $startTime = microtime(true);
 
         $settle->settle(
-            fn($v) => $v === 2,
+            fn($v): bool => $v === 2,
             $currentValue,
         );
 
@@ -131,6 +138,7 @@ class SettleTest extends TestCase
         $settle = new Settle($this->logger, 4, 2);
 
         $currentValue = function (): int {
+            /** @var int $i */
             static $i = 0;
             return [1, 1, 1, 2][$i++];
         };
@@ -138,7 +146,7 @@ class SettleTest extends TestCase
         $startTime = microtime(true);
 
         $settle->settle(
-            fn($v) => $v === 2,
+            fn($v): bool => $v === 2,
             $currentValue,
         );
 
@@ -152,7 +160,7 @@ class SettleTest extends TestCase
     {
         self::assertCount(
             $expectedCount,
-            array_filter(self::$logsHandler->getRecords(), fn(array $log) => $log['message'] === $message),
+            array_filter(self::$logsHandler->getRecords(), fn(array $log): bool => $log['message'] === $message),
         );
     }
 }


### PR DESCRIPTION
## Link to issue
https://linear.app/keboola/issue/AJDA-2222/update-doctrine-in-editor-service

## Description
Brings the `settle` library onto the same modern toolchain as the rest of the AJDA-2222 dependency-stack upgrade. Bumps the dev tooling to PHPUnit 10, PHPStan 2 (wiring in the phpunit/symfony extensions), coding-standard 16 and infection 0.34. Source is modernised to constructor property promotion. The `dev-settle` Docker service now uses the `dev84` (PHP 8.4) base.

The runtime requirement is raised from `>=7.4` to `^8.2` (dropping PHP 7.4/8.0/8.1). The dev/CI stack runs on PHP 8.4, but the library deliberately stays installable on 8.2/8.3 so consumers there are unaffected.

No behavioural change to the public API.

## Justification
Part of AJDA-2222 — aligning the platform libraries on the modern PHP / Symfony 7+ dev stack.

## Plans for Customer Communication
None.

## Impact Analysis
Library-only, no runtime behaviour change. The only consumer-visible effect is the raised PHP requirement (`>=7.4` → `^8.2`); consumers on PHP 8.2 or newer are unaffected. Not gated by a feature flag.

## Deployment Plan
Release a tagged version.

## Rollback Plan
Revert this PR.

## Post-Release Support Plan
None.