### PR TITLE
PAT-1902 Proper OAuth token support in api-bundle

### DIFF
--- a/libs/api-bundle/README.md
+++ b/libs/api-bundle/README.md
@@ -158,6 +158,12 @@ The base options are preconfigured by the bundle: the Connection (Storage API) U
 from the request's `X-KBC-RunId` header; branch / backend come from an optional per-call
 `ClientOptions`.
 
+The client uses the auth type the request was authenticated with: a legacy or exchanged Storage
+token is sent as `X-StorageApi-Token`, while an OAuth token (`Authorization: Bearer …`) is sent with
+the bearer scheme. `StorageApiToken::getTokenType()` exposes it (`AuthType::STORAGE_TOKEN` /
+`AuthType::BEARER`) so a token value carried as a bearer token is not mistaken for a Storage token
+if you build a client yourself.
+
 ```php
 #[StorageApiTokenAuth]
 public function __invoke(StorageClientApiFactory $storage)
@@ -187,11 +193,12 @@ public function __invoke(?StorageClientApiFactory $storage)
 
 `Keboola\ApiBundle\Test\AuthenticatorTestTrait` stubs the authenticators in functional
 (`WebTestCase`) tests so guarded controllers can be exercised without reaching real
-Storage/Manage APIs. It provides four helpers:
+Storage/Manage APIs. It provides five helpers:
 
 | Helper | Stubs auth for | Returns |
 | --- | --- | --- |
-| `setupFakeStorageApiToken(tokenString?, projectId, features, adminId?)` | `#[StorageApiTokenAuth]` via legacy `X-StorageApi-Token` | `StorageApiToken` |
+| `setupFakeStorageApiToken(tokenString?, projectId, features, adminId?)` | `#[StorageApiTokenAuth]` via legacy `X-StorageApi-Token` (resolves to an `AuthType::STORAGE_TOKEN` token) | `StorageApiToken` |
+| `setupFakeOAuthToken(tokenString?, projectId, features, adminId?)` | `#[StorageApiTokenAuth]` via an OAuth `Authorization: Bearer` token (resolves to an `AuthType::BEARER` token) | `StorageApiToken` |
 | `setupFakeConnectionToken(projectId, features, tokenString?, adminId?)` | `#[StorageApiTokenAuth]` via a `kbc_at_`/`kbc_pat_` programmatic token (stubs the exchange resolver client) | `StorageApiToken` |
 | `setupFakeManageApiToken(tokenString, scopes, features)` | `#[ApplicationTokenAuth]` (both the `X-KBC-ManageApiToken` header and the Kubernetes ServiceAccount JWT) | `void` |
 | `bootCleanClient()` | — boots a fresh, reboot-disabled `KernelBrowser` on a clean container | `KernelBrowser` |

--- a/libs/api-bundle/composer.json
+++ b/libs/api-bundle/composer.json
@@ -2,13 +2,19 @@
     "name": "keboola/api-bundle",
     "description": "Keboola API Bundle",
     "type": "symfony-bundle",
+    "repositories": [
+        {
+            "type": "vcs",
+            "url": "https://github.com/keboola/storage-api-php-client-branch-wrapper"
+        }
+    ],
     "require": {
         "php": ">=8.2",
         "cuyz/valinor-bundle": "^0.4",
         "keboola/kbc-manage-api-php-client": "^v10.2",
         "keboola/permission-checker": "^2.0|^3.0",
         "keboola/service-client": "^1.0",
-        "keboola/storage-api-php-client-branch-wrapper": "^6.7",
+        "keboola/storage-api-php-client-branch-wrapper": "dev-pepa/PAT-1902_token-type as 6.8.x-dev",
         "monolog/monolog": "^2.0|^3.0",
         "psr/log": "^1.1|^2.0|^3.0",
         "symfony/dependency-injection": "^6.0|^7.0",

--- a/libs/api-bundle/composer.json
+++ b/libs/api-bundle/composer.json
@@ -8,7 +8,7 @@
         "keboola/kbc-manage-api-php-client": "^v10.2",
         "keboola/permission-checker": "^2.0|^3.0",
         "keboola/service-client": "^1.0",
-        "keboola/storage-api-php-client-branch-wrapper": "dev-pepa/PAT-1902_token-type as 6.8.x-dev",
+        "keboola/storage-api-php-client-branch-wrapper": "^6.8.0",
         "monolog/monolog": "^2.0|^3.0",
         "psr/log": "^1.1|^2.0|^3.0",
         "symfony/dependency-injection": "^6.0|^7.0",

--- a/libs/api-bundle/composer.json
+++ b/libs/api-bundle/composer.json
@@ -2,12 +2,6 @@
     "name": "keboola/api-bundle",
     "description": "Keboola API Bundle",
     "type": "symfony-bundle",
-    "repositories": [
-        {
-            "type": "vcs",
-            "url": "https://github.com/keboola/storage-api-php-client-branch-wrapper"
-        }
-    ],
     "require": {
         "php": ">=8.2",
         "cuyz/valinor-bundle": "^0.4",

--- a/libs/api-bundle/src/Security/StorageApiToken/StorageApiToken.php
+++ b/libs/api-bundle/src/Security/StorageApiToken/StorageApiToken.php
@@ -5,10 +5,34 @@ declare(strict_types=1);
 namespace Keboola\ApiBundle\Security\StorageApiToken;
 
 use Keboola\ApiBundle\Security\TokenInterface;
+use Keboola\StorageApiBranch\Factory\AuthType;
 use Keboola\StorageApiBranch\StorageApiToken as BaseStorageApiToken;
+use SensitiveParameter;
 
 class StorageApiToken extends BaseStorageApiToken implements TokenInterface
 {
+    /**
+     * @param array<mixed, mixed> $tokenInfo
+     */
+    public function __construct(
+        array $tokenInfo,
+        #[SensitiveParameter] string $tokenValue,
+        private readonly AuthType $tokenType,
+    ) {
+        parent::__construct($tokenInfo, $tokenValue);
+    }
+
+    /**
+     * Auth type the token was resolved with: {@see AuthType::STORAGE_TOKEN} for a legacy Storage
+     * token (also the exchanged programmatic-token path) or {@see AuthType::BEARER} for an OAuth
+     * bearer token. Lets consumers build a Storage client with the matching auth scheme instead of
+     * assuming the token value is always a Storage token.
+     */
+    public function getTokenType(): AuthType
+    {
+        return $this->tokenType;
+    }
+
     public function eraseCredentials(): void
     {
     }

--- a/libs/api-bundle/src/Security/StorageApiToken/StorageApiToken.php
+++ b/libs/api-bundle/src/Security/StorageApiToken/StorageApiToken.php
@@ -7,11 +7,6 @@ namespace Keboola\ApiBundle\Security\StorageApiToken;
 use Keboola\ApiBundle\Security\TokenInterface;
 use Keboola\StorageApiBranch\StorageApiToken as BaseStorageApiToken;
 
-/**
- * Adds Symfony {@see \Symfony\Component\Security\Core\User\UserInterface} semantics to the base
- * token. The auth type ({@see BaseStorageApiToken::getTokenType()}) lives on the base; this class
- * does not override the constructor, so callers pass it (or accept the base's deprecation default).
- */
 class StorageApiToken extends BaseStorageApiToken implements TokenInterface
 {
     public function eraseCredentials(): void

--- a/libs/api-bundle/src/Security/StorageApiToken/StorageApiToken.php
+++ b/libs/api-bundle/src/Security/StorageApiToken/StorageApiToken.php
@@ -5,26 +5,15 @@ declare(strict_types=1);
 namespace Keboola\ApiBundle\Security\StorageApiToken;
 
 use Keboola\ApiBundle\Security\TokenInterface;
-use Keboola\StorageApiBranch\Factory\AuthType;
 use Keboola\StorageApiBranch\StorageApiToken as BaseStorageApiToken;
-use SensitiveParameter;
 
+/**
+ * Adds Symfony {@see \Symfony\Component\Security\Core\User\UserInterface} semantics to the base
+ * token. The auth type ({@see BaseStorageApiToken::getTokenType()}) lives on the base; this class
+ * does not override the constructor, so callers pass it (or accept the base's deprecation default).
+ */
 class StorageApiToken extends BaseStorageApiToken implements TokenInterface
 {
-    /**
-     * @param array<mixed, mixed> $tokenInfo
-     */
-    public function __construct(
-        array $tokenInfo,
-        #[SensitiveParameter] string $tokenValue,
-        AuthType $tokenType,
-    ) {
-        // Auth type stays mandatory here (unlike the deprecated-optional base constructor) so every
-        // api-bundle construction states it explicitly; forwarding it to the base means getTokenType()
-        // is inherited and no deprecation is triggered.
-        parent::__construct($tokenInfo, $tokenValue, $tokenType);
-    }
-
     public function eraseCredentials(): void
     {
     }

--- a/libs/api-bundle/src/Security/StorageApiToken/StorageApiToken.php
+++ b/libs/api-bundle/src/Security/StorageApiToken/StorageApiToken.php
@@ -17,20 +17,12 @@ class StorageApiToken extends BaseStorageApiToken implements TokenInterface
     public function __construct(
         array $tokenInfo,
         #[SensitiveParameter] string $tokenValue,
-        private readonly AuthType $tokenType,
+        AuthType $tokenType,
     ) {
-        parent::__construct($tokenInfo, $tokenValue);
-    }
-
-    /**
-     * Auth type the token was resolved with: {@see AuthType::STORAGE_TOKEN} for a legacy Storage
-     * token (also the exchanged programmatic-token path) or {@see AuthType::BEARER} for an OAuth
-     * bearer token. Lets consumers build a Storage client with the matching auth scheme instead of
-     * assuming the token value is always a Storage token.
-     */
-    public function getTokenType(): AuthType
-    {
-        return $this->tokenType;
+        // Auth type stays mandatory here (unlike the deprecated-optional base constructor) so every
+        // api-bundle construction states it explicitly; forwarding it to the base means getTokenType()
+        // is inherited and no deprecation is triggered.
+        parent::__construct($tokenInfo, $tokenValue, $tokenType);
     }
 
     public function eraseCredentials(): void

--- a/libs/api-bundle/src/Security/StorageApiToken/StorageApiTokenFactory.php
+++ b/libs/api-bundle/src/Security/StorageApiToken/StorageApiTokenFactory.php
@@ -134,8 +134,7 @@ class StorageApiTokenFactory
             );
         }
 
-        // The exchange resolves the programmatic token to a legacy Storage token, so it is always
-        // typed as a Storage token regardless of the bearer token the caller sent.
+        // The exchange resolves the programmatic token to a legacy Storage token.
         return new StorageApiToken($tokenDetail, $storageToken, AuthType::STORAGE_TOKEN);
     }
 
@@ -150,9 +149,7 @@ class StorageApiTokenFactory
         $storageApiClient = $wrapper->getBasicClient();
         $tokenInfo = $storageApiClient->verifyToken();
 
-        // The request factory already decided the auth type from the request headers (bearer vs
-        // X-StorageApi-Token); reuse that decision so the token is not later mistaken for a legacy
-        // Storage token. Falls back to Storage token if, unexpectedly, no type was resolved.
+        // Reuse the auth type the request factory resolved from the request headers.
         $authType = $wrapper->getClientOptionsReadOnly()->getAuthType() ?? AuthType::STORAGE_TOKEN;
 
         return new StorageApiToken($tokenInfo, $storageApiClient->getTokenString(), $authType);

--- a/libs/api-bundle/src/Security/StorageApiToken/StorageApiTokenFactory.php
+++ b/libs/api-bundle/src/Security/StorageApiToken/StorageApiTokenFactory.php
@@ -8,6 +8,7 @@ use Keboola\ManageApi\Client as ManageApiClient;
 use Keboola\ManageApi\ClientException as ManageApiClientException;
 use Keboola\ManageApi\MaintenanceException;
 use Keboola\StorageApi\ClientException;
+use Keboola\StorageApiBranch\Factory\AuthType;
 use Keboola\StorageApiBranch\Factory\StorageClientRequestFactory;
 use Psr\Log\LoggerInterface;
 use RuntimeException;
@@ -133,7 +134,9 @@ class StorageApiTokenFactory
             );
         }
 
-        return new StorageApiToken($tokenDetail, $storageToken);
+        // The exchange resolves the programmatic token to a legacy Storage token, so it is always
+        // typed as a Storage token regardless of the bearer token the caller sent.
+        return new StorageApiToken($tokenDetail, $storageToken, AuthType::STORAGE_TOKEN);
     }
 
     /**
@@ -147,7 +150,12 @@ class StorageApiTokenFactory
         $storageApiClient = $wrapper->getBasicClient();
         $tokenInfo = $storageApiClient->verifyToken();
 
-        return new StorageApiToken($tokenInfo, $storageApiClient->getTokenString());
+        // The request factory already decided the auth type from the request headers (bearer vs
+        // X-StorageApi-Token); reuse that decision so the token is not later mistaken for a legacy
+        // Storage token. Falls back to Storage token if, unexpectedly, no type was resolved.
+        $authType = $wrapper->getClientOptionsReadOnly()->getAuthType() ?? AuthType::STORAGE_TOKEN;
+
+        return new StorageApiToken($tokenInfo, $storageApiClient->getTokenString(), $authType);
     }
 
     private function extractProjectId(Request $request): int

--- a/libs/api-bundle/src/StorageApiClient/StorageClientApiFactory.php
+++ b/libs/api-bundle/src/StorageApiClient/StorageClientApiFactory.php
@@ -4,10 +4,9 @@ declare(strict_types=1);
 
 namespace Keboola\ApiBundle\StorageApiClient;
 
+use Keboola\ApiBundle\Security\StorageApiToken\StorageApiToken;
 use Keboola\StorageApiBranch\ClientWrapper;
-use Keboola\StorageApiBranch\Factory\AuthType;
 use Keboola\StorageApiBranch\Factory\ClientOptions;
-use Keboola\StorageApiBranch\StorageApiToken;
 use Symfony\Component\HttpFoundation\Request;
 
 class StorageClientApiFactory
@@ -29,7 +28,9 @@ class StorageClientApiFactory
         }
 
         $options->setToken($this->token->getTokenValue());
-        $options->setAuthType(AuthType::STORAGE_TOKEN);
+        // Propagate the auth type the token was resolved with (bearer for OAuth tokens, storage
+        // token otherwise) instead of assuming the value is always a legacy Storage token.
+        $options->setAuthType($this->token->getTokenType());
         $options->setRunId($this->getRunId($options));
 
         return new ClientWrapper($options);

--- a/libs/api-bundle/src/StorageApiClient/StorageClientApiFactory.php
+++ b/libs/api-bundle/src/StorageApiClient/StorageClientApiFactory.php
@@ -28,8 +28,6 @@ class StorageClientApiFactory
         }
 
         $options->setToken($this->token->getTokenValue());
-        // Propagate the auth type the token was resolved with (bearer for OAuth tokens, storage
-        // token otherwise) instead of assuming the value is always a legacy Storage token.
         $options->setAuthType($this->token->getTokenType());
         $options->setRunId($this->getRunId($options));
 

--- a/libs/api-bundle/src/StorageApiClient/StorageClientApiFactoryResolver.php
+++ b/libs/api-bundle/src/StorageApiClient/StorageClientApiFactoryResolver.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Keboola\ApiBundle\StorageApiClient;
 
+use Keboola\ApiBundle\Security\StorageApiToken\StorageApiToken;
 use Keboola\StorageApiBranch\Factory\ClientOptions;
-use Keboola\StorageApiBranch\StorageApiToken;
 use RuntimeException;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Controller\ValueResolverInterface;

--- a/libs/api-bundle/src/Test/AuthenticatorTestTrait.php
+++ b/libs/api-bundle/src/Test/AuthenticatorTestTrait.php
@@ -10,6 +10,8 @@ use Keboola\ApiBundle\Security\StorageApiToken\StorageApiToken;
 use Keboola\ManageApi\Client as ManageApiClient;
 use Keboola\StorageApi\Client as StorageApiClient;
 use Keboola\StorageApiBranch\ClientWrapper;
+use Keboola\StorageApiBranch\Factory\AuthType;
+use Keboola\StorageApiBranch\Factory\ClientOptions;
 use Keboola\StorageApiBranch\Factory\StorageClientRequestFactory;
 use PHPUnit\Framework\MockObject\MockObject;
 use Symfony\Bundle\FrameworkBundle\KernelBrowser;
@@ -92,6 +94,9 @@ trait AuthenticatorTestTrait
     }
 
     /**
+     * Stubs #[StorageApiTokenAuth] authenticated with a legacy X-StorageApi-Token, so the resolved
+     * token is typed as a Storage token.
+     *
      * @param list<string> $features
      */
     private function setupFakeStorageApiToken(
@@ -100,7 +105,51 @@ trait AuthenticatorTestTrait
         array $features = [],
         ?string $adminId = null,
     ): StorageApiToken {
-        $tokenString ??= uniqid('fakeStorageToken-', true);
+        return $this->registerFakeRequestToken(
+            $tokenString ?? uniqid('fakeStorageToken-', true),
+            $projectId,
+            $features,
+            $adminId,
+            AuthType::STORAGE_TOKEN,
+        );
+    }
+
+    /**
+     * Stubs #[StorageApiTokenAuth] authenticated with an OAuth bearer token (Authorization: Bearer),
+     * so the resolved token is typed as a bearer token and a Storage client built from it via
+     * {@see StorageClientApiFactory} authenticates with the bearer scheme.
+     *
+     * @param list<string> $features
+     */
+    private function setupFakeOAuthToken(
+        ?string $tokenString = null,
+        string $projectId = '123',
+        array $features = [],
+        ?string $adminId = null,
+    ): StorageApiToken {
+        return $this->registerFakeRequestToken(
+            $tokenString ?? uniqid('fakeOAuthToken-', true),
+            $projectId,
+            $features,
+            $adminId,
+            AuthType::BEARER,
+        );
+    }
+
+    /**
+     * Stubs the request-verification path ({@see StorageApiTokenFactory::createFromRequest()}) for a
+     * token carried directly by the request, tagging the fake wrapper with $authType so the resolved
+     * {@see StorageApiToken} carries the matching type.
+     *
+     * @param list<string> $features
+     */
+    private function registerFakeRequestToken(
+        string $tokenString,
+        string $projectId,
+        array $features,
+        ?string $adminId,
+        AuthType $authType,
+    ): StorageApiToken {
         $tokenData = $this->buildFakeStorageTokenData($projectId, $features, $adminId);
 
         $storageApiClient = $this->createMock(StorageApiClient::class);
@@ -109,13 +158,14 @@ trait AuthenticatorTestTrait
 
         $clientWrapper = $this->createMock(ClientWrapper::class);
         $clientWrapper->method('getBasicClient')->willReturn($storageApiClient);
+        $clientWrapper->method('getClientOptionsReadOnly')->willReturn(new ClientOptions(authType: $authType));
 
         $clientRequestFactory = $this->createMock(StorageClientRequestFactory::class);
         $clientRequestFactory->method('createClientWrapper')->willReturn($clientWrapper);
 
         self::getContainer()->set(StorageClientRequestFactory::class, $clientRequestFactory);
 
-        return new StorageApiToken($tokenData, $tokenString);
+        return new StorageApiToken($tokenData, $tokenString, $authType);
     }
 
     /**
@@ -150,7 +200,8 @@ trait AuthenticatorTestTrait
 
         self::getContainer()->set(KeboolaApiExtension::STORAGE_TOKEN_RESOLVER_CLIENT_ID, $resolverClient);
 
-        return new StorageApiToken($tokenData, $tokenString);
+        // The exchange resolves the programmatic token to a legacy Storage token.
+        return new StorageApiToken($tokenData, $tokenString, AuthType::STORAGE_TOKEN);
     }
 
     /**

--- a/libs/api-bundle/tests/Security/StorageApiToken/StorageApiTokenAuthenticatorTest.php
+++ b/libs/api-bundle/tests/Security/StorageApiToken/StorageApiTokenAuthenticatorTest.php
@@ -9,6 +9,7 @@ use Keboola\ApiBundle\Attribute\StorageApiTokenAuth;
 use Keboola\ApiBundle\Security\StorageApiToken\StorageApiToken;
 use Keboola\ApiBundle\Security\StorageApiToken\StorageApiTokenAuthenticator;
 use Keboola\ApiBundle\Security\StorageApiToken\StorageApiTokenFactory;
+use Keboola\StorageApiBranch\Factory\AuthType;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Request;
@@ -215,7 +216,7 @@ class StorageApiTokenAuthenticatorTest extends TestCase
             'description' => 'test',
             'owner' => ['features' => ['feature-a']],
         ];
-        $storageApiToken = new StorageApiToken($tokenData, 'tok');
+        $storageApiToken = new StorageApiToken($tokenData, 'tok', AuthType::STORAGE_TOKEN);
 
         $authenticator = new StorageApiTokenAuthenticator(
             $this->createMock(StorageApiTokenFactory::class),
@@ -233,7 +234,7 @@ class StorageApiTokenAuthenticatorTest extends TestCase
             'description' => 'test',
             'owner' => ['features' => ['feature-a']],
         ];
-        $storageApiToken = new StorageApiToken($tokenData, 'tok');
+        $storageApiToken = new StorageApiToken($tokenData, 'tok', AuthType::STORAGE_TOKEN);
 
         $authenticator = new StorageApiTokenAuthenticator(
             $this->createMock(StorageApiTokenFactory::class),

--- a/libs/api-bundle/tests/Security/StorageApiToken/StorageApiTokenFactoryTest.php
+++ b/libs/api-bundle/tests/Security/StorageApiToken/StorageApiTokenFactoryTest.php
@@ -16,6 +16,8 @@ use Keboola\StorageApi\Client;
 use Keboola\StorageApi\ClientException;
 use Keboola\StorageApi\MaintenanceException;
 use Keboola\StorageApiBranch\ClientWrapper;
+use Keboola\StorageApiBranch\Factory\AuthType;
+use Keboola\StorageApiBranch\Factory\ClientOptions;
 use Keboola\StorageApiBranch\Factory\StorageClientRequestFactory;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
@@ -85,6 +87,53 @@ class StorageApiTokenFactoryTest extends TestCase
         $token = $this->createFactory(clientRequestFactory: $factoryMock)->createFromRequest($request);
 
         self::assertSame('tok', $token->getTokenValue());
+    }
+
+    /**
+     * The resulting token records the auth type the request was actually verified with, so OAuth
+     * bearer tokens are not later mistaken for legacy Storage tokens.
+     */
+    #[DataProvider('provideRequestAuthTypes')]
+    public function testCreateFromRequestSetsTokenTypeFromResolvedAuthType(
+        ?AuthType $resolvedAuthType,
+        AuthType $expectedTokenType,
+    ): void {
+        $clientMock = $this->createMock(Client::class);
+        $clientMock->method('verifyToken')->willReturn(['id' => '42', 'description' => 'test']);
+        $clientMock->method('getTokenString')->willReturn('tok');
+
+        $wrapperMock = $this->createMock(ClientWrapper::class);
+        $wrapperMock->method('getBasicClient')->willReturn($clientMock);
+        $wrapperMock
+            ->method('getClientOptionsReadOnly')
+            ->willReturn(new ClientOptions(authType: $resolvedAuthType));
+
+        $factoryMock = $this->createMock(StorageClientRequestFactory::class);
+        $factoryMock
+            ->expects(self::once())
+            ->method('createClientWrapper')
+            ->willReturn($wrapperMock);
+
+        $token = $this->createFactory(clientRequestFactory: $factoryMock)
+            ->createFromRequest(Request::create('https://keboola.com'));
+
+        self::assertSame($expectedTokenType, $token->getTokenType());
+    }
+
+    public static function provideRequestAuthTypes(): Generator
+    {
+        yield 'oauth bearer token' => [
+            'resolvedAuthType' => AuthType::BEARER,
+            'expectedTokenType' => AuthType::BEARER,
+        ];
+        yield 'legacy storage token' => [
+            'resolvedAuthType' => AuthType::STORAGE_TOKEN,
+            'expectedTokenType' => AuthType::STORAGE_TOKEN,
+        ];
+        yield 'unknown auth type falls back to storage token' => [
+            'resolvedAuthType' => null,
+            'expectedTokenType' => AuthType::STORAGE_TOKEN,
+        ];
     }
 
     // ---------------------------------------------------------------------------
@@ -195,6 +244,8 @@ class StorageApiTokenFactoryTest extends TestCase
         self::assertSame($tokenDetail, $token->getTokenInfo());
         self::assertSame('123', $token->getProjectId());
         self::assertSame(['feat-a'], $token->getFeatures());
+        // The exchange yields a legacy Storage token, so it must be typed as such - never as bearer.
+        self::assertSame(AuthType::STORAGE_TOKEN, $token->getTokenType());
 
         // The original request must remain untouched.
         self::assertSame(

--- a/libs/api-bundle/tests/Security/StorageApiToken/StorageApiTokenFactoryTest.php
+++ b/libs/api-bundle/tests/Security/StorageApiToken/StorageApiTokenFactoryTest.php
@@ -90,8 +90,7 @@ class StorageApiTokenFactoryTest extends TestCase
     }
 
     /**
-     * The resulting token records the auth type the request was actually verified with, so OAuth
-     * bearer tokens are not later mistaken for legacy Storage tokens.
+     * The resulting token records the auth type the request was verified with.
      */
     #[DataProvider('provideRequestAuthTypes')]
     public function testCreateFromRequestSetsTokenTypeFromResolvedAuthType(
@@ -244,7 +243,7 @@ class StorageApiTokenFactoryTest extends TestCase
         self::assertSame($tokenDetail, $token->getTokenInfo());
         self::assertSame('123', $token->getProjectId());
         self::assertSame(['feat-a'], $token->getFeatures());
-        // The exchange yields a legacy Storage token, so it must be typed as such - never as bearer.
+        // The exchange yields a legacy Storage token.
         self::assertSame(AuthType::STORAGE_TOKEN, $token->getTokenType());
 
         // The original request must remain untouched.

--- a/libs/api-bundle/tests/Security/StorageApiToken/StorageApiTokenTest.php
+++ b/libs/api-bundle/tests/Security/StorageApiToken/StorageApiTokenTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Keboola\ApiBundle\Tests\Security\StorageApiToken;
 
 use Keboola\ApiBundle\Security\StorageApiToken\StorageApiToken;
+use Keboola\StorageApiBranch\Factory\AuthType;
 use PHPUnit\Framework\TestCase;
 
 class StorageApiTokenTest extends TestCase
@@ -36,6 +37,7 @@ class StorageApiTokenTest extends TestCase
                 'componentAccess' => ['keboola.component'],
             ],
             'tokenValue',
+            AuthType::STORAGE_TOKEN,
         );
 
         self::assertSame('123', $token->getTokenId());
@@ -105,6 +107,7 @@ class StorageApiTokenTest extends TestCase
                 ],
             ],
             'tokenValue',
+            AuthType::STORAGE_TOKEN,
         );
 
         self::assertNull($token->getRole());
@@ -124,6 +127,7 @@ class StorageApiTokenTest extends TestCase
                 'componentAccess' => [],
             ],
             'tokenValue',
+            AuthType::STORAGE_TOKEN,
         );
 
         self::assertSame([], $token->getAllowedComponents());
@@ -141,8 +145,31 @@ class StorageApiTokenTest extends TestCase
                 ],
             ],
             'tokenValue',
+            AuthType::STORAGE_TOKEN,
         );
 
         self::assertSame(null, $token->getAllowedComponents());
+    }
+
+    public function testTokenTypeIsStorageTokenWhenSpecified(): void
+    {
+        $token = new StorageApiToken(
+            ['id' => '123', 'owner' => ['id' => '456', 'features' => []]],
+            'tokenValue',
+            AuthType::STORAGE_TOKEN,
+        );
+
+        self::assertSame(AuthType::STORAGE_TOKEN, $token->getTokenType());
+    }
+
+    public function testTokenTypeIsBearerWhenSpecified(): void
+    {
+        $token = new StorageApiToken(
+            ['id' => '123', 'owner' => ['id' => '456', 'features' => []]],
+            'oauth-bearer-value',
+            AuthType::BEARER,
+        );
+
+        self::assertSame(AuthType::BEARER, $token->getTokenType());
     }
 }

--- a/libs/api-bundle/tests/StorageApiClient/StorageClientApiFactoryResolverTest.php
+++ b/libs/api-bundle/tests/StorageApiClient/StorageClientApiFactoryResolverTest.php
@@ -7,6 +7,7 @@ namespace Keboola\ApiBundle\Tests\StorageApiClient;
 use Keboola\ApiBundle\Security\StorageApiToken\StorageApiToken as SecurityStorageApiToken;
 use Keboola\ApiBundle\StorageApiClient\StorageClientApiFactory;
 use Keboola\ApiBundle\StorageApiClient\StorageClientApiFactoryResolver;
+use Keboola\StorageApiBranch\Factory\AuthType;
 use Keboola\StorageApiBranch\Factory\ClientOptions;
 use PHPUnit\Framework\TestCase;
 use RuntimeException;
@@ -58,7 +59,7 @@ class StorageClientApiFactoryResolverTest extends TestCase
             }
         };
 
-        $storageToken = new SecurityStorageApiToken([], 'resolved-token');
+        $storageToken = new SecurityStorageApiToken([], 'resolved-token', AuthType::STORAGE_TOKEN);
         $securityToken = $this->createMock(TokenInterface::class);
         $securityToken->expects(self::once())->method('getUser')->willReturn($storageToken);
         $tokenStorage = $this->createMock(TokenStorageInterface::class);
@@ -120,7 +121,7 @@ class StorageClientApiFactoryResolverTest extends TestCase
             }
         };
 
-        $storageToken = new SecurityStorageApiToken([], 'resolved-token');
+        $storageToken = new SecurityStorageApiToken([], 'resolved-token', AuthType::STORAGE_TOKEN);
         $securityToken = $this->createMock(TokenInterface::class);
         $securityToken->expects(self::once())->method('getUser')->willReturn($storageToken);
         $tokenStorage = $this->createMock(TokenStorageInterface::class);

--- a/libs/api-bundle/tests/StorageApiClient/StorageClientApiFactoryTest.php
+++ b/libs/api-bundle/tests/StorageApiClient/StorageClientApiFactoryTest.php
@@ -4,18 +4,25 @@ declare(strict_types=1);
 
 namespace Keboola\ApiBundle\Tests\StorageApiClient;
 
+use Keboola\ApiBundle\Security\StorageApiToken\StorageApiToken;
 use Keboola\ApiBundle\StorageApiClient\StorageClientApiFactory;
 use Keboola\StorageApiBranch\Factory\AuthType;
 use Keboola\StorageApiBranch\Factory\ClientOptions;
-use Keboola\StorageApiBranch\StorageApiToken;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Request;
 
 class StorageClientApiFactoryTest extends TestCase
 {
-    private static function factory(ClientOptions $baseClientOptions, Request $request): StorageClientApiFactory
-    {
-        return new StorageClientApiFactory($baseClientOptions, $request, new StorageApiToken([], 'bound-token'));
+    private static function factory(
+        ClientOptions $baseClientOptions,
+        Request $request,
+        ?StorageApiToken $token = null,
+    ): StorageClientApiFactory {
+        return new StorageClientApiFactory(
+            $baseClientOptions,
+            $request,
+            $token ?? new StorageApiToken([], 'bound-token', AuthType::STORAGE_TOKEN),
+        );
     }
 
     public function testCreateClientWrapperUsesBoundTokenWithStorageTokenAuth(): void
@@ -26,6 +33,20 @@ class StorageClientApiFactoryTest extends TestCase
 
         self::assertSame('bound-token', $options->getToken());
         self::assertSame(AuthType::STORAGE_TOKEN, $options->getAuthType());
+    }
+
+    public function testCreateClientWrapperUsesBearerAuthTypeForOAuthToken(): void
+    {
+        $factory = self::factory(
+            new ClientOptions('https://connection.test'),
+            new Request(),
+            new StorageApiToken([], 'oauth-bearer-token', AuthType::BEARER),
+        );
+
+        $options = $factory->createClientWrapper()->getClientOptionsReadOnly();
+
+        self::assertSame('oauth-bearer-token', $options->getToken());
+        self::assertSame(AuthType::BEARER, $options->getAuthType());
     }
 
     public function testRunIdTakenFromRequestHeaderWhenPresent(): void

--- a/libs/api-bundle/tests/Test/AuthenticatorTestTraitTest.php
+++ b/libs/api-bundle/tests/Test/AuthenticatorTestTraitTest.php
@@ -58,8 +58,7 @@ class AuthenticatorTestTraitTest extends WebTestCase
         self::assertSame('oauth-token', $token->getTokenValue());
         self::assertSame('456', $token->getProjectId());
         self::assertSame(['feat-a'], $token->getFeatures());
-        // An OAuth request resolves to a bearer-typed token, so a Storage client built from it
-        // authenticates with the bearer scheme instead of X-StorageApi-Token.
+        // An OAuth request resolves to a bearer-typed token.
         self::assertSame(AuthType::BEARER, $token->getTokenType());
 
         self::assertInstanceOf(

--- a/libs/api-bundle/tests/Test/AuthenticatorTestTraitTest.php
+++ b/libs/api-bundle/tests/Test/AuthenticatorTestTraitTest.php
@@ -8,6 +8,7 @@ use Keboola\ApiBundle\DependencyInjection\KeboolaApiExtension;
 use Keboola\ApiBundle\Security\ApplicationToken\ManageApiClientFactory;
 use Keboola\ApiBundle\Test\AuthenticatorTestTrait;
 use Keboola\ManageApi\Client as ManageApiClient;
+use Keboola\StorageApiBranch\Factory\AuthType;
 use Keboola\StorageApiBranch\Factory\StorageClientRequestFactory;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
@@ -37,6 +38,29 @@ class AuthenticatorTestTraitTest extends WebTestCase
         self::assertSame('my-token', $token->getTokenValue());
         self::assertSame('456', $token->getProjectId());
         self::assertSame(['feat-a'], $token->getFeatures());
+        self::assertSame(AuthType::STORAGE_TOKEN, $token->getTokenType());
+
+        self::assertInstanceOf(
+            StorageClientRequestFactory::class,
+            self::getContainer()->get(StorageClientRequestFactory::class),
+        );
+    }
+
+    public function testSetupFakeOAuthToken(): void
+    {
+        $token = $this->setupFakeOAuthToken(
+            tokenString: 'oauth-token',
+            projectId: '456',
+            features: ['feat-a'],
+            adminId: '99',
+        );
+
+        self::assertSame('oauth-token', $token->getTokenValue());
+        self::assertSame('456', $token->getProjectId());
+        self::assertSame(['feat-a'], $token->getFeatures());
+        // An OAuth request resolves to a bearer-typed token, so a Storage client built from it
+        // authenticates with the bearer scheme instead of X-StorageApi-Token.
+        self::assertSame(AuthType::BEARER, $token->getTokenType());
 
         self::assertInstanceOf(
             StorageClientRequestFactory::class,


### PR DESCRIPTION
## Release Notes
https://linear.app/keboola/issue/PAT-1902/api-bundle-proper-oauth-token-support

> [!NOTE]
> `StorageApiTokenFactory` bude respektuje/predava typ StorageTokenu (fixuje podporu OAuth tokenu)

OAuth (bearer) token authenticated requests pass through `StorageApiTokenAuthenticator`, but the resolved `StorageApiToken` kept only the raw token value with no record of how it was authenticated. `StorageClientApiFactory` then hardcoded `AuthType::STORAGE_TOKEN`, so a Storage client built from an OAuth-authenticated request mislabeled the bearer token as a legacy Storage token and sent it as `X-StorageApi-Token`.

The auth type now lives on the base `Keboola\StorageApiBranch\StorageApiToken`, exposed via `getTokenType()` (see the branch-wrapper PR below). This change makes api-bundle set and use it: `StorageApiTokenFactory` records the auth type when it builds the token — bearer when the request arrived as `Authorization: Bearer`, storage token for `X-StorageApi-Token` and for the `kbc_at_`/`kbc_pat_` programmatic-token exchange — and `StorageClientApiFactory` propagates `getTokenType()` instead of assuming a Storage token, so OAuth requests build a bearer-scheme client. The api-bundle `StorageApiToken` subclass is unchanged and inherits `getTokenType()` from the base.

Key changes:
* `StorageApiTokenFactory` sets the resolved auth type on the token (bearer vs storage token; the exchange path is always a storage token).
* `StorageClientApiFactory` uses `token->getTokenType()` instead of a hardcoded `AuthType::STORAGE_TOKEN`.
* `AuthenticatorTestTrait` adds `setupFakeOAuthToken()` for exercising the bearer path in functional tests.

Depends on:
* `storage-api-php-client-branch-wrapper` https://github.com/keboola/storage-api-php-client-branch-wrapper/pull/38 — adds `StorageApiToken::getTokenType()`.

> [!NOTE]
> `composer.json` is dev-pinned to the branch-wrapper branch for validation. Bump to the released branch-wrapper version (6.8/7.0) before merging.

## Plans for customer communication
None.

## Impact analysis
No end-user impact. The behavior change is internal to services that combine `#[StorageApiTokenAuth]` with `StorageClientApiFactory`: OAuth-authenticated requests now build a correctly bearer-typed Storage client instead of mislabeling the token as a Storage token. Legacy Storage-token flows are unaffected.

## Change type
Fix

## Justification
Proper OAuth/MCP token support in api-bundle (PAT-1902).

## Deployment
Merge & automatic deploy.

## Rollback plan
Revert of this PR.

## Post release support plan
None.
