### PR TITLE
fix(php-api-client-base): log requests at DEBUG instead of INFO (AJDA-2999)

### DIFF
--- a/libs/php-api-client-base/src/ApiClient.php
+++ b/libs/php-api-client-base/src/ApiClient.php
@@ -98,9 +98,6 @@ class ApiClient
             'auth',
         );
 
-        // Log every request at DEBUG: this is per-request diagnostic noise, so it must stay
-        // below the default INFO threshold consumers ship in production (otherwise every API
-        // call shows up in their logs). It surfaces only when debug logging is turned on.
         $stack->push(Middleware::log(
             $logger,
             new MessageFormatter('{method} {uri} : {code} {res_header_Content-Length}'),

--- a/libs/php-api-client-base/src/ApiClient.php
+++ b/libs/php-api-client-base/src/ApiClient.php
@@ -17,6 +17,7 @@ use Keboola\ApiClientBase\Auth\RequestAuthenticatorInterface;
 use Keboola\ApiClientBase\Exception\ClientException;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
+use Psr\Log\LogLevel;
 use Psr\Log\NullLogger;
 use Throwable;
 
@@ -97,9 +98,13 @@ class ApiClient
             'auth',
         );
 
+        // Log every request at DEBUG: this is per-request diagnostic noise, so it must stay
+        // below the default INFO threshold consumers ship in production (otherwise every API
+        // call shows up in their logs). It surfaces only when debug logging is turned on.
         $stack->push(Middleware::log(
             $logger,
             new MessageFormatter('{method} {uri} : {code} {res_header_Content-Length}'),
+            LogLevel::DEBUG,
         ));
 
         $this->httpClient = new GuzzleClient([

--- a/libs/sandboxes-service-api-client/tests/Apps/AppsApiClientTest.php
+++ b/libs/sandboxes-service-api-client/tests/Apps/AppsApiClientTest.php
@@ -733,6 +733,6 @@ class AppsApiClientTest extends TestCase
         );
         $client->listApps();
 
-        self::assertTrue($handler->hasRecords('INFO'), 'Passed logger should receive log entries');
+        self::assertTrue($handler->hasRecords('DEBUG'), 'Passed logger should receive log entries');
     }
 }

--- a/libs/sandboxes-service-api-client/tests/Sandboxes/SandboxesApiClientTest.php
+++ b/libs/sandboxes-service-api-client/tests/Sandboxes/SandboxesApiClientTest.php
@@ -616,6 +616,6 @@ class SandboxesApiClientTest extends TestCase
         );
         $client->getCurrentProject();
 
-        self::assertTrue($handler->hasRecords('INFO'), 'Passed logger should receive log entries');
+        self::assertTrue($handler->hasRecords('DEBUG'), 'Passed logger should receive log entries');
     }
 }


### PR DESCRIPTION
## Link to issue

https://linear.app/keboola/issue/AJDA-2999/conditional-flows-result-chybne-faze-prepise-vysledky-predchozich

## Description

`ApiClient` pushes a Guzzle `Middleware::log` for every request. It was constructed without an explicit log level, so it used Guzzle's default `LogLevel::INFO`. Once services migrated onto this base client (via `internal-api-php-client`), every API call started appearing in their production logs as lines like:

```
GET http://job-queue-internal-api.default.svc.cluster.local/jobs?id%5B%5D=...&limit=100 : 200
```

Per-request tracing is diagnostic noise that should sit *below* the `info` threshold consumers run in production. This changes the middleware to log at `LogLevel::DEBUG`, so the request line only shows up when a consumer explicitly enables debug logging. Retry logging (`warning`, in `RetryDecider`) and error handling are unchanged.

No consumer-side config change is needed — prod handlers filtering at `min_level: info` (e.g. job-queue-daemon) stop emitting these lines automatically.

## Justification

See linked issue — the noise appeared as part of the AJDA-2999 client migration and is undesired in production logs.

## Plans for Customer Communication

None.

## Impact Analysis

Low. Only affects the severity at which the per-request HTTP log line is emitted. Any consumer that actually wants to see these lines can lower its Monolog handler to `debug`. No behavior change to requests, retries, or error handling. Not gated by a feature flag.

## Deployment Plan

Release a tagged version (library). Consumers pick it up on their next dependency bump — in particular the `internal-api-php-client` migration PRs that introduced the base client.

## Rollback Plan

Revert this PR.

## Post-Release Support Plan

None.
