### PR TITLE
chore(php-api-client-base): add ext-json dependency

### DIFF
--- a/libs/php-api-client-base/composer.json
+++ b/libs/php-api-client-base/composer.json
@@ -21,6 +21,7 @@
     },
     "require": {
         "php": "^8.2",
+        "ext-json": "*",
         "guzzlehttp/guzzle": "^7.8",
         "psr/http-message": "^1.0|^2.0",
         "psr/log": "^1.0|^2.0|^3.0",


### PR DESCRIPTION
## Release Notes

Adds `ext-json` to the `require` section of `keboola/php-api-client-base`. The library uses the JSON extension at runtime — `src/Json.php` calls `json_encode()` / `json_decode()` with `JSON_THROW_ON_ERROR` — but the dependency was only implicit. Declaring it lets Composer fail fast on environments without `ext-json` and brings the base client in line with the rest of the monorepo, where libraries declare `ext-json` explicitly.

## Plans for customer communication
None.

## Impact analysis
No end-user impact. `ext-json` is bundled and enabled by default in all supported PHP builds; this only makes the existing runtime requirement explicit.

## Change type
Maintenance

## Justification
Declare the implicit `ext-json` runtime dependency explicitly.

## Deployment
Merge & automatic deploy.

## Rollback plan
Revert of this PR.

## Post release support plan
None.
