### PR TITLE
fix(azure-api-client): AJDA-2222 fix testLogger for Guzzle 7.9+ URI validation

### DIFF
--- a/libs/azure-api-client/tests/ApiClientTest.php
+++ b/libs/azure-api-client/tests/ApiClientTest.php
@@ -83,7 +83,8 @@ class ApiClientTest extends TestCase
     {
 
         $client = new ApiClient(
-            configuration: new ApiClientConfiguration(
+            'https://example.com/',
+            new ApiClientConfiguration(
                 requestHandler: fn($request) => Create::promiseFor(new Response(201, [], 'boo')),
                 logger: $this->logger,
             ),


### PR DESCRIPTION
## Link to issue

https://linear.app/keboola/issue/AJDA-2222/update-doctrine-in-editor-service

## Description

`ApiClientTest::testLogger` started erroring with `URI must include a scheme and host` after the monorepo upgrade. The repo keeps no `composer.lock`, so CI now resolves Guzzle 7.13.0. Guzzle 7.9.0 added strict URI validation in `Client::send()`: a relative request URI (`/`) with no `base_uri` is rejected before it ever reaches the request handler. The older, lenient Guzzle let it through.

`testLogger` was the only request-sending test constructing an `ApiClient` without a base URL. The fix gives it an absolute base URL, matching every other request-sending test (and real usage, where the client is always built with a base URL and relative request paths). The mock request handler returns the same 201 regardless of URI, and the log assertion is unaffected.

No library/`src` code changed — this is a test-only fix for a third-party behaviour change.

## Justification

Unblocks the green build for the doctrine/Symfony upgrade work tracked in AJDA-2222.

## Plans for Customer Communication

None.

## Impact Analysis

Test-only change, no production code touched. No feature flag.

## Deployment Plan

Release a tagged version.

## Rollback Plan

Revert this PR.

## Post-Release Support Plan

None.