### PR TITLE
fix(output-mapping): preserve production table typing in branches [AJDA-3014]

### DIFF
--- a/libs/output-mapping/src/LoadTableTaskCreator.php
+++ b/libs/output-mapping/src/LoadTableTaskCreator.php
@@ -82,6 +82,25 @@ class LoadTableTaskCreator
             );
             $this->tableCreator->createTableDefinition($source->getDestination()->getBucketId(), $tableDefinition);
             $loadTask = new LoadTableTask($source->getDestination(), $loadOptions, true);
+        } elseif (!$canCreateTypedTable &&
+            $settings->hasNewNativeTypesFeature() &&
+            !$storageSources->didTableExistBefore() &&
+            $source->getSchema()
+        ) {
+            // Typed-table creation was suppressed because the production (default-branch) table is
+            // non-typed (AJDA-3014). The columns are still known from the schema, so create a plain
+            // non-typed table with those columns; otherwise the headless CSV would be imported with
+            // its first data row taken as the header (via the CreateAndLoadTableTask fallback).
+            $this->tableCreator->createTable(
+                $source->getDestination()->getBucketId(),
+                $source->getDestination()->getTableName(),
+                array_map(
+                    fn (MappingFromConfigurationSchemaColumn $column) => $column->getName(),
+                    $source->getSchema(),
+                ),
+                $loadOptions,
+            );
+            $loadTask = new LoadTableTask($source->getDestination(), $loadOptions, true);
         } elseif (!$storageSources->didTableExistBefore() && $source->hasColumns()) {
             // tabulka neexistuje a známe sloupce z manifestu
             $this->tableCreator->createTable(

--- a/libs/output-mapping/src/LoadTableTaskCreator.php
+++ b/libs/output-mapping/src/LoadTableTaskCreator.php
@@ -40,11 +40,14 @@ class LoadTableTaskCreator
             $settings->hasNewNativeTypesFeature(),
             $settings->getTreatValuesAsNull(),
         );
+        $defaultBranchTable = $storageSources->getDefaultBranchTable();
+        $canCreateTypedTable = $defaultBranchTable === null || $defaultBranchTable->isTyped();
 
         // some scenarios are not supported by the SAPI, so we need to take care of them manually here
         // - columns in config + headless CSV (SAPI always expect to have a header in CSV)
         // - sliced files
-        if ($settings->hasNativeTypesFeature() &&
+        if ($canCreateTypedTable &&
+            $settings->hasNativeTypesFeature() &&
             !$storageSources->didTableExistBefore() &&
             $source->hasColumns() && $source->hasColumnMetadata()
         ) {
@@ -67,7 +70,8 @@ class LoadTableTaskCreator
             );
             $this->tableCreator->createTableDefinition($source->getDestination()->getBucketId(), $tableDefinition);
             $loadTask = new LoadTableTask($source->getDestination(), $loadOptions, true);
-        } elseif ($settings->hasNewNativeTypesFeature() &&
+        } elseif ($canCreateTypedTable &&
+            $settings->hasNewNativeTypesFeature() &&
             !$storageSources->didTableExistBefore() &&
             $source->getSchema()
         ) {

--- a/libs/output-mapping/src/Mapping/MappingStorageSources.php
+++ b/libs/output-mapping/src/Mapping/MappingStorageSources.php
@@ -9,8 +9,11 @@ use Keboola\OutputMapping\Storage\TableInfo;
 
 class MappingStorageSources
 {
-    public function __construct(readonly private BucketInfo $bucket, readonly private ?TableInfo $table)
-    {
+    public function __construct(
+        readonly private BucketInfo $bucket,
+        readonly private ?TableInfo $table,
+        readonly private ?TableInfo $defaultBranchTable = null,
+    ) {
     }
 
     public function getBucket(): BucketInfo
@@ -26,5 +29,10 @@ class MappingStorageSources
     public function getTable(): ?TableInfo
     {
         return $this->table;
+    }
+
+    public function getDefaultBranchTable(): ?TableInfo
+    {
+        return $this->defaultBranchTable;
     }
 }

--- a/libs/output-mapping/src/Storage/StoragePreparer.php
+++ b/libs/output-mapping/src/Storage/StoragePreparer.php
@@ -35,6 +35,15 @@ class StoragePreparer
         $destinationTableInfo = $this->getDestinationTableInfoIfExists(
             $processedSource->getDestination()->getTableId(),
         );
+        $defaultBranchTableInfo = null;
+        if ($destinationTableInfo === null &&
+            $this->clientWrapper->getClientOptionsReadOnly()->useBranchStorage() &&
+            $this->clientWrapper->isDevelopmentBranch()
+        ) {
+            $defaultBranchTableInfo = $this->getDefaultBranchTableInfoIfExists(
+                $processedSource->getDestination()->getTableId(),
+            );
+        }
 
         if ($destinationTableInfo !== null) {
             if ($this->hasNewNativeTypeFeature && $processedSource->getSchema()) {
@@ -69,13 +78,26 @@ class StoragePreparer
             );
         }
 
-        return new MappingStorageSources($destinationBucket, $destinationTableInfo);
+        return new MappingStorageSources($destinationBucket, $destinationTableInfo, $defaultBranchTableInfo);
     }
 
     private function getDestinationTableInfoIfExists(string $tableId): ?TableInfo
     {
         try {
             return new TableInfo($this->clientWrapper->getTableAndFileStorageClient()->getTable($tableId));
+        } catch (ClientException $e) {
+            if ($e->getCode() !== 404) {
+                throw $e;
+            }
+        }
+
+        return null;
+    }
+
+    private function getDefaultBranchTableInfoIfExists(string $tableId): ?TableInfo
+    {
+        try {
+            return new TableInfo($this->clientWrapper->getClientForDefaultBranch()->getTable($tableId));
         } catch (ClientException $e) {
             if ($e->getCode() !== 404) {
                 throw $e;

--- a/libs/output-mapping/tests/LoadTableTaskCreatorTest.php
+++ b/libs/output-mapping/tests/LoadTableTaskCreatorTest.php
@@ -14,6 +14,7 @@ use Keboola\OutputMapping\Mapping\MappingFromProcessedConfiguration;
 use Keboola\OutputMapping\Mapping\MappingFromRawConfigurationAndPhysicalDataWithManifest;
 use Keboola\OutputMapping\Mapping\MappingStorageSources;
 use Keboola\OutputMapping\Storage\BucketInfo;
+use Keboola\OutputMapping\Storage\TableInfo;
 use Keboola\OutputMapping\Tests\AbstractTestCase;
 use Keboola\OutputMapping\Tests\Needs\NeedsEmptyOutputBucket;
 use Keboola\OutputMapping\Tests\Needs\NeedsTestTables;
@@ -345,6 +346,140 @@ class LoadTableTaskCreatorTest extends AbstractTestCase
             $this->emptyOutputBucketId . '.test0',
             $loadTask->getDestinationTableName(),
         );
+    }
+
+    #[NeedsEmptyOutputBucket]
+    public function testNativeTypeCreationSuppressedWhenDefaultBranchTableNonTyped(): void
+    {
+        // The source has native types enabled and column metadata, so it would normally create a
+        // typed table (see testNativeTypeLoadTaskTableNotExists). Because the production
+        // (default-branch) table already exists and is NON-typed, typed creation must be
+        // suppressed and a plain non-typed table created instead (AJDA-3014).
+        $settings = self::createMock(OutputMappingSettings::class);
+        // Both typed-creation branches are gated on $canCreateTypedTable first, which is false
+        // here and short-circuits, so the feature flags are never even queried.
+        $settings->expects(self::never())->method('hasNativeTypesFeature');
+        $settings->expects(self::once())->method('hasNewNativeTypesFeature')->willReturn(false);
+
+        $strategy = self::createMock(LocalTableStrategy::class);
+        $strategy->expects(self::once())
+            ->method('prepareLoadTaskOptions')
+            ->willReturn([]);
+
+        $source = self::createMock(MappingFromProcessedConfiguration::class);
+        $source->expects(self::once())->method('hasColumns')->willReturn(true);
+        $source->expects(self::exactly(3))->method('getDestination')->willReturn(
+            new MappingDestination($this->emptyOutputBucketId . '.destinationTable'),
+        );
+        $source->expects(self::once())->method('getPrimaryKey')->willReturn([]);
+        $source->expects(self::exactly(2))->method('getColumns')->willReturn(['Id', 'Name']);
+
+        $storageSources = self::createMock(MappingStorageSources::class);
+        $storageSources->expects(self::exactly(2))->method('didTableExistBefore')->willReturn(false);
+        $storageSources->expects(self::once())->method('getDefaultBranchTable')->willReturn(
+            new TableInfo([
+                'id' => $this->emptyOutputBucketId . '.destinationTable',
+                'columns' => ['Id', 'Name'],
+                'primaryKey' => [],
+                'isTyped' => false,
+            ]),
+        );
+
+        $loadTableTaskCreator = new LoadTableTaskCreator(
+            $this->clientWrapper,
+            $this->testLogger,
+        );
+        $loadTask = $loadTableTaskCreator->create(
+            strategy: $strategy,
+            source: $source,
+            storageSources: $storageSources,
+            settings: $settings,
+        );
+
+        self::assertInstanceOf(LoadTableTask::class, $loadTask);
+        self::assertTrue($loadTask->isUsingFreshlyCreatedTable());
+        $storageTable = $this->clientWrapper->getTableAndFileStorageClient()->getTable(
+            $this->emptyOutputBucketId . '.destinationTable',
+        );
+
+        self::assertFalse($storageTable['isTyped']);
+        self::assertSame(['Id', 'Name'], $storageTable['columns']);
+    }
+
+    #[NeedsEmptyOutputBucket]
+    public function testNativeTypeCreationAllowedWhenDefaultBranchTableTyped(): void
+    {
+        // Same setup as testNativeTypeLoadTaskTableNotExists, but with a TYPED production
+        // (default-branch) table present. The fix must not over-suppress: typed creation stays
+        // allowed when the production table is already typed (AJDA-3014).
+        $settings = self::createMock(OutputMappingSettings::class);
+        $settings->expects(self::once())->method('hasNativeTypesFeature')->willReturn(true);
+        $settings->expects(self::once())->method('hasBigqueryNativeTypesFeature')->willReturn(false);
+
+        $strategy = self::createMock(LocalTableStrategy::class);
+        $strategy->expects(self::once())
+            ->method('prepareLoadTaskOptions')
+            ->willReturn([]);
+
+        $source = self::createMock(MappingFromProcessedConfiguration::class);
+        $source->expects(self::once())->method('hasColumns')->willReturn(true);
+        $source->expects(self::once())->method('hasColumnMetadata')->willReturn(true);
+        $source->expects(self::once())->method('hasMetadata')->willReturn(false);
+        $source->expects(self::exactly(3))->method('getDestination')->willReturn(
+            new MappingDestination($this->emptyOutputBucketId . '.destinationTable'),
+        );
+        $source->expects(self::exactly(2))->method('getPrimaryKey')->willReturn([]);
+        $source->expects(self::once())->method('getColumnMetadata')->willReturn([
+            new MappingColumnMetadata('col1', [
+                [
+                    'key' => 'KBC.datatype.basetype',
+                    'value' => 'STRING',
+                ],
+            ]),
+            new MappingColumnMetadata('col2', [
+                [
+                    'key' => 'KBC.datatype.basetype',
+                    'value' => 'INTEGER',
+                ],
+            ]),
+        ]);
+
+        $storageSources = self::createMock(MappingStorageSources::class);
+        $storageSources->expects(self::exactly(2))->method('didTableExistBefore')->willReturn(false);
+        $storageSources->expects(self::once())->method('getDefaultBranchTable')->willReturn(
+            new TableInfo([
+                'id' => $this->emptyOutputBucketId . '.destinationTable',
+                'columns' => ['col1', 'col2'],
+                'primaryKey' => [],
+                'isTyped' => true,
+            ]),
+        );
+        $storageSources->expects(self::once())->method('getBucket')->willReturn(
+            new BucketInfo([
+                'id' => $this->emptyOutputBucketId,
+                'backend' => 'Snowflake',
+                'metadata' => [],
+            ]),
+        );
+
+        $loadTableTaskCreator = new LoadTableTaskCreator(
+            $this->clientWrapper,
+            $this->testLogger,
+        );
+        $loadTask = $loadTableTaskCreator->create(
+            strategy: $strategy,
+            source: $source,
+            storageSources: $storageSources,
+            settings: $settings,
+        );
+
+        self::assertInstanceOf(LoadTableTask::class, $loadTask);
+        self::assertTrue($loadTask->isUsingFreshlyCreatedTable());
+        $storageTable = $this->clientWrapper->getTableAndFileStorageClient()->getTable(
+            $this->emptyOutputBucketId . '.destinationTable',
+        );
+
+        self::assertTrue($storageTable['isTyped']);
     }
 
     /**

--- a/libs/output-mapping/tests/LoadTableTaskCreatorTest.php
+++ b/libs/output-mapping/tests/LoadTableTaskCreatorTest.php
@@ -356,10 +356,12 @@ class LoadTableTaskCreatorTest extends AbstractTestCase
         // (default-branch) table already exists and is NON-typed, typed creation must be
         // suppressed and a plain non-typed table created instead (AJDA-3014).
         $settings = self::createMock(OutputMappingSettings::class);
-        // Both typed-creation branches are gated on $canCreateTypedTable first, which is false
-        // here and short-circuits, so the feature flags are never even queried.
+        // The typed-creation branches are gated on $canCreateTypedTable first, which is false here
+        // and short-circuits, so hasNativeTypesFeature() is never queried. hasNewNativeTypesFeature()
+        // is queried in buildLoadOptions and again in the suppressed-schema branch (returns false
+        // here since this is the metadata path, so a plain non-typed table is created via columns).
         $settings->expects(self::never())->method('hasNativeTypesFeature');
-        $settings->expects(self::once())->method('hasNewNativeTypesFeature')->willReturn(false);
+        $settings->expects(self::exactly(2))->method('hasNewNativeTypesFeature')->willReturn(false);
 
         $strategy = self::createMock(LocalTableStrategy::class);
         $strategy->expects(self::once())

--- a/libs/output-mapping/tests/Mapping/MappingStorageSourcesTest.php
+++ b/libs/output-mapping/tests/Mapping/MappingStorageSourcesTest.php
@@ -38,5 +38,10 @@ class MappingStorageSourcesTest extends TestCase
         self::assertEquals($bucketInfo, $source->getBucket());
         self::assertFalse($source->didTableExistBefore());
         self::assertNull($source->getTable());
+        self::assertNull($source->getDefaultBranchTable());
+
+        $source = new MappingStorageSources($bucketInfo, null, $table);
+        self::assertFalse($source->didTableExistBefore());
+        self::assertEquals($table, $source->getDefaultBranchTable());
     }
 }

--- a/libs/output-mapping/tests/Writer/StorageApiLocalTableWriterTest.php
+++ b/libs/output-mapping/tests/Writer/StorageApiLocalTableWriterTest.php
@@ -348,16 +348,6 @@ class StorageApiLocalTableWriterTest extends AbstractTestCase
             "\"2\",\"development\"\n",
         );
 
-        $realToken = $this->clientWrapper->getToken();
-        $token = $this->createMock(StorageApiToken::class);
-        $token
-            ->method('hasFeature')
-            ->willReturnCallback(
-                static fn(string $feature): bool => $feature === OutputMappingSettings::NEW_NATIVE_TYPES_FEATURE
-                    || $realToken->hasFeature($feature),
-            )
-        ;
-
         $tableQueue = $this->getTableLoader()->uploadTables(
             configuration: new OutputMappingSettings(
                 configuration: [
@@ -387,7 +377,7 @@ class StorageApiLocalTableWriterTest extends AbstractTestCase
                     ],
                 ],
                 sourcePathPrefix: 'upload',
-                storageApiToken: $token,
+                storageApiToken: $this->createTokenWithNewNativeTypesFeature(),
                 isFailedJob: false,
                 dataTypeSupport: OutputMappingSettings::DATA_TYPES_SUPPORT_AUTHORITATIVE,
             ),
@@ -395,7 +385,143 @@ class StorageApiLocalTableWriterTest extends AbstractTestCase
         );
         $tableQueue->waitForAll();
 
-        self::assertFalse($this->clientWrapper->getTableAndFileStorageClient()->getTable($tableId)['isTyped']);
+        // The branch table must stay non-typed AND still have the correct columns and data:
+        // the suppressed-typing path routes through the "unknown columns" CreateAndLoadTableTask
+        // fallback, so we explicitly assert columns/data are correct, not just the isTyped flag.
+        $branchTable = $this->clientWrapper->getTableAndFileStorageClient()->getTable($tableId);
+        self::assertFalse($branchTable['isTyped']);
+        self::assertSame(['Id', 'Name'], $branchTable['columns']);
+        $this->assertTableRowsEquals($tableId, [
+            '"id","name"',
+            '"2","development"',
+        ]);
+    }
+
+    #[NeedsEmptyOutputBucket]
+    #[NeedsDevBranch]
+    public function testFirstDevBranchWriteCreatesTypedTableWhenProductionTableTyped(): void
+    {
+        // Counterpart to testFirstDevBranchWritePreservesNonTypedProductionTable: when the
+        // production table is already TYPED, the fix must NOT over-suppress — the branch table
+        // must still be created typed (AJDA-3014).
+        $root = $this->temp->getTmpFolder();
+        $tableName = 'table';
+        $tableId = $this->emptyOutputBucketId . '.' . $tableName;
+
+        $this->clientWrapper->getTableAndFileStorageClient()->createTableDefinition(
+            $this->emptyOutputBucketId,
+            [
+                'name' => $tableName,
+                'primaryKeysNames' => [],
+                'columns' => [
+                    ['name' => 'Id', 'basetype' => 'INTEGER'],
+                    ['name' => 'Name', 'basetype' => 'STRING'],
+                ],
+            ],
+        );
+        self::assertTrue($this->clientWrapper->getTableAndFileStorageClient()->getTable($tableId)['isTyped']);
+
+        $clientOptions = $this->clientWrapper->getClientOptionsReadOnly()
+            ->setBranchId($this->devBranchId)
+            ->setUseBranchStorage(true)
+        ;
+        $this->clientWrapper = new ClientWrapper($clientOptions);
+
+        file_put_contents(
+            $root . '/upload/table.csv',
+            "\"2\",\"development\"\n",
+        );
+
+        $tableQueue = $this->getTableLoader()->uploadTables(
+            configuration: new OutputMappingSettings(
+                configuration: [
+                    'mapping' => [
+                        [
+                            'source' => 'table.csv',
+                            'destination' => $tableId,
+                            'schema' => [
+                                ['name' => 'Id', 'data_type' => ['base' => ['type' => 'INTEGER']]],
+                                ['name' => 'Name', 'data_type' => ['base' => ['type' => 'STRING']]],
+                            ],
+                        ],
+                    ],
+                ],
+                sourcePathPrefix: 'upload',
+                storageApiToken: $this->createTokenWithNewNativeTypesFeature(),
+                isFailedJob: false,
+                dataTypeSupport: OutputMappingSettings::DATA_TYPES_SUPPORT_AUTHORITATIVE,
+            ),
+            systemMetadata: new SystemMetadata(['componentId' => 'foo', 'branchId' => $this->devBranchId]),
+        );
+        $tableQueue->waitForAll();
+
+        self::assertTrue($this->clientWrapper->getTableAndFileStorageClient()->getTable($tableId)['isTyped']);
+    }
+
+    #[NeedsEmptyOutputBucket]
+    #[NeedsDevBranch]
+    public function testFirstDevBranchWriteCreatesTypedTableWhenProductionTableAbsent(): void
+    {
+        // A genuinely new table (no production counterpart) must still get automatic typed-table
+        // creation inside the branch — the fix only preserves the status of pre-existing
+        // production tables (AJDA-3014). This also exercises the 404 path of
+        // StoragePreparer::getDefaultBranchTableInfoIfExists.
+        $root = $this->temp->getTmpFolder();
+        $tableName = 'table';
+        $tableId = $this->emptyOutputBucketId . '.' . $tableName;
+
+        self::assertFalse($this->clientWrapper->getTableAndFileStorageClient()->tableExists($tableId));
+
+        $clientOptions = $this->clientWrapper->getClientOptionsReadOnly()
+            ->setBranchId($this->devBranchId)
+            ->setUseBranchStorage(true)
+        ;
+        $this->clientWrapper = new ClientWrapper($clientOptions);
+
+        file_put_contents(
+            $root . '/upload/table.csv',
+            "\"2\",\"development\"\n",
+        );
+
+        $tableQueue = $this->getTableLoader()->uploadTables(
+            configuration: new OutputMappingSettings(
+                configuration: [
+                    'mapping' => [
+                        [
+                            'source' => 'table.csv',
+                            'destination' => $tableId,
+                            'schema' => [
+                                ['name' => 'Id', 'data_type' => ['base' => ['type' => 'INTEGER']]],
+                                ['name' => 'Name', 'data_type' => ['base' => ['type' => 'STRING']]],
+                            ],
+                        ],
+                    ],
+                ],
+                sourcePathPrefix: 'upload',
+                storageApiToken: $this->createTokenWithNewNativeTypesFeature(),
+                isFailedJob: false,
+                dataTypeSupport: OutputMappingSettings::DATA_TYPES_SUPPORT_AUTHORITATIVE,
+            ),
+            systemMetadata: new SystemMetadata(['componentId' => 'foo', 'branchId' => $this->devBranchId]),
+        );
+        $tableQueue->waitForAll();
+
+        self::assertTrue($this->clientWrapper->getTableAndFileStorageClient()->getTable($tableId)['isTyped']);
+    }
+
+    private function createTokenWithNewNativeTypesFeature(): StorageApiToken
+    {
+        $realToken = $this->clientWrapper->getToken();
+        $token = $this->createMock(StorageApiToken::class);
+        $token
+            ->method('hasFeature')
+            ->willReturnCallback(
+                static fn(string $feature): bool => $feature === OutputMappingSettings::NEW_NATIVE_TYPES_FEATURE
+                    || $realToken->hasFeature($feature),
+            )
+        ;
+
+        return $token;
     }
 
     #[NeedsEmptyOutputBucket]

--- a/libs/output-mapping/tests/Writer/StorageApiLocalTableWriterTest.php
+++ b/libs/output-mapping/tests/Writer/StorageApiLocalTableWriterTest.php
@@ -320,6 +320,85 @@ class StorageApiLocalTableWriterTest extends AbstractTestCase
     }
 
     #[NeedsEmptyOutputBucket]
+    #[NeedsDevBranch]
+    public function testFirstDevBranchWritePreservesNonTypedProductionTable(): void
+    {
+        $root = $this->temp->getTmpFolder();
+        $tableName = 'table';
+        $tableId = $this->emptyOutputBucketId . '.' . $tableName;
+        $productionCsv = new CsvFile($root . '/production.csv');
+        $productionCsv->writeRow(['Id', 'Name']);
+        $productionCsv->writeRow(['1', 'production']);
+
+        $this->clientWrapper->getTableAndFileStorageClient()->createTableAsync(
+            $this->emptyOutputBucketId,
+            $tableName,
+            $productionCsv,
+        );
+        self::assertFalse($this->clientWrapper->getTableAndFileStorageClient()->getTable($tableId)['isTyped']);
+
+        $clientOptions = $this->clientWrapper->getClientOptionsReadOnly()
+            ->setBranchId($this->devBranchId)
+            ->setUseBranchStorage(true)
+        ;
+        $this->clientWrapper = new ClientWrapper($clientOptions);
+
+        file_put_contents(
+            $root . '/upload/table.csv',
+            "\"2\",\"development\"\n",
+        );
+
+        $realToken = $this->clientWrapper->getToken();
+        $token = $this->createMock(StorageApiToken::class);
+        $token
+            ->method('hasFeature')
+            ->willReturnCallback(
+                static fn(string $feature): bool => $feature === OutputMappingSettings::NEW_NATIVE_TYPES_FEATURE
+                    || $realToken->hasFeature($feature),
+            )
+        ;
+
+        $tableQueue = $this->getTableLoader()->uploadTables(
+            configuration: new OutputMappingSettings(
+                configuration: [
+                    'mapping' => [
+                        [
+                            'source' => 'table.csv',
+                            'destination' => $tableId,
+                            'schema' => [
+                                [
+                                    'name' => 'Id',
+                                    'data_type' => [
+                                        'base' => [
+                                            'type' => 'INTEGER',
+                                        ],
+                                    ],
+                                ],
+                                [
+                                    'name' => 'Name',
+                                    'data_type' => [
+                                        'base' => [
+                                            'type' => 'STRING',
+                                        ],
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+                sourcePathPrefix: 'upload',
+                storageApiToken: $token,
+                isFailedJob: false,
+                dataTypeSupport: OutputMappingSettings::DATA_TYPES_SUPPORT_AUTHORITATIVE,
+            ),
+            systemMetadata: new SystemMetadata(['componentId' => 'foo', 'branchId' => $this->devBranchId]),
+        );
+        $tableQueue->waitForAll();
+
+        self::assertFalse($this->clientWrapper->getTableAndFileStorageClient()->getTable($tableId)['isTyped']);
+    }
+
+    #[NeedsEmptyOutputBucket]
     public function testWriteTableOutputMappingExistingTable(): void
     {
         $root = $this->temp->getTmpFolder();


### PR DESCRIPTION
## Summary
Fixes [AJDA-3014](https://linear.app/keboola/issue/AJDA-3014) (SUPPORT-16987): Branched Storage was creating non-typed production tables as **typed** on their first write inside a development branch, because automatic typed-table creation was applied to what is effectively a pre-existing table just being materialized into the branch for the first time. After merge to production the transformation (built/tested against the typed branch table) then breaks against the still non-typed production table.

The fix consults the corresponding **default-branch** table when a destination is created for the first time in Branched Storage, and only allows automatic typed-table creation when the production table doesn't exist yet or is already typed:

```php
// StoragePreparer::prepareStorageBucketAndTable
$defaultBranchTableInfo = null;
if ($destinationTableInfo === null
    && $clientOptions->useBranchStorage()
    && $clientWrapper->isDevelopmentBranch()
) {
    $defaultBranchTableInfo = $this->getDefaultBranchTableInfoIfExists($tableId); // getClientForDefaultBranch()->getTable(), 404 => null
}
return new MappingStorageSources($destinationBucket, $destinationTableInfo, $defaultBranchTableInfo);

// LoadTableTaskCreator
$defaultBranchTable = $storageSources->getDefaultBranchTable();
$canCreateTypedTable = $defaultBranchTable === null || $defaultBranchTable->isTyped();
// $canCreateTypedTable now gates both the hasNativeTypesFeature and hasNewNativeTypesFeature typed-creation branches
```

A production non-typed table therefore stays non-typed in the dev branch even when the output has an authoritative schema. New branch-only tables and existing branch tables keep their current behavior.

When typed creation is **suppressed** for a schema-based source, `LoadTableTaskCreator` now creates a plain **non-typed** table using the schema's column names (the DDL-first `createTable` path) instead of falling through to the `CreateAndLoadTableTask` "unknown columns" branch. Without this, a headless CSV (as produced by native-types transformations) would be imported with its first data row taken as the header, leaving the branch table with garbage column names. This branch is gated on `!$canCreateTypedTable`, so no previously-passing scenario changes behavior.

This ports the reviewed fix from the read-only standalone repo (keboola/output-mapping#1) into the monorepo source at `libs/output-mapping`, since that repo is a read-only publish target.

## Test coverage
- `LoadTableTaskCreatorTest` — unit-level tests locking the `$canCreateTypedTable` gate: typed creation is **suppressed** when the default-branch table is non-typed (asserting the resulting table is non-typed **with the correct columns**), and still **allowed** when the default-branch table is typed.
- `StorageApiLocalTableWriterTest` — `testFirstDevBranchWritePreservesNonTypedProductionTable` now asserts columns and row data (not just the `isTyped` flag), plus two positive end-to-end cases proving the fix does not over-suppress: branch tables are still created typed when the production table is **typed** or **absent** (the latter also exercising the 404 path of `getDefaultBranchTableInfoIfExists`).

## Scope & known limitations

This is deliberately a **step-1 "stop the bleeding" stopgap**, not the full fix:

- **One-directional mirror.** It only *gates off* typed creation; it never *forces* it. The reported break is strictly one-directional (non-typed prod → typed branch → error after merge), and that direction is fully covered. The inverse case (prod typed, but the transformation itself would not produce a typed table) still yields a non-typed branch table — a harmless divergence that belongs to the follow-up convergence work, not this stopgap.
- **Interim layer.** The "branch mirrors prod on first materialization" invariant is implemented here client-side in `output-mapping`. Structurally it belongs in **Branched Storage** (Connection/Storage side), where lazy branch-table creation actually happens. This change is localized and trivially removable once the invariant moves down, so it introduces no architectural lock-in.

Follow-ups tracked separately:
- [AJDA-3053](https://linear.app/keboola/issue/AJDA-3053) — merge-aware "switch table to native types" action (declared retype property that survives merge).
- [AJDA-3054](https://linear.app/keboola/issue/AJDA-3054) — typing as a declared property enforced by output mapping (recreate-if-typing-differs) + the branch-mirrors-prod invariant living in Branched Storage.

## Release Notes
- **Justification**
    - Branched Storage was silently upgrading pre-existing non-typed production tables to typed tables the first time they were materialized into a development branch. Transformations developed and tested against the typed branch table (without the NULLIF/cast guards that a non-typed table needs) then failed once merged to production, where the table is still non-typed. This breaks the core promise of development branches — that what you test in a branch behaves the same after merge.
    - The change makes a branch preserve the production table's current typing status on first write: a non-typed production table stays non-typed in the branch (with its correct columns), regardless of the transformation's automatic data-type detection setting. Automatic detection continues to apply only to genuinely new tables.

- **Plans for Customer Communication**
    - No proactive customer communication required for the stopgap; it restores the expected/documented behavior and removes a data-integrity footgun. The reporting customer (Košík, SUPPORT-16987) should be notified that the branch-vs-production typing mismatch is fixed. Larger follow-up work (explicit native-types migration action) will be communicated separately when delivered.

- **Impact Analysis**
    - Affects only output mapping when writing into Branched Storage in a development branch, on the first write of a table that does not yet exist in the branch. It adds one extra Storage API `getTable` call against the default branch in that narrow path. No impact on production writes, non-branch writes, or writes to tables already present in the branch. No single-tenant-specific impact.
    - Not behind a feature flag; behavior change is scoped to the branch-storage first-write path described above.

- **Deployment Plan**
    - Library release via the standard monorepo split/publish; consumed by output-mapping consumers (job runner) on their next dependency bump. Continuous deployment, no stack-by-stack rollout required. Not critical.

- **Rollback Plan**
    - Two-way door. The change is localized to `output-mapping` and can be reverted/redeployed independently; reverting restores the previous (buggy) behavior with no data migration needed.

- **Post-Release Support Plan**
    - No special ongoing support needed. Support team can close SUPPORT-16987 referencing this fix once released. Follow-up issues (AJDA-3053, AJDA-3054) track the fuller native-types migration story.

Link to Devin session: https://app.devin.ai/sessions/2cf3e8a34494418daea07c967b0cd25e
Requested by: @MiroCillik
