### PR TITLE
PAT-1896 Drop StorageClientRequestFactory dependency from api-bundle

### DIFF
--- a/libs/api-bundle/README.md
+++ b/libs/api-bundle/README.md
@@ -149,9 +149,10 @@ which the bundle requires directly, so no extra installation is needed.
 
 When `#[StorageApiTokenAuth]` is enabled, type-hint
 `Keboola\ApiBundle\StorageApiClient\StorageClientApiFactory` on a controller argument; the bundle
-injects a factory already bound to the current request and the resolved `StorageApiToken`. Unlike the
-header-based `StorageClientRequestFactory`, it uses the token resolved by the authenticator, so it
-works for programmatic (`kbc_pat_*` / `kbc_at_*`) tokens too.
+injects a factory already bound to the current request and the resolved `StorageApiToken`. It uses
+the token resolved by the authenticator, so it works for programmatic (`kbc_pat_*` / `kbc_at_*`)
+tokens too, and shares the same base `ClientOptions` the bundle uses internally to verify the
+incoming token — no external Storage client factory needs to be registered by the consuming app.
 
 The base options are preconfigured by the bundle: the Connection (Storage API) URL from the
 `ServiceClient`, the shared logger, and the configured `app_name` as user agent. The run id comes
@@ -242,6 +243,12 @@ Storage/Manage APIs. It provides five helpers:
 | `setupFakeConnectionToken(projectId, features, tokenString?, adminId?)` | `#[StorageApiTokenAuth]` via a `kbc_at_`/`kbc_pat_` programmatic token (stubs the exchange resolver client) | `StorageApiToken` |
 | `setupFakeManageApiToken(tokenString, scopes, features)` | `#[ApplicationTokenAuth]` (both the `X-KBC-ManageApiToken` header and the Kubernetes ServiceAccount JWT) | `void` |
 | `bootCleanClient()` | — boots a fresh, reboot-disabled `KernelBrowser` on a clean container | `KernelBrowser` |
+
+> [!IMPORTANT]
+> `setupFakeStorageApiToken()` / `setupFakeOAuthToken()` only stub token *verification* — the
+> resolved `AuthType` is derived by the authenticator from the request headers, exactly as in
+> production. Send the matching scheme on the request under test: `X-StorageApi-Token: …` for
+> `setupFakeStorageApiToken()` and `Authorization: Bearer …` for `setupFakeOAuthToken()`.
 
 ### Why `bootCleanClient()`
 

--- a/libs/api-bundle/src/DependencyInjection/KeboolaApiExtension.php
+++ b/libs/api-bundle/src/DependencyInjection/KeboolaApiExtension.php
@@ -10,13 +10,13 @@ use Keboola\ApiBundle\Security\ApplicationToken\ApplicationTokenAuthenticator;
 use Keboola\ApiBundle\Security\ApplicationToken\ManageApiClientFactory;
 use Keboola\ApiBundle\Security\StorageApiToken\StorageApiTokenAuthenticator;
 use Keboola\ApiBundle\Security\StorageApiToken\StorageApiTokenFactory;
-use Keboola\ApiBundle\StorageApiClient\StorageClientApiFactory;
+use Keboola\ApiBundle\StorageApiClient\RequestStorageClientFactory;
 use Keboola\ApiBundle\StorageApiClient\StorageClientApiFactoryResolver;
 use Keboola\ManageApi\Client as ManageApiClient;
 use Keboola\ServiceClient\ServiceClient;
 use Keboola\ServiceClient\ServiceDnsType;
+use Keboola\StorageApiBranch\ClientWrapper;
 use Keboola\StorageApiBranch\Factory\ClientOptions;
-use Keboola\StorageApiBranch\Factory\StorageClientRequestFactory;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
@@ -32,6 +32,12 @@ class KeboolaApiExtension extends Extension
      * legacy Storage tokens. Exposed so functional tests can swap it for a mock.
      */
     public const STORAGE_TOKEN_RESOLVER_CLIENT_ID = 'keboola.api_bundle.storage_token_resolver_client';
+
+    /**
+     * Service id of the base Storage {@see ClientOptions} shared by token verification and the
+     * controller-facing Storage client, so both use identical Connection URL / logger / options.
+     */
+    private const STORAGE_CLIENT_BASE_OPTIONS_ID = 'keboola.api_bundle.storage_client_base_options';
 
     /**
      * Path to the projected Kubernetes ServiceAccount token (audience keboola-connection) the
@@ -75,30 +81,15 @@ class KeboolaApiExtension extends Extension
         array $config,
         array &$authenticators,
     ): void {
-        if (!class_exists(StorageClientRequestFactory::class)) {
+        if (!class_exists(ClientWrapper::class)) {
             return;
         }
 
-        // Manage API client that exchanges programmatic tokens for legacy Storage tokens. It
-        // authenticates with the service's projected Kubernetes ServiceAccount JWT (read per
-        // request) and calls Connection over the ServiceClient's default DNS.
-        $container->register(self::STORAGE_TOKEN_RESOLVER_CLIENT_ID, ManageApiClient::class)
-            ->setFactory([new Reference(ManageApiClientFactory::class), 'getClientForServiceAccountTokenPath'])
-            ->setArguments([self::SERVICE_ACCOUNT_TOKEN_PATH])
-        ;
-
-        $container->register(StorageApiTokenFactory::class)
-            ->setArgument('$clientRequestFactory', new Reference(StorageClientRequestFactory::class))
-            ->setArgument('$resolverClient', new Reference(self::STORAGE_TOKEN_RESOLVER_CLIENT_ID))
-            ->setArgument('$logger', new Reference('logger'))
-        ;
-
-        $container->register(StorageApiTokenAuthenticator::class)
-            ->setArgument('$tokenFactory', new Reference(StorageApiTokenFactory::class))
-        ;
-        $authenticators[StorageApiTokenAuth::class] = new Reference(StorageApiTokenAuthenticator::class);
-
-        // StorageClientApiFactory controller-argument value resolver
+        // Base Storage ClientOptions shared by token verification (RequestStorageClientFactory) and
+        // the controller-facing StorageClientApiFactory (via StorageClientApiFactoryResolver), so a
+        // request is verified with the same Connection URL / logger / user agent / tuned options the
+        // controller-facing client uses. Connection URL comes from the ServiceClient; consumers tune
+        // it through the storage_client_options node.
         $connectionUrl = (new Definition())
             ->setFactory([new Reference(ServiceClient::class), 'getConnectionServiceUrl']);
 
@@ -111,8 +102,34 @@ class KeboolaApiExtension extends Extension
         assert(is_array($storageClientOptions));
         $this->applyStorageClientOptions($baseClientOptions, $storageClientOptions);
 
+        $container->setDefinition(self::STORAGE_CLIENT_BASE_OPTIONS_ID, $baseClientOptions);
+
+        // Manage API client that exchanges programmatic tokens for legacy Storage tokens. It
+        // authenticates with the service's projected Kubernetes ServiceAccount JWT (read per
+        // request) and calls Connection over the ServiceClient's default DNS.
+        $container->register(self::STORAGE_TOKEN_RESOLVER_CLIENT_ID, ManageApiClient::class)
+            ->setFactory([new Reference(ManageApiClientFactory::class), 'getClientForServiceAccountTokenPath'])
+            ->setArguments([self::SERVICE_ACCOUNT_TOKEN_PATH])
+        ;
+
+        $container->register(RequestStorageClientFactory::class)
+            ->setArgument('$baseClientOptions', new Reference(self::STORAGE_CLIENT_BASE_OPTIONS_ID))
+        ;
+
+        $container->register(StorageApiTokenFactory::class)
+            ->setArgument('$clientFactory', new Reference(RequestStorageClientFactory::class))
+            ->setArgument('$resolverClient', new Reference(self::STORAGE_TOKEN_RESOLVER_CLIENT_ID))
+            ->setArgument('$logger', new Reference('logger'))
+        ;
+
+        $container->register(StorageApiTokenAuthenticator::class)
+            ->setArgument('$tokenFactory', new Reference(StorageApiTokenFactory::class))
+        ;
+        $authenticators[StorageApiTokenAuth::class] = new Reference(StorageApiTokenAuthenticator::class);
+
+        // StorageClientApiFactory controller-argument value resolver
         $container->register(StorageClientApiFactoryResolver::class)
-            ->setArgument('$baseClientOptions', $baseClientOptions)
+            ->setArgument('$baseClientOptions', new Reference(self::STORAGE_CLIENT_BASE_OPTIONS_ID))
             ->setArgument('$tokenStorage', new Reference(TokenStorageInterface::class))
             ->addTag('controller.argument_value_resolver')
         ;

--- a/libs/api-bundle/src/Security/StorageApiToken/RequestToken.php
+++ b/libs/api-bundle/src/Security/StorageApiToken/RequestToken.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Keboola\ApiBundle\Security\StorageApiToken;
+
+use SensitiveParameter;
+
+/**
+ * A token extracted from an incoming request together with its classified {@see RequestTokenType},
+ * the single source of truth for how the token is subsequently handled.
+ */
+final class RequestToken
+{
+    public function __construct(
+        #[SensitiveParameter]
+        public readonly string $token,
+        public readonly RequestTokenType $type,
+    ) {
+    }
+}

--- a/libs/api-bundle/src/Security/StorageApiToken/RequestTokenType.php
+++ b/libs/api-bundle/src/Security/StorageApiToken/RequestTokenType.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Keboola\ApiBundle\Security\StorageApiToken;
+
+/**
+ * The kind of token an incoming request carries, as classified from its headers by
+ * {@see StorageApiTokenAuthenticator}. Each case maps to exactly one handling method on
+ * {@see StorageApiTokenFactory}.
+ */
+enum RequestTokenType
+{
+    /** Legacy Storage token: `X-StorageApi-Token`, or a non-Bearer `Authorization` value. */
+    case StorageToken;
+
+    /** OAuth bearer token: `Authorization: Bearer <token>` that is not a programmatic token. */
+    case OAuthToken;
+
+    /** Connection programmatic token: `Authorization: Bearer <kbc_at_*|kbc_pat_*>`. */
+    case Programmatic;
+}

--- a/libs/api-bundle/src/Security/StorageApiToken/StorageApiTokenAuthenticator.php
+++ b/libs/api-bundle/src/Security/StorageApiToken/StorageApiTokenAuthenticator.php
@@ -24,6 +24,8 @@ use Symfony\Component\Security\Core\Exception\AccessDeniedException;
 class StorageApiTokenAuthenticator implements TokenAuthenticatorInterface
 {
     private const BEARER_PATTERN = '/^Bearer\s+(.+)$/i';
+    private const AUTHORIZATION_HEADER = 'Authorization';
+    private const TOKEN_HEADER = 'X-StorageApi-Token';
 
     public function __construct(
         private readonly StorageApiTokenFactory $tokenFactory,
@@ -32,18 +34,7 @@ class StorageApiTokenAuthenticator implements TokenAuthenticatorInterface
 
     public function extractToken(Request $request): ?string
     {
-        // Check Authorization header first
-        $authHeader = $request->headers->get('Authorization');
-        if ($authHeader !== null) {
-            // Validate it's a Bearer token and strip prefix
-            if (preg_match(self::BEARER_PATTERN, $authHeader, $matches)) {
-                return $matches[1];
-            }
-            return $authHeader;
-        }
-
-        // Check X-StorageApi-Token header
-        return $request->headers->get('X-StorageApi-Token');
+        return $this->extractCredential($request)?->token;
     }
 
     public function authenticateToken(
@@ -53,34 +44,53 @@ class StorageApiTokenAuthenticator implements TokenAuthenticatorInterface
     ): StorageApiToken {
         assert($authAttribute instanceof StorageApiTokenAuth);
 
-        // Exchange is restricted to programmatic tokens that explicitly arrive as
-        // `Authorization: Bearer <kbc_at|kbc_pat>`. A bare `Authorization: <kbc_...>` or
-        // `X-StorageApi-Token: kbc_...` is an undocumented shape and stays on the legacy
-        // verification path, preserving pre-exchange behaviour.
-        if ($this->isProgrammaticBearerToken($request, $token)) {
-            return $this->tokenFactory->createFromProgrammaticToken($request, $token);
-        }
+        // AttributeAuthenticator only calls authenticateToken() after extractToken() returned a
+        // non-null token, and passes back exactly that token - so re-extracting here yields a
+        // credential whose token matches $token. Each classified type maps to one factory method.
+        $credential = $this->extractCredential($request);
+        assert($credential !== null && $credential->token === $token);
 
-        return $this->tokenFactory->createFromRequest($request);
+        return match ($credential->type) {
+            RequestTokenType::Programmatic => $this->tokenFactory
+                ->createFromProgrammaticToken($request, $credential->token),
+            RequestTokenType::OAuthToken => $this->tokenFactory
+                ->createFromOAuthToken($request, $credential->token),
+            RequestTokenType::StorageToken => $this->tokenFactory
+                ->createFromStorageToken($request, $credential->token),
+        };
     }
 
     /**
-     * True only when $token is a programmatic token and is exactly the value presented as
-     * `Authorization: Bearer <kbc_...>`. Other carriers (bare Authorization value,
-     * X-StorageApi-Token) are not eligible for exchange. Comparing against $token guarantees
-     * the exchanged token is the one {@see self::extractToken()} returned.
+     * Single source of truth for the token an incoming request carries and its {@see RequestTokenType}:
+     * `Authorization: Bearer <kbc_at_*|kbc_pat_*>` is {@see RequestTokenType::Programmatic}, any other
+     * `Authorization: Bearer <t>` is {@see RequestTokenType::OAuthToken}, and any non-Bearer
+     * `Authorization` value (taken verbatim) or the `X-StorageApi-Token` header is
+     * {@see RequestTokenType::StorageToken}. Returns null when no token is present.
      */
-    private function isProgrammaticBearerToken(Request $request, string $token): bool
+    private function extractCredential(Request $request): ?RequestToken
     {
-        if (!ProgrammaticToken::matches($token)) {
-            return false;
+        $authHeader = $request->headers->get(self::AUTHORIZATION_HEADER);
+        if ($authHeader !== null) {
+            if (preg_match(self::BEARER_PATTERN, $authHeader, $matches) === 1) {
+                $bearerToken = $matches[1];
+                $type = ProgrammaticToken::matches($bearerToken)
+                    ? RequestTokenType::Programmatic
+                    : RequestTokenType::OAuthToken;
+
+                return new RequestToken($bearerToken, $type);
+            }
+
+            // A non-Bearer Authorization value is taken verbatim and treated as a legacy token,
+            // preserving the historical extractToken() behaviour.
+            return new RequestToken($authHeader, RequestTokenType::StorageToken);
         }
 
-        $authHeader = $request->headers->get('Authorization');
+        $storageToken = $request->headers->get(self::TOKEN_HEADER);
+        if ($storageToken !== null && $storageToken !== '') {
+            return new RequestToken($storageToken, RequestTokenType::StorageToken);
+        }
 
-        return $authHeader !== null
-            && preg_match(self::BEARER_PATTERN, $authHeader, $matches) === 1
-            && $matches[1] === $token;
+        return null;
     }
 
     public function authorizeToken(AuthAttributeInterface $authAttribute, TokenInterface $token): void

--- a/libs/api-bundle/src/Security/StorageApiToken/StorageApiTokenFactory.php
+++ b/libs/api-bundle/src/Security/StorageApiToken/StorageApiTokenFactory.php
@@ -4,12 +4,12 @@ declare(strict_types=1);
 
 namespace Keboola\ApiBundle\Security\StorageApiToken;
 
+use Keboola\ApiBundle\StorageApiClient\RequestStorageClientFactory;
 use Keboola\ManageApi\Client as ManageApiClient;
 use Keboola\ManageApi\ClientException as ManageApiClientException;
 use Keboola\ManageApi\MaintenanceException;
 use Keboola\StorageApi\ClientException;
 use Keboola\StorageApiBranch\Factory\AuthType;
-use Keboola\StorageApiBranch\Factory\StorageClientRequestFactory;
 use Psr\Log\LoggerInterface;
 use RuntimeException;
 use SensitiveParameter;
@@ -19,7 +19,8 @@ use Symfony\Component\Security\Core\Exception\CustomUserMessageAuthenticationExc
 
 /**
  * Builds a {@see StorageApiToken}. Legacy tokens carried by the request are verified directly
- * against Storage API ({@see self::createFromRequest()}). Connection programmatic tokens
+ * against Storage API ({@see self::createFromStorageToken()} / {@see self::createFromOAuthToken()}).
+ * Connection programmatic tokens
  * (kbc_at_* / kbc_pat_*) are exchanged through Manage API's auth-bridge resolver
  * ({@see ManageApiClient::resolveStorageToken()}), which returns the legacy Storage token
  * together with its full token detail (the same payload as GET /v2/storage/tokens/verify), so no
@@ -33,19 +34,55 @@ class StorageApiTokenFactory
     private const PROJECT_ID_HEADER = 'X-KBC-ProjectId';
 
     public function __construct(
-        private readonly StorageClientRequestFactory $clientRequestFactory,
+        private readonly RequestStorageClientFactory $clientFactory,
         private readonly ManageApiClient $resolverClient,
         private readonly LoggerInterface $logger,
     ) {
     }
 
     /**
-     * Verifies the token carried by the request (Authorization: Bearer or X-StorageApi-Token).
+     * Verifies a legacy Storage token (carried as `X-StorageApi-Token`) against Storage API; the
+     * resulting {@see StorageApiToken} is typed {@see AuthType::STORAGE_TOKEN}.
      */
-    public function createFromRequest(Request $request): StorageApiToken
-    {
+    public function createFromStorageToken(
+        Request $request,
+        #[SensitiveParameter]
+        string $token,
+    ): StorageApiToken {
+        return $this->verify($request, $token, AuthType::STORAGE_TOKEN);
+    }
+
+    /**
+     * Verifies an OAuth bearer token (carried as `Authorization: Bearer`) against Storage API; the
+     * resulting {@see StorageApiToken} is typed {@see AuthType::BEARER} so it is sent with the bearer
+     * scheme when a client is later built from it.
+     */
+    public function createFromOAuthToken(
+        Request $request,
+        #[SensitiveParameter]
+        string $token,
+    ): StorageApiToken {
+        return $this->verify($request, $token, AuthType::BEARER);
+    }
+
+    /**
+     * Shared Storage-API verification for the two request-carried token types. 4xx Storage errors
+     * are surfaced to the caller; other errors bubble up unchanged. Programmatic tokens never reach
+     * this — their detail comes from the resolver ({@see self::createFromProgrammaticToken()}).
+     */
+    private function verify(
+        Request $request,
+        #[SensitiveParameter]
+        string $token,
+        AuthType $authType,
+    ): StorageApiToken {
         try {
-            return $this->verifyRequestToken($request);
+            $storageApiClient = $this->clientFactory
+                ->createClientWrapper($token, $authType, $request)
+                ->getBasicClient();
+            $tokenInfo = $storageApiClient->verifyToken();
+
+            return new StorageApiToken($tokenInfo, $storageApiClient->getTokenString(), $authType);
         } catch (ClientException $e) {
             if ($e->getCode() >= 400 && $e->getCode() < 500) {
                 throw new CustomUserMessageAuthenticationException($e->getMessage(), [], $e->getCode(), $e);
@@ -136,23 +173,6 @@ class StorageApiTokenFactory
 
         // The exchange resolves the programmatic token to a legacy Storage token.
         return new StorageApiToken($tokenDetail, $storageToken, AuthType::STORAGE_TOKEN);
-    }
-
-    /**
-     * Raw verification against Storage API for legacy tokens carried by the request;
-     * {@see self::createFromRequest()} maps the exceptions (4xx messages are echoed to the
-     * caller). Programmatic tokens never reach this - their detail comes from the resolver.
-     */
-    private function verifyRequestToken(Request $request): StorageApiToken
-    {
-        $wrapper = $this->clientRequestFactory->createClientWrapper($request);
-        $storageApiClient = $wrapper->getBasicClient();
-        $tokenInfo = $storageApiClient->verifyToken();
-
-        // Reuse the auth type the request factory resolved from the request headers.
-        $authType = $wrapper->getClientOptionsReadOnly()->getAuthType() ?? AuthType::STORAGE_TOKEN;
-
-        return new StorageApiToken($tokenInfo, $storageApiClient->getTokenString(), $authType);
     }
 
     private function extractProjectId(Request $request): int

--- a/libs/api-bundle/src/StorageApiClient/RequestStorageClientFactory.php
+++ b/libs/api-bundle/src/StorageApiClient/RequestStorageClientFactory.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Keboola\ApiBundle\StorageApiClient;
+
+use Keboola\StorageApiBranch\ClientWrapper;
+use Keboola\StorageApiBranch\Factory\AuthType;
+use Keboola\StorageApiBranch\Factory\ClientOptions;
+use SensitiveParameter;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * Builds the Storage {@see ClientWrapper} used to verify a token carried by an incoming request.
+ *
+ * Bundle-owned successor to keboola/storage-api-php-client-branch-wrapper's
+ * {@see \Keboola\StorageApiBranch\Factory\StorageClientRequestFactory}: the request's token and
+ * auth type are resolved once by
+ * {@see \Keboola\ApiBundle\Security\StorageApiToken\StorageApiTokenAuthenticator} and passed in,
+ * so this factory only binds them onto the bundle's base {@see ClientOptions} (the same base the
+ * controller-facing {@see StorageClientApiFactory} uses). Kept injectable (non-final) so functional
+ * tests can replace it via {@see \Keboola\ApiBundle\Test\AuthenticatorTestTrait}.
+ */
+class RequestStorageClientFactory
+{
+    public function __construct(
+        private readonly ClientOptions $baseClientOptions,
+    ) {
+    }
+
+    public function createClientWrapper(
+        #[SensitiveParameter]
+        string $token,
+        AuthType $authType,
+        Request $request,
+        ?ClientOptions $overrides = null,
+    ): ClientWrapper {
+        return StorageClientWrapperFactory::create(
+            $this->baseClientOptions,
+            $token,
+            $authType,
+            $request,
+            $overrides,
+        );
+    }
+}

--- a/libs/api-bundle/src/StorageApiClient/StorageClientApiFactory.php
+++ b/libs/api-bundle/src/StorageApiClient/StorageClientApiFactory.php
@@ -11,7 +11,7 @@ use Symfony\Component\HttpFoundation\Request;
 
 class StorageClientApiFactory
 {
-    public const RUN_ID_HEADER = 'X-KBC-RunId';
+    public const RUN_ID_HEADER = StorageClientWrapperFactory::RUN_ID_HEADER;
 
     public function __construct(
         private readonly ClientOptions $baseClientOptions,
@@ -22,32 +22,12 @@ class StorageClientApiFactory
 
     public function createClientWrapper(?ClientOptions $clientOptions = null): ClientWrapper
     {
-        $options = clone $this->baseClientOptions;
-        if ($clientOptions !== null) {
-            $options->addValuesFrom($clientOptions);
-        }
-
-        $options->setToken($this->token->getTokenValue());
-        $options->setAuthType($this->token->getTokenType());
-        $options->setRunId($this->getRunId($options));
-
-        return new ClientWrapper($options);
-    }
-
-    private function getRunId(ClientOptions $options): string
-    {
-        $runId = (string) $this->request->headers->get(self::RUN_ID_HEADER);
-
-        if ($runId === '') {
-            $runIdGenerator = $options->getRunIdGenerator();
-            if ($runIdGenerator !== null) {
-                $runId = $runIdGenerator($options);
-                assert(is_string($runId));
-            } else {
-                $runId = uniqid('run-');
-            }
-        }
-
-        return $runId;
+        return StorageClientWrapperFactory::create(
+            $this->baseClientOptions,
+            $this->token->getTokenValue(),
+            $this->token->getTokenType(),
+            $this->request,
+            $clientOptions,
+        );
     }
 }

--- a/libs/api-bundle/src/StorageApiClient/StorageClientWrapperFactory.php
+++ b/libs/api-bundle/src/StorageApiClient/StorageClientWrapperFactory.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Keboola\ApiBundle\StorageApiClient;
+
+use Keboola\StorageApiBranch\ClientWrapper;
+use Keboola\StorageApiBranch\Factory\AuthType;
+use Keboola\StorageApiBranch\Factory\ClientOptions;
+use SensitiveParameter;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * Single place that turns base {@see ClientOptions} plus a resolved (token, authType) into a
+ * Storage {@see ClientWrapper}: it clones the base (so it is never mutated), merges optional
+ * per-call overrides, pins the token/authType (which therefore win over overrides) and resolves
+ * the run id from the request. Shared by the controller-facing {@see StorageClientApiFactory} and
+ * the token-verification {@see RequestStorageClientFactory} so the wrapper is built one way only.
+ */
+final class StorageClientWrapperFactory
+{
+    public const RUN_ID_HEADER = 'X-KBC-RunId';
+
+    public static function create(
+        ClientOptions $baseClientOptions,
+        #[SensitiveParameter]
+        string $token,
+        AuthType $authType,
+        Request $request,
+        ?ClientOptions $overrides = null,
+    ): ClientWrapper {
+        $options = clone $baseClientOptions;
+        if ($overrides !== null) {
+            $options->addValuesFrom($overrides);
+        }
+
+        $options->setToken($token);
+        $options->setAuthType($authType);
+        $options->setRunId(self::resolveRunId($request, $options));
+
+        return new ClientWrapper($options);
+    }
+
+    private static function resolveRunId(Request $request, ClientOptions $options): string
+    {
+        $runId = (string) $request->headers->get(self::RUN_ID_HEADER);
+        if ($runId !== '') {
+            return $runId;
+        }
+
+        $runIdGenerator = $options->getRunIdGenerator();
+        if ($runIdGenerator !== null) {
+            $runId = $runIdGenerator($options);
+            assert(is_string($runId));
+            return $runId;
+        }
+
+        return uniqid('run-');
+    }
+}

--- a/libs/api-bundle/src/Test/AuthenticatorTestTrait.php
+++ b/libs/api-bundle/src/Test/AuthenticatorTestTrait.php
@@ -7,12 +7,11 @@ namespace Keboola\ApiBundle\Test;
 use Keboola\ApiBundle\DependencyInjection\KeboolaApiExtension;
 use Keboola\ApiBundle\Security\ApplicationToken\ManageApiClientFactory;
 use Keboola\ApiBundle\Security\StorageApiToken\StorageApiToken;
+use Keboola\ApiBundle\StorageApiClient\RequestStorageClientFactory;
 use Keboola\ManageApi\Client as ManageApiClient;
 use Keboola\StorageApi\Client as StorageApiClient;
 use Keboola\StorageApiBranch\ClientWrapper;
 use Keboola\StorageApiBranch\Factory\AuthType;
-use Keboola\StorageApiBranch\Factory\ClientOptions;
-use Keboola\StorageApiBranch\Factory\StorageClientRequestFactory;
 use PHPUnit\Framework\MockObject\MockObject;
 use Symfony\Bundle\FrameworkBundle\KernelBrowser;
 use Symfony\Component\BrowserKit\AbstractBrowser;
@@ -137,9 +136,12 @@ trait AuthenticatorTestTrait
     }
 
     /**
-     * Stubs the request-verification path ({@see StorageApiTokenFactory::createFromRequest()}) for a
-     * token carried directly by the request, tagging the fake wrapper with $authType so the resolved
-     * {@see StorageApiToken} carries the matching type.
+     * Stubs the request-verification path ({@see StorageApiTokenFactory::createFromStorageToken()} /
+     * {@see StorageApiTokenFactory::createFromOAuthToken()}) for a token carried directly by the
+     * request. The resolved {@see StorageApiToken} carries $authType;
+     * the request the test issues must use the matching scheme (`Authorization: Bearer …` for
+     * {@see AuthType::BEARER}, `X-StorageApi-Token` for {@see AuthType::STORAGE_TOKEN}), since the
+     * authenticator derives the auth type from the request headers exactly as it does in production.
      *
      * @param list<string> $features
      */
@@ -158,12 +160,11 @@ trait AuthenticatorTestTrait
 
         $clientWrapper = $this->createMock(ClientWrapper::class);
         $clientWrapper->method('getBasicClient')->willReturn($storageApiClient);
-        $clientWrapper->method('getClientOptionsReadOnly')->willReturn(new ClientOptions(authType: $authType));
 
-        $clientRequestFactory = $this->createMock(StorageClientRequestFactory::class);
-        $clientRequestFactory->method('createClientWrapper')->willReturn($clientWrapper);
+        $clientFactory = $this->createMock(RequestStorageClientFactory::class);
+        $clientFactory->method('createClientWrapper')->willReturn($clientWrapper);
 
-        self::getContainer()->set(StorageClientRequestFactory::class, $clientRequestFactory);
+        self::getContainer()->set(RequestStorageClientFactory::class, $clientFactory);
 
         return new StorageApiToken($tokenData, $tokenString, $authType);
     }

--- a/libs/api-bundle/tests/DependencyInjection/KeboolaApiExtensionTest.php
+++ b/libs/api-bundle/tests/DependencyInjection/KeboolaApiExtensionTest.php
@@ -8,6 +8,7 @@ use Keboola\ApiBundle\DependencyInjection\KeboolaApiExtension;
 use Keboola\ApiBundle\Security\ApplicationToken\ManageApiClientFactory;
 use Keboola\ApiBundle\Security\StorageApiToken\StorageApiTokenAuthenticator;
 use Keboola\ApiBundle\Security\StorageApiToken\StorageApiTokenFactory;
+use Keboola\ApiBundle\StorageApiClient\RequestStorageClientFactory;
 use Keboola\ApiBundle\StorageApiClient\StorageClientApiFactoryResolver;
 use Keboola\ManageApi\Client as ManageApiClient;
 use Keboola\ServiceClient\ServiceClient;
@@ -35,6 +36,28 @@ class KeboolaApiExtensionTest extends TestCase
         return $container;
     }
 
+    /**
+     * The base Storage ClientOptions is a shared service both token verification
+     * ({@see RequestStorageClientFactory}) and the controller-facing resolver reference. Resolve
+     * that reference from the given service argument and return the underlying definition, asserting
+     * both consumers point at the very same service id.
+     */
+    private function resolveSharedBaseClientOptions(ContainerBuilder $container): Definition
+    {
+        $resolverRef = $container->getDefinition(StorageClientApiFactoryResolver::class)
+            ->getArgument('$baseClientOptions');
+        self::assertInstanceOf(Reference::class, $resolverRef);
+
+        $verificationRef = $container->getDefinition(RequestStorageClientFactory::class)
+            ->getArgument('$baseClientOptions');
+        self::assertInstanceOf(Reference::class, $verificationRef);
+
+        // token verification and the controller-facing client must share one base-options service
+        self::assertSame((string) $resolverRef, (string) $verificationRef);
+
+        return $container->getDefinition((string) $resolverRef);
+    }
+
     // -------------------------------------------------------------------------
     // Service registration
     // -------------------------------------------------------------------------
@@ -50,6 +73,10 @@ class KeboolaApiExtensionTest extends TestCase
         self::assertTrue(
             $container->hasDefinition(KeboolaApiExtension::STORAGE_TOKEN_RESOLVER_CLIENT_ID),
             'Storage token resolver client must be registered',
+        );
+        self::assertTrue(
+            $container->hasDefinition(RequestStorageClientFactory::class),
+            'RequestStorageClientFactory must be registered',
         );
         self::assertTrue(
             $container->hasDefinition(StorageApiTokenAuthenticator::class),
@@ -69,8 +96,7 @@ class KeboolaApiExtensionTest extends TestCase
         $definition = $container->getDefinition(StorageClientApiFactoryResolver::class);
         self::assertArrayHasKey('controller.argument_value_resolver', $definition->getTags());
 
-        $baseClientOptions = $definition->getArgument('$baseClientOptions');
-        self::assertInstanceOf(Definition::class, $baseClientOptions);
+        $baseClientOptions = $this->resolveSharedBaseClientOptions($container);
         self::assertSame(ClientOptions::class, $baseClientOptions->getClass());
 
         // userAgent is the configured app name
@@ -121,11 +147,15 @@ class KeboolaApiExtensionTest extends TestCase
         );
     }
 
-    public function testTokenFactoryReceivesResolverClientAndLogger(): void
+    public function testTokenFactoryReceivesClientFactoryResolverClientAndLogger(): void
     {
         $container = $this->buildContainer([[]]);
 
         $definition = $container->getDefinition(StorageApiTokenFactory::class);
+
+        $clientFactory = $definition->getArgument('$clientFactory');
+        self::assertInstanceOf(Reference::class, $clientFactory);
+        self::assertSame(RequestStorageClientFactory::class, (string) $clientFactory);
 
         $resolverClient = $definition->getArgument('$resolverClient');
         self::assertInstanceOf(Reference::class, $resolverClient);
@@ -164,8 +194,7 @@ class KeboolaApiExtensionTest extends TestCase
             ],
         ]]);
 
-        $base = $container->getDefinition(StorageClientApiFactoryResolver::class)->getArgument('$baseClientOptions');
-        self::assertInstanceOf(Definition::class, $base);
+        $base = $this->resolveSharedBaseClientOptions($container);
 
         self::assertSame(10, $base->getArgument('$backoffMaxTries'));
         self::assertSame(5, $base->getArgument('$awsRetries'));
@@ -186,8 +215,7 @@ class KeboolaApiExtensionTest extends TestCase
             ],
         ]]);
 
-        $base = $container->getDefinition(StorageClientApiFactoryResolver::class)->getArgument('$baseClientOptions');
-        self::assertInstanceOf(Definition::class, $base);
+        $base = $this->resolveSharedBaseClientOptions($container);
 
         $logger = $base->getArgument('$logger');
         self::assertInstanceOf(Reference::class, $logger);
@@ -200,8 +228,7 @@ class KeboolaApiExtensionTest extends TestCase
             'storage_client_options' => 'app.storage_options',
         ]]);
 
-        $base = $container->getDefinition(StorageClientApiFactoryResolver::class)->getArgument('$baseClientOptions');
-        self::assertInstanceOf(Definition::class, $base);
+        $base = $this->resolveSharedBaseClientOptions($container);
 
         $calls = $base->getMethodCalls();
         self::assertCount(1, $calls);
@@ -224,8 +251,7 @@ class KeboolaApiExtensionTest extends TestCase
     {
         $container = $this->buildContainer([[]]);
 
-        $base = $container->getDefinition(StorageClientApiFactoryResolver::class)->getArgument('$baseClientOptions');
-        self::assertInstanceOf(Definition::class, $base);
+        $base = $this->resolveSharedBaseClientOptions($container);
 
         self::assertSame([], $base->getMethodCalls());
         self::assertSame(

--- a/libs/api-bundle/tests/Security/StorageApiToken/StorageApiTokenAuthenticatorTest.php
+++ b/libs/api-bundle/tests/Security/StorageApiToken/StorageApiTokenAuthenticatorTest.php
@@ -98,16 +98,38 @@ class StorageApiTokenAuthenticatorTest extends TestCase
         $tokenFactory = $this->createMock(StorageApiTokenFactory::class);
         $tokenFactory
             ->expects(self::once())
-            ->method('createFromRequest')
-            ->with($request)
+            ->method('createFromStorageToken')
+            ->with($request, 'legacy-token')
             ->willReturn($expectedToken);
-        $tokenFactory
-            ->expects(self::never())
-            ->method('createFromProgrammaticToken');
+        $tokenFactory->expects(self::never())->method('createFromOAuthToken');
+        $tokenFactory->expects(self::never())->method('createFromProgrammaticToken');
 
         $authenticator = new StorageApiTokenAuthenticator($tokenFactory);
 
         $result = $authenticator->authenticateToken(new StorageApiTokenAuth(), 'legacy-token', $request);
+
+        self::assertSame($expectedToken, $result);
+    }
+
+    public function testAuthenticateTokenRoutesOAuthBearerTokenToOAuthVerification(): void
+    {
+        $expectedToken = $this->createMock(StorageApiToken::class);
+
+        $request = Request::create('https://keboola.com');
+        $request->headers->set('Authorization', 'Bearer oauth-access-token');
+
+        $tokenFactory = $this->createMock(StorageApiTokenFactory::class);
+        $tokenFactory
+            ->expects(self::once())
+            ->method('createFromOAuthToken')
+            ->with($request, 'oauth-access-token')
+            ->willReturn($expectedToken);
+        $tokenFactory->expects(self::never())->method('createFromStorageToken');
+        $tokenFactory->expects(self::never())->method('createFromProgrammaticToken');
+
+        $authenticator = new StorageApiTokenAuthenticator($tokenFactory);
+
+        $result = $authenticator->authenticateToken(new StorageApiTokenAuth(), 'oauth-access-token', $request);
 
         self::assertSame($expectedToken, $result);
     }
@@ -121,9 +143,8 @@ class StorageApiTokenAuthenticatorTest extends TestCase
         $request->headers->set(self::PROJECT_ID_HEADER, '123');
 
         $tokenFactory = $this->createMock(StorageApiTokenFactory::class);
-        $tokenFactory
-            ->expects(self::never())
-            ->method('createFromRequest');
+        $tokenFactory->expects(self::never())->method('createFromStorageToken');
+        $tokenFactory->expects(self::never())->method('createFromOAuthToken');
         $tokenFactory
             ->expects(self::once())
             ->method('createFromProgrammaticToken')
@@ -144,46 +165,19 @@ class StorageApiTokenAuthenticatorTest extends TestCase
     ): void {
         $expectedToken = $this->createMock(StorageApiToken::class);
 
-        // The programmatic token does not arrive as `Authorization: Bearer`, so the legacy
-        // verification path must be used and exchange must not be attempted.
+        // The programmatic token does not arrive as `Authorization: Bearer`, so it is classified as
+        // a legacy Storage token and verified as such; exchange must not be attempted.
         $tokenFactory = $this->createMock(StorageApiTokenFactory::class);
         $tokenFactory
             ->expects(self::once())
-            ->method('createFromRequest')
+            ->method('createFromStorageToken')
+            ->with(self::anything(), self::SUBJECT_TOKEN)
             ->willReturn($expectedToken);
-        $tokenFactory
-            ->expects(self::never())
-            ->method('createFromProgrammaticToken');
+        $tokenFactory->expects(self::never())->method('createFromOAuthToken');
+        $tokenFactory->expects(self::never())->method('createFromProgrammaticToken');
 
         $request = Request::create('https://keboola.com');
         $request->headers->set($headerName, $headerValue);
-        $request->headers->set(self::PROJECT_ID_HEADER, '123');
-
-        $authenticator = new StorageApiTokenAuthenticator($tokenFactory);
-
-        $result = $authenticator->authenticateToken(new StorageApiTokenAuth(), self::SUBJECT_TOKEN, $request);
-
-        self::assertSame($expectedToken, $result);
-    }
-
-    public function testAuthenticateTokenDoesNotExchangeWhenBearerHeaderDiffersFromExtractedToken(): void
-    {
-        $expectedToken = $this->createMock(StorageApiToken::class);
-
-        // Defensive consistency check: exchange may only run with the token extractToken()
-        // returned. If the Authorization header somehow carries a different programmatic token
-        // than $token, the request falls back to legacy verification.
-        $tokenFactory = $this->createMock(StorageApiTokenFactory::class);
-        $tokenFactory
-            ->expects(self::once())
-            ->method('createFromRequest')
-            ->willReturn($expectedToken);
-        $tokenFactory
-            ->expects(self::never())
-            ->method('createFromProgrammaticToken');
-
-        $request = Request::create('https://keboola.com');
-        $request->headers->set('Authorization', 'Bearer kbc_at_different');
         $request->headers->set(self::PROJECT_ID_HEADER, '123');
 
         $authenticator = new StorageApiTokenAuthenticator($tokenFactory);

--- a/libs/api-bundle/tests/Security/StorageApiToken/StorageApiTokenFactoryTest.php
+++ b/libs/api-bundle/tests/Security/StorageApiToken/StorageApiTokenFactoryTest.php
@@ -9,6 +9,7 @@ use Generator;
 use GuzzleHttp\Exception\ConnectException;
 use GuzzleHttp\Psr7\Request as GuzzleRequest;
 use Keboola\ApiBundle\Security\StorageApiToken\StorageApiTokenFactory;
+use Keboola\ApiBundle\StorageApiClient\RequestStorageClientFactory;
 use Keboola\ManageApi\Client as ManageApiClient;
 use Keboola\ManageApi\ClientException as ManageApiClientException;
 use Keboola\ManageApi\MaintenanceException as ManageApiMaintenanceException;
@@ -17,8 +18,6 @@ use Keboola\StorageApi\ClientException;
 use Keboola\StorageApi\MaintenanceException;
 use Keboola\StorageApiBranch\ClientWrapper;
 use Keboola\StorageApiBranch\Factory\AuthType;
-use Keboola\StorageApiBranch\Factory\ClientOptions;
-use Keboola\StorageApiBranch\Factory\StorageClientRequestFactory;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
@@ -33,12 +32,12 @@ class StorageApiTokenFactoryTest extends TestCase
     private const PROJECT_ID_HEADER = 'X-KBC-ProjectId';
 
     private function createFactory(
-        ?StorageClientRequestFactory $clientRequestFactory = null,
+        ?RequestStorageClientFactory $clientFactory = null,
         ?ManageApiClient $resolverClient = null,
         ?LoggerInterface $logger = null,
     ): StorageApiTokenFactory {
         return new StorageApiTokenFactory(
-            $clientRequestFactory ?? $this->createMock(StorageClientRequestFactory::class),
+            $clientFactory ?? $this->createMock(RequestStorageClientFactory::class),
             $resolverClient ?? $this->createMock(ManageApiClient::class),
             $logger ?? new NullLogger(),
         );
@@ -54,96 +53,65 @@ class StorageApiTokenFactoryTest extends TestCase
     }
 
     // ---------------------------------------------------------------------------
-    // createFromRequest – happy path
+    // createFromStorageToken / createFromOAuthToken – happy path
     // ---------------------------------------------------------------------------
 
-    public function testCreateFromRequestSuccess(): void
+    public function testCreateFromStorageTokenVerifiesAsStorageToken(): void
     {
-        $clientMock = $this->createMock(Client::class);
-        $clientMock
-            ->expects(self::once())
-            ->method('verifyToken')
-            ->willReturn(['id' => '42', 'description' => 'test']);
-        $clientMock
-            ->expects(self::once())
-            ->method('getTokenString')
-            ->willReturn('tok');
+        $factoryMock = $this->mockClientFactoryReturningVerifiedToken('tok', AuthType::STORAGE_TOKEN);
 
-        $wrapperMock = $this->createMock(ClientWrapper::class);
-        $wrapperMock
-            ->expects(self::once())
-            ->method('getBasicClient')
-            ->willReturn($clientMock);
-
-        $factoryMock = $this->createMock(StorageClientRequestFactory::class);
-        $factoryMock
-            ->expects(self::once())
-            ->method('createClientWrapper')
-            ->willReturn($wrapperMock);
-
-        $request = Request::create('https://keboola.com');
-        $request->headers->set(StorageClientRequestFactory::TOKEN_HEADER, 'tok');
-
-        $token = $this->createFactory(clientRequestFactory: $factoryMock)->createFromRequest($request);
+        $token = $this->createFactory(clientFactory: $factoryMock)
+            ->createFromStorageToken(Request::create('https://keboola.com'), 'tok');
 
         self::assertSame('tok', $token->getTokenValue());
+        self::assertSame(AuthType::STORAGE_TOKEN, $token->getTokenType());
+    }
+
+    public function testCreateFromOAuthTokenVerifiesAsBearer(): void
+    {
+        $factoryMock = $this->mockClientFactoryReturningVerifiedToken('tok', AuthType::BEARER);
+
+        $token = $this->createFactory(clientFactory: $factoryMock)
+            ->createFromOAuthToken(Request::create('https://keboola.com'), 'tok');
+
+        self::assertSame('tok', $token->getTokenValue());
+        self::assertSame(AuthType::BEARER, $token->getTokenType());
     }
 
     /**
-     * The resulting token records the auth type the request was verified with.
+     * Builds a RequestStorageClientFactory mock whose wrapper verifies successfully, asserting it is
+     * asked to build the client for the expected token/auth type.
      */
-    #[DataProvider('provideRequestAuthTypes')]
-    public function testCreateFromRequestSetsTokenTypeFromResolvedAuthType(
-        ?AuthType $resolvedAuthType,
-        AuthType $expectedTokenType,
-    ): void {
+    private function mockClientFactoryReturningVerifiedToken(
+        string $expectedToken,
+        AuthType $expectedAuthType,
+    ): RequestStorageClientFactory {
         $clientMock = $this->createMock(Client::class);
-        $clientMock->method('verifyToken')->willReturn(['id' => '42', 'description' => 'test']);
-        $clientMock->method('getTokenString')->willReturn('tok');
+        $clientMock->expects(self::once())->method('verifyToken')->willReturn(['id' => '42', 'description' => 'test']);
+        $clientMock->expects(self::once())->method('getTokenString')->willReturn($expectedToken);
 
         $wrapperMock = $this->createMock(ClientWrapper::class);
-        $wrapperMock->method('getBasicClient')->willReturn($clientMock);
-        $wrapperMock
-            ->method('getClientOptionsReadOnly')
-            ->willReturn(new ClientOptions(authType: $resolvedAuthType));
+        $wrapperMock->expects(self::once())->method('getBasicClient')->willReturn($clientMock);
 
-        $factoryMock = $this->createMock(StorageClientRequestFactory::class);
+        $factoryMock = $this->createMock(RequestStorageClientFactory::class);
         $factoryMock
             ->expects(self::once())
             ->method('createClientWrapper')
+            ->with($expectedToken, $expectedAuthType, self::anything())
             ->willReturn($wrapperMock);
 
-        $token = $this->createFactory(clientRequestFactory: $factoryMock)
-            ->createFromRequest(Request::create('https://keboola.com'));
-
-        self::assertSame($expectedTokenType, $token->getTokenType());
-    }
-
-    public static function provideRequestAuthTypes(): Generator
-    {
-        yield 'oauth bearer token' => [
-            'resolvedAuthType' => AuthType::BEARER,
-            'expectedTokenType' => AuthType::BEARER,
-        ];
-        yield 'legacy storage token' => [
-            'resolvedAuthType' => AuthType::STORAGE_TOKEN,
-            'expectedTokenType' => AuthType::STORAGE_TOKEN,
-        ];
-        yield 'unknown auth type falls back to storage token' => [
-            'resolvedAuthType' => null,
-            'expectedTokenType' => AuthType::STORAGE_TOKEN,
-        ];
+        return $factoryMock;
     }
 
     // ---------------------------------------------------------------------------
-    // createFromRequest – exception mapping
+    // verify – exception mapping (via createFromStorageToken)
     // ---------------------------------------------------------------------------
 
     /**
      * @param class-string<Exception> $expectedExceptionClass
      */
     #[DataProvider('provideExceptionData')]
-    public function testCreateFromRequestFailure(
+    public function testVerifyFailure(
         ClientException $clientException,
         string $expectedExceptionClass,
         string $expectedExceptionMessage,
@@ -161,20 +129,18 @@ class StorageApiTokenFactoryTest extends TestCase
             ->method('getBasicClient')
             ->willReturn($clientMock);
 
-        $factoryMock = $this->createMock(StorageClientRequestFactory::class);
+        $factoryMock = $this->createMock(RequestStorageClientFactory::class);
         $factoryMock
             ->expects(self::once())
             ->method('createClientWrapper')
             ->willReturn($wrapperMock);
 
-        $request = Request::create('https://keboola.com');
-        $request->headers->set(StorageClientRequestFactory::TOKEN_HEADER, 'token');
-
         self::expectException($expectedExceptionClass);
         self::expectExceptionMessage($expectedExceptionMessage);
         self::expectExceptionCode($expectedExceptionCode);
 
-        $this->createFactory(clientRequestFactory: $factoryMock)->createFromRequest($request);
+        $this->createFactory(clientFactory: $factoryMock)
+            ->createFromStorageToken(Request::create('https://keboola.com'), 'token');
     }
 
     public static function provideExceptionData(): Generator
@@ -229,14 +195,14 @@ class StorageApiTokenFactoryTest extends TestCase
             ]);
 
         // The resolver response carries the full token detail, so Storage API must not be hit.
-        $factoryMock = $this->createMock(StorageClientRequestFactory::class);
+        $factoryMock = $this->createMock(RequestStorageClientFactory::class);
         $factoryMock
             ->expects(self::never())
             ->method('createClientWrapper');
 
         $originalRequest = $this->createProgrammaticTokenRequest();
 
-        $token = $this->createFactory(clientRequestFactory: $factoryMock, resolverClient: $resolverClient)
+        $token = $this->createFactory(clientFactory: $factoryMock, resolverClient: $resolverClient)
             ->createFromProgrammaticToken($originalRequest, self::SUBJECT_TOKEN);
 
         self::assertSame('legacy-token', $token->getTokenValue());
@@ -409,13 +375,13 @@ class StorageApiTokenFactoryTest extends TestCase
             ->method('resolveStorageToken')
             ->willReturn($response);
 
-        $clientRequestFactory = $this->createMock(StorageClientRequestFactory::class);
-        $clientRequestFactory
+        $clientFactory = $this->createMock(RequestStorageClientFactory::class);
+        $clientFactory
             ->expects(self::never())
             ->method('createClientWrapper');
 
         $factory = $this->createFactory(
-            clientRequestFactory: $clientRequestFactory,
+            clientFactory: $clientFactory,
             resolverClient: $resolverClient,
         );
 

--- a/libs/api-bundle/tests/StorageApiClient/RequestStorageClientFactoryTest.php
+++ b/libs/api-bundle/tests/StorageApiClient/RequestStorageClientFactoryTest.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Keboola\ApiBundle\Tests\StorageApiClient;
+
+use Keboola\ApiBundle\StorageApiClient\RequestStorageClientFactory;
+use Keboola\StorageApiBranch\Factory\AuthType;
+use Keboola\StorageApiBranch\Factory\ClientOptions;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+
+class RequestStorageClientFactoryTest extends TestCase
+{
+    public function testBuildsWrapperBoundToGivenTokenAndAuthType(): void
+    {
+        $factory = new RequestStorageClientFactory(new ClientOptions('https://connection.test'));
+
+        $options = $factory
+            ->createClientWrapper('my-token', AuthType::BEARER, new Request())
+            ->getClientOptionsReadOnly();
+
+        self::assertSame('my-token', $options->getToken());
+        self::assertSame(AuthType::BEARER, $options->getAuthType());
+        self::assertSame('https://connection.test', $options->getUrl());
+    }
+
+    public function testRunIdTakenFromRequestHeader(): void
+    {
+        $factory = new RequestStorageClientFactory(new ClientOptions('https://connection.test'));
+
+        $wrapper = $factory->createClientWrapper(
+            'my-token',
+            AuthType::STORAGE_TOKEN,
+            new Request([], [], [], [], [], ['HTTP_X_KBC_RUNID' => '42']),
+        );
+
+        self::assertSame('42', $wrapper->getClientOptionsReadOnly()->getRunId());
+    }
+
+    public function testBaseOptionsAreNotMutatedBetweenCalls(): void
+    {
+        $base = new ClientOptions('https://connection.test');
+        $factory = new RequestStorageClientFactory($base);
+
+        $factory->createClientWrapper('token-a', AuthType::STORAGE_TOKEN, new Request());
+        $second = $factory
+            ->createClientWrapper('token-b', AuthType::BEARER, new Request())
+            ->getClientOptionsReadOnly();
+
+        self::assertNull($base->getToken());
+        self::assertSame('token-b', $second->getToken());
+        self::assertSame(AuthType::BEARER, $second->getAuthType());
+    }
+}

--- a/libs/api-bundle/tests/StorageApiClient/StorageClientWrapperFactoryTest.php
+++ b/libs/api-bundle/tests/StorageApiClient/StorageClientWrapperFactoryTest.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Keboola\ApiBundle\Tests\StorageApiClient;
+
+use Keboola\ApiBundle\StorageApiClient\StorageClientWrapperFactory;
+use Keboola\StorageApiBranch\Factory\AuthType;
+use Keboola\StorageApiBranch\Factory\ClientOptions;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+
+class StorageClientWrapperFactoryTest extends TestCase
+{
+    public function testBindsTokenAndStorageAuthType(): void
+    {
+        $options = StorageClientWrapperFactory::create(
+            new ClientOptions('https://connection.test'),
+            'my-token',
+            AuthType::STORAGE_TOKEN,
+            new Request(),
+        )->getClientOptionsReadOnly();
+
+        self::assertSame('my-token', $options->getToken());
+        self::assertSame(AuthType::STORAGE_TOKEN, $options->getAuthType());
+    }
+
+    public function testBindsBearerAuthType(): void
+    {
+        $options = StorageClientWrapperFactory::create(
+            new ClientOptions('https://connection.test'),
+            'bearer-token',
+            AuthType::BEARER,
+            new Request(),
+        )->getClientOptionsReadOnly();
+
+        self::assertSame('bearer-token', $options->getToken());
+        self::assertSame(AuthType::BEARER, $options->getAuthType());
+    }
+
+    public function testRunIdTakenFromRequestHeaderWhenPresent(): void
+    {
+        $wrapper = StorageClientWrapperFactory::create(
+            new ClientOptions('https://connection.test'),
+            'my-token',
+            AuthType::STORAGE_TOKEN,
+            new Request([], [], [], [], [], ['HTTP_X_KBC_RUNID' => '42']),
+        );
+
+        self::assertSame('42', $wrapper->getClientOptionsReadOnly()->getRunId());
+    }
+
+    public function testRunIdFallsBackToGeneratedValueWhenHeaderMissing(): void
+    {
+        $wrapper = StorageClientWrapperFactory::create(
+            new ClientOptions('https://connection.test'),
+            'my-token',
+            AuthType::STORAGE_TOKEN,
+            new Request(),
+        );
+
+        self::assertStringStartsWith('run-', (string) $wrapper->getClientOptionsReadOnly()->getRunId());
+    }
+
+    public function testRunIdGeneratorUsedWhenHeaderMissing(): void
+    {
+        $base = new ClientOptions('https://connection.test');
+        $base->setRunIdGenerator(fn (ClientOptions $o): string => 'gen-' . $o->getUrl());
+
+        $wrapper = StorageClientWrapperFactory::create($base, 'my-token', AuthType::STORAGE_TOKEN, new Request());
+
+        self::assertSame('gen-https://connection.test', $wrapper->getClientOptionsReadOnly()->getRunId());
+    }
+
+    public function testPerCallOverridesAreMergedButResolvedTokenAndAuthTypeWin(): void
+    {
+        $options = StorageClientWrapperFactory::create(
+            new ClientOptions('https://connection.test'),
+            'my-token',
+            AuthType::STORAGE_TOKEN,
+            new Request(),
+            new ClientOptions(token: 'override-token', branchId: '777', authType: AuthType::BEARER),
+        )->getClientOptionsReadOnly();
+
+        self::assertSame('777', $options->getBranchId());
+        // token/authType are pinned after the overrides are merged, so the resolved values win
+        self::assertSame('my-token', $options->getToken());
+        self::assertSame(AuthType::STORAGE_TOKEN, $options->getAuthType());
+    }
+
+    public function testBaseOptionsAreNotMutated(): void
+    {
+        $base = new ClientOptions('https://connection.test');
+
+        StorageClientWrapperFactory::create($base, 'my-token', AuthType::STORAGE_TOKEN, new Request());
+
+        self::assertNull($base->getToken());
+        self::assertNull($base->getAuthType());
+    }
+}

--- a/libs/api-bundle/tests/Test/AuthenticatorTestTraitTest.php
+++ b/libs/api-bundle/tests/Test/AuthenticatorTestTraitTest.php
@@ -6,10 +6,10 @@ namespace Keboola\ApiBundle\Tests\Test;
 
 use Keboola\ApiBundle\DependencyInjection\KeboolaApiExtension;
 use Keboola\ApiBundle\Security\ApplicationToken\ManageApiClientFactory;
+use Keboola\ApiBundle\StorageApiClient\RequestStorageClientFactory;
 use Keboola\ApiBundle\Test\AuthenticatorTestTrait;
 use Keboola\ManageApi\Client as ManageApiClient;
 use Keboola\StorageApiBranch\Factory\AuthType;
-use Keboola\StorageApiBranch\Factory\StorageClientRequestFactory;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
 
@@ -41,8 +41,8 @@ class AuthenticatorTestTraitTest extends WebTestCase
         self::assertSame(AuthType::STORAGE_TOKEN, $token->getTokenType());
 
         self::assertInstanceOf(
-            StorageClientRequestFactory::class,
-            self::getContainer()->get(StorageClientRequestFactory::class),
+            RequestStorageClientFactory::class,
+            self::getContainer()->get(RequestStorageClientFactory::class),
         );
     }
 
@@ -62,8 +62,8 @@ class AuthenticatorTestTraitTest extends WebTestCase
         self::assertSame(AuthType::BEARER, $token->getTokenType());
 
         self::assertInstanceOf(
-            StorageClientRequestFactory::class,
-            self::getContainer()->get(StorageClientRequestFactory::class),
+            RequestStorageClientFactory::class,
+            self::getContainer()->get(RequestStorageClientFactory::class),
         );
     }
 


### PR DESCRIPTION
## Release Notes
https://linear.app/keboola/issue/PAT-1896

`api-bundle` no longer depends on `Keboola\StorageApiBranch\Factory\StorageClientRequestFactory` from `keboola/storage-api-php-client-branch-wrapper`. That class was referenced as a service the bundle never registered, so every consuming app had to wire it up (with its own base `ClientOptions`) for `#[StorageApiTokenAuth]` to work — an undocumented footgun that also let token *verification* and the controller-facing Storage client drift apart on their base options. The package itself stays required: `ClientWrapper`, `ClientOptions`, `AuthType` and the base `StorageApiToken` are still used.

Verification now builds its Storage client from the bundle's own base `ClientOptions` via a new bundle-owned `RequestStorageClientFactory`, so verification and `StorageClientApiFactory` share one base-options service. `StorageApiTokenAuthenticator` classifies the incoming token exactly once — `extractCredential()` returns a `RequestTokenType` of `StorageToken` / `OAuthToken` / `Programmatic` — and dispatches each type to one dedicated `StorageApiTokenFactory` method. `ClientWrapper` construction, including run-id resolution, lives once in `StorageClientWrapperFactory`.

Key changes:
* Remove the `StorageClientRequestFactory` dependency and the implicit "consuming app must register it" contract.
* Add `RequestStorageClientFactory` (mockable verification seam), `StorageClientWrapperFactory` (single `ClientWrapper` builder), and the `RequestToken` / `RequestTokenType` classification the authenticator emits.
* Classify the request token once and map each type to one factory method: `createFromStorageToken()` / `createFromOAuthToken()` (both delegating to a shared private `verify()`) and `createFromProgrammaticToken()` — replacing the previous asymmetric `createFromRequest()` / `createFromProgrammaticToken()` split.
* Verification and the controller-facing client share one base `ClientOptions` service, so `storage_client_options` now applies to both.

## Plans for customer communication
None.

## Impact analysis
No end-user impact for the supported auth paths: `X-StorageApi-Token` and `Authorization: Bearer` behave identically (auth-type mapping and programmatic-token exchange are unchanged, and locked by existing tests). Two edge deltas on unsupported/malformed input, both still returning `401`: a non-`Bearer` `Authorization` value with no `X-StorageApi-Token` now reaches a Storage verify instead of an immediate local 401, and in functional tests the resolved auth type follows the request headers (as production already did) instead of a mock-baked value — the `AuthenticatorTestTrait` helpers require the request under test to carry the matching scheme.

## Change type
Refactoring

## Justification
Remove an implicit cross-package coupling (the unregistered `StorageClientRequestFactory` service) and de-duplicate token extraction and Storage client construction in api-bundle.

## Deployment
Merge & automatic deploy.

## Rollback plan
Revert of this PR.

## Post release support plan
None.
