### PR TITLE
chore(sandboxes-service-api-client): drop provisioningStrategy field

### DIFF
--- a/libs/sandboxes-service-api-client/src/Apps/App.php
+++ b/libs/sandboxes-service-api-client/src/Apps/App.php
@@ -17,7 +17,6 @@ final class App implements ResponseModelInterface
         'configVersion',
         'state',
         'desiredState',
-        'provisioningStrategy',
     ];
 
     public const STATE_CREATED = 'created';
@@ -31,9 +30,6 @@ final class App implements ResponseModelInterface
     public const DESIRED_STATE_RUNNING = 'running';
     public const DESIRED_STATE_STOPPED = 'stopped';
     public const DESIRED_STATE_DELETED = 'deleted';
-
-    public const PROVISIONING_STRATEGY_JOB_QUEUE = 'jobQueue';
-    public const PROVISIONING_STRATEGY_OPERATOR = 'operator';
 
     /** @var array<string> */
     public const VALID_STATES = [
@@ -53,12 +49,6 @@ final class App implements ResponseModelInterface
         self::DESIRED_STATE_DELETED,
     ];
 
-    /** @var array<string> */
-    public const VALID_PROVISIONING_STRATEGIES = [
-        self::PROVISIONING_STRATEGY_JOB_QUEUE,
-        self::PROVISIONING_STRATEGY_OPERATOR,
-    ];
-
     private string $id;
     private string $projectId;
     private string $componentId;
@@ -71,7 +61,6 @@ final class App implements ResponseModelInterface
     private ?string $lastRequestTimestamp = null;
     private ?string $url = null;
     private int $autoSuspendAfterSeconds;
-    private string $provisioningStrategy;
 
     public static function fromResponseData(array $data): static
     {
@@ -94,7 +83,6 @@ final class App implements ResponseModelInterface
         $app->setLastRequestTimestamp($data['lastRequestTimestamp'] ?? null);
         $app->setUrl($data['url'] ?? null);
         $app->setAutoSuspendAfterSeconds((int) ($data['autoSuspendAfterSeconds'] ?? 0));
-        $app->setProvisioningStrategy((string) $data['provisioningStrategy']);
 
         return $app;
     }
@@ -114,7 +102,6 @@ final class App implements ResponseModelInterface
             'lastRequestTimestamp' => $this->lastRequestTimestamp,
             'url' => $this->url,
             'autoSuspendAfterSeconds' => $this->autoSuspendAfterSeconds,
-            'provisioningStrategy' => $this->provisioningStrategy,
         ];
     }
 
@@ -261,26 +248,6 @@ final class App implements ResponseModelInterface
     public function setAutoSuspendAfterSeconds(int $autoSuspendAfterSeconds): self
     {
         $this->autoSuspendAfterSeconds = $autoSuspendAfterSeconds;
-        return $this;
-    }
-
-    public function getProvisioningStrategy(): string
-    {
-        return $this->provisioningStrategy;
-    }
-
-    public function setProvisioningStrategy(string $provisioningStrategy): self
-    {
-        if (!in_array($provisioningStrategy, self::VALID_PROVISIONING_STRATEGIES, true)) {
-            throw new ClientException(
-                sprintf(
-                    'Invalid provisioning strategy "%s". Valid strategies are: %s',
-                    $provisioningStrategy,
-                    implode(', ', self::VALID_PROVISIONING_STRATEGIES),
-                ),
-            );
-        }
-        $this->provisioningStrategy = $provisioningStrategy;
         return $this;
     }
 }

--- a/libs/sandboxes-service-api-client/tests/Apps/AppTest.php
+++ b/libs/sandboxes-service-api-client/tests/Apps/AppTest.php
@@ -25,7 +25,6 @@ class AppTest extends TestCase
             'lastRequestTimestamp' => '2024-02-02T12:00:00+01:00',
             'url' => 'https://example.com',
             'autoSuspendAfterSeconds' => 3600,
-            'provisioningStrategy' => 'operator',
         ]);
 
         self::assertSame('app-id', $app->getId());
@@ -39,7 +38,6 @@ class AppTest extends TestCase
         self::assertSame('2024-02-02T12:00:00+01:00', $app->getLastRequestTimestamp());
         self::assertSame('https://example.com', $app->getUrl());
         self::assertSame(3600, $app->getAutoSuspendAfterSeconds());
-        self::assertSame('operator', $app->getProvisioningStrategy());
     }
 
     public function testGettersWithNullableValues(): void
@@ -56,7 +54,6 @@ class AppTest extends TestCase
             'lastRequestTimestamp' => null,
             'url' => null,
             'autoSuspendAfterSeconds' => 0,
-            'provisioningStrategy' => 'jobQueue',
         ]);
 
         self::assertNull($app->getBranchId());
@@ -80,7 +77,6 @@ class AppTest extends TestCase
             'lastRequestTimestamp' => '2024-02-02T12:00:00+01:00',
             'url' => 'https://example.com',
             'autoSuspendAfterSeconds' => 3600,
-            'provisioningStrategy' => 'operator',
         ];
 
         $app = App::fromResponseData($expectedData);
@@ -101,7 +97,6 @@ class AppTest extends TestCase
             'configVersion',
             'state',
             'desiredState',
-            'provisioningStrategy',
         ];
 
         foreach ($requiredProps as $property) {
@@ -122,7 +117,6 @@ class AppTest extends TestCase
             'configVersion' => '5',
             'state' => 'running',
             'desiredState' => 'running',
-            'provisioningStrategy' => 'operator',
         ];
 
         unset($data[$missingProperty]);
@@ -221,50 +215,6 @@ class AppTest extends TestCase
         self::assertSame($app, $result);
     }
 
-    /**
-     * @return Generator<string, array{string}>
-     */
-    public function invalidProvisioningStrategiesDataProvider(): Generator
-    {
-        yield 'invalid strategy' => ['invalid'];
-        yield 'empty strategy' => [''];
-        yield 'kubernetes strategy' => ['kubernetes'];
-    }
-
-    /**
-     * @dataProvider invalidProvisioningStrategiesDataProvider
-     */
-    public function testInvalidProvisioningStrategy(string $invalidStrategy): void
-    {
-        $this->expectException(ClientException::class);
-        $this->expectExceptionMessage('Invalid provisioning strategy');
-
-        $app = new App();
-        $app->setProvisioningStrategy($invalidStrategy);
-    }
-
-    /**
-     * @return Generator<string, array{string}>
-     */
-    public function validProvisioningStrategiesDataProvider(): Generator
-    {
-        foreach (App::VALID_PROVISIONING_STRATEGIES as $strategy) {
-            yield $strategy => [$strategy];
-        }
-    }
-
-    /**
-     * @dataProvider validProvisioningStrategiesDataProvider
-     */
-    public function testValidProvisioningStrategy(string $validStrategy): void
-    {
-        $app = new App();
-        $result = $app->setProvisioningStrategy($validStrategy);
-
-        self::assertSame($validStrategy, $app->getProvisioningStrategy());
-        self::assertSame($app, $result);
-    }
-
     public function testSettersReturnSelfForChaining(): void
     {
         $app = new App();
@@ -291,7 +241,6 @@ class AppTest extends TestCase
             'configVersion' => '5',
             'state' => 'running',
             'desiredState' => 'running',
-            'provisioningStrategy' => 'operator',
         ]);
 
         self::assertSame(0, $app->getAutoSuspendAfterSeconds());
@@ -320,16 +269,6 @@ class AppTest extends TestCase
                 self::assertStringContainsString($state, $message);
             }
         }
-
-        try {
-            $app->setProvisioningStrategy('invalid');
-            self::fail('Expected exception was not thrown');
-        } catch (ClientException $e) {
-            $message = $e->getMessage();
-            foreach (App::VALID_PROVISIONING_STRATEGIES as $strategy) {
-                self::assertStringContainsString($strategy, $message);
-            }
-        }
     }
 
     public function testFromResponseDataCastsNumericValuesToStrings(): void
@@ -343,7 +282,6 @@ class AppTest extends TestCase
             'configVersion' => 5,
             'state' => 'running',
             'desiredState' => 'running',
-            'provisioningStrategy' => 'operator',
             'type' => 42,
             'autoSuspendAfterSeconds' => '3600',
         ]);
@@ -375,21 +313,5 @@ class AppTest extends TestCase
 
         self::assertNull($app->getType());
         self::assertSame($app, $result);
-    }
-
-    public function testFromResponseDataSetsProvisioningStrategyFromCast(): void
-    {
-        $app = App::fromResponseData([
-            'id' => 'app-id',
-            'projectId' => 'project-id',
-            'componentId' => 'keboola.data-apps',
-            'configId' => 'config-id',
-            'configVersion' => '1',
-            'state' => 'running',
-            'desiredState' => 'running',
-            'provisioningStrategy' => 'jobQueue',
-        ]);
-
-        self::assertSame('jobQueue', $app->getProvisioningStrategy());
     }
 }

--- a/libs/sandboxes-service-api-client/tests/Apps/AppsApiClientTest.php
+++ b/libs/sandboxes-service-api-client/tests/Apps/AppsApiClientTest.php
@@ -39,7 +39,6 @@ class AppsApiClientTest extends TestCase
                 'lastRequestTimestamp' => '2024-02-01T08:00:00+01:00',
                 'url' => 'https://example.com',
                 'autoSuspendAfterSeconds' => 3600,
-                'provisioningStrategy' => 'operator',
             ],
             [
                 'id' => 'app-id-2',
@@ -53,7 +52,6 @@ class AppsApiClientTest extends TestCase
                 'lastRequestTimestamp' => null,
                 'url' => null,
                 'autoSuspendAfterSeconds' => 0,
-                'provisioningStrategy' => 'jobQueue',
             ],
         ];
 
@@ -103,7 +101,6 @@ class AppsApiClientTest extends TestCase
                 'lastRequestTimestamp' => '2024-02-01T08:00:00+01:00',
                 'url' => 'https://example.com',
                 'autoSuspendAfterSeconds' => 3600,
-                'provisioningStrategy' => 'operator',
             ],
         ];
 
@@ -149,7 +146,6 @@ class AppsApiClientTest extends TestCase
             'lastRequestTimestamp' => '2024-02-01T08:00:00+01:00',
             'url' => 'https://example.com',
             'autoSuspendAfterSeconds' => 3600,
-            'provisioningStrategy' => 'operator',
         ];
 
         $mock = new MockHandler([
@@ -285,7 +281,6 @@ class AppsApiClientTest extends TestCase
                 'lastRequestTimestamp' => '2024-02-01T08:00:00+01:00',
                 'url' => null,
                 'autoSuspendAfterSeconds' => 3600,
-                'provisioningStrategy' => 'operator',
             ],
         ];
 
@@ -330,7 +325,6 @@ class AppsApiClientTest extends TestCase
             'lastRequestTimestamp' => null,
             'url' => null,
             'autoSuspendAfterSeconds' => 3600,
-            'provisioningStrategy' => 'operator',
         ];
 
         $mock = new MockHandler([


### PR DESCRIPTION
## Release Notes
https://github.com/keboola/sandboxes-service/pull/631

The sandboxes-service is removing the `provisioningStrategy` field from its Apps API response. This PR drops the field from the `sandboxes-service-api-client` so the client no longer reads or exposes it. Without this change `App::fromResponseData()` would fail with an undefined-array-key error the moment the API stops returning the field.

The `provisioningStrategy` property, its constants (`PROVISIONING_STRATEGY_JOB_QUEUE`, `PROVISIONING_STRATEGY_OPERATOR`, `VALID_PROVISIONING_STRATEGIES`), the required-property entry, the getter/setter, and the `toArray()` key are all removed, together with the corresponding test fixtures and assertions.

## Plans for customer communication
None.

## Impact analysis
The client no longer reads or exposes `provisioningStrategy`. This is required to stay compatible with the sandboxes-service API dropping the field; any consumer that read `getProvisioningStrategy()` must stop doing so.

## Change type
Maintenance

## Justification
Keep the API client compatible with the sandboxes-service API that is dropping the `provisioningStrategy` field.

## Deployment
Merge & automatic deploy.

## Rollback plan
Revert of this PR.

## Post release support plan
None.
