### PR TITLE
PAT-1959 Own the runId generator; drop client-wrapper StorageClientRequestFactory

### DIFF
--- a/libs/api-bundle/README.md
+++ b/libs/api-bundle/README.md
@@ -156,8 +156,9 @@ incoming token — no external Storage client factory needs to be registered by 
 
 The base options are preconfigured by the bundle: the Connection (Storage API) URL from the
 `ServiceClient`, the shared logger, and the configured `app_name` as user agent. The run id comes
-from the request's `X-KBC-RunId` header; branch / backend come from an optional per-call
-`ClientOptions`.
+from the request's `X-KBC-RunId` header, then an optional configured generator (see
+[Customizing the run id](#customizing-the-run-id)), then a generated `run-*` value; branch / backend
+come from an optional per-call `ClientOptions`.
 
 The client uses the auth type the request was authenticated with: a legacy or exchanged Storage
 token is sent as `X-StorageApi-Token`, while an OAuth token (`Authorization: Bearer …`) is sent with
@@ -211,7 +212,7 @@ keboola_api:
 ```
 
 Or reference a fully-custom `ClientOptions` service — the only way to set options that cannot be
-expressed in YAML (`jobPollRetryDelay` / `runIdGenerator` closures, `BackendConfiguration`):
+expressed in YAML (`jobPollRetryDelay` closure, `BackendConfiguration`):
 
 ```yaml
 keboola_api:
@@ -229,6 +230,40 @@ $services->set('app.storage_client_options', ClientOptions::class)
 
 The service's non-null values are merged over the bundle base via `ClientOptions::addValuesFrom()`.
 The `service` (string) form and the individual options are mutually exclusive.
+
+### Customizing the run id
+
+By default the Storage run id is the request's `X-KBC-RunId` header, falling back to a generated
+`run-*` value. To generate it yourself when the header is absent, register a
+`Closure(ClientOptions): string` service and point the `storage_client_options.run_id_generator`
+knob at it:
+
+```yaml
+keboola_api:
+  storage_client_options:
+    run_id_generator: app.storage_run_id_generator   # service id
+```
+
+```php
+// services.php — a Closure isn't directly constructible, so expose it from a factory.
+$services->set('app.storage_run_id_generator', Closure::class)
+    ->factory([RunIdGeneratorFactory::class, 'create']);   // returns fn(ClientOptions $o): string
+```
+
+The closure receives the resolved per-call `ClientOptions` and must return the run id; the
+`X-KBC-RunId` header still wins when present. This replaces setting a `runIdGenerator` on a custom
+`ClientOptions` service, which the Storage client wrapper no longer supports.
+
+`run_id_generator` is grouped under `storage_client_options` for cohesion but is passed to the
+client factory rather than merged into `ClientOptions`, so — unlike the other keys — it may be
+combined with the `service` form:
+
+```yaml
+keboola_api:
+  storage_client_options:
+    service: app.storage_client_options       # custom ClientOptions (jobPollRetryDelay, …)
+    run_id_generator: app.storage_run_id_generator
+```
 
 ## Testing controllers
 

--- a/libs/api-bundle/composer.json
+++ b/libs/api-bundle/composer.json
@@ -8,7 +8,7 @@
         "keboola/kbc-manage-api-php-client": "^v10.2",
         "keboola/permission-checker": "^2.0|^3.0",
         "keboola/service-client": "^1.0",
-        "keboola/storage-api-php-client-branch-wrapper": "^6.8.0",
+        "keboola/storage-api-php-client-branch-wrapper": "^7.0",
         "monolog/monolog": "^2.0|^3.0",
         "psr/log": "^1.1|^2.0|^3.0",
         "symfony/dependency-injection": "^6.0|^7.0",

--- a/libs/api-bundle/src/DependencyInjection/Configuration.php
+++ b/libs/api-bundle/src/DependencyInjection/Configuration.php
@@ -52,9 +52,22 @@ class Configuration implements ConfigurationInterface
                             ->cannotBeEmpty()
                             ->info('Service id of a PSR LoggerInterface to use instead of the default @logger.')
                         ->end()
+                        ->scalarNode('run_id_generator')
+                            ->cannotBeEmpty()
+                            ->info(
+                                'Service id of a Closure(ClientOptions): string that generates the Storage '
+                                . 'run id when the request carries no X-KBC-RunId header (unset falls back to '
+                                . 'uniqid("run-")). Not merged into ClientOptions - it is passed to the Storage '
+                                . 'client factory - so it may accompany either the service or individual-options '
+                                . 'form.',
+                            )
+                        ->end()
                     ->end()
                     ->validate()
-                        ->ifTrue(fn(array $v) => isset($v['service']) && count($v) > 1)
+                        // run_id_generator is not a ClientOptions value, so exclude it from the
+                        // service-vs-individual-options exclusivity check.
+                        ->ifTrue(fn(array $v) => isset($v['service'])
+                            && count(array_diff_key($v, ['run_id_generator' => null])) > 1)
                         ->thenInvalid(
                             'storage_client_options: use either a service reference (string) '
                             . 'or individual options, not both.',

--- a/libs/api-bundle/src/DependencyInjection/KeboolaApiExtension.php
+++ b/libs/api-bundle/src/DependencyInjection/KeboolaApiExtension.php
@@ -112,9 +112,17 @@ class KeboolaApiExtension extends Extension
             ->setArguments([self::SERVICE_ACCOUNT_TOKEN_PATH])
         ;
 
-        $container->register(StorageClientRequestFactory::class)
-            ->setArgument('$baseClientOptions', new Reference(self::STORAGE_CLIENT_BASE_OPTIONS_ID))
-        ;
+        $requestFactory = $container->register(StorageClientRequestFactory::class)
+            ->setArgument('$baseClientOptions', new Reference(self::STORAGE_CLIENT_BASE_OPTIONS_ID));
+
+        // Optional run id generator: a consumer-registered Closure(ClientOptions): string service.
+        // Grouped under storage_client_options for config cohesion but wired to the factory (not
+        // merged into ClientOptions, which no longer carries a generator in branch-wrapper 7.0).
+        if (isset($storageClientOptions['run_id_generator'])) {
+            $runIdGenerator = $storageClientOptions['run_id_generator'];
+            assert(is_string($runIdGenerator));
+            $requestFactory->setArgument('$runIdGenerator', new Reference($runIdGenerator));
+        }
 
         $container->register(StorageApiTokenFactory::class)
             ->setArgument('$clientFactory', new Reference(StorageClientRequestFactory::class))

--- a/libs/api-bundle/src/StorageApiClient/StorageClientRequestFactory.php
+++ b/libs/api-bundle/src/StorageApiClient/StorageClientRequestFactory.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Keboola\ApiBundle\StorageApiClient;
 
+use Closure;
 use Keboola\StorageApiBranch\ClientWrapper;
 use Keboola\StorageApiBranch\Factory\AuthType;
 use Keboola\StorageApiBranch\Factory\ClientOptions;
@@ -26,8 +27,15 @@ class StorageClientRequestFactory
 {
     public const RUN_ID_HEADER = 'X-KBC-RunId';
 
+    /**
+     * @param ?Closure(ClientOptions): string $runIdGenerator Optional run id generator, called with the
+     *     resolved per-call options when the request carries no {@see self::RUN_ID_HEADER}. Injected by
+     *     the bundle from the `keboola_api.storage_client_options.run_id_generator` service id; owned
+     *     here because 7.0's {@see ClientOptions} no longer carries a generator.
+     */
     public function __construct(
         private readonly ClientOptions $baseClientOptions,
+        private readonly ?Closure $runIdGenerator = null,
     ) {
     }
 
@@ -57,9 +65,8 @@ class StorageClientRequestFactory
             return $runId;
         }
 
-        $runIdGenerator = $options->getRunIdGenerator();
-        if ($runIdGenerator !== null) {
-            $runId = $runIdGenerator($options);
+        if ($this->runIdGenerator !== null) {
+            $runId = ($this->runIdGenerator)($options);
             assert(is_string($runId));
             return $runId;
         }

--- a/libs/api-bundle/tests/DependencyInjection/ConfigurationTest.php
+++ b/libs/api-bundle/tests/DependencyInjection/ConfigurationTest.php
@@ -79,6 +79,38 @@ class ConfigurationTest extends TestCase
         ]);
     }
 
+    public function testStorageClientOptionsRunIdGeneratorAllowedWithIndividualOptions(): void
+    {
+        $config = $this->process([
+            'storage_client_options' => [
+                'backoff_max_tries' => 10,
+                'run_id_generator' => 'app.run_id_generator',
+            ],
+        ]);
+
+        self::assertSame(
+            ['backoff_max_tries' => 10, 'run_id_generator' => 'app.run_id_generator'],
+            $config['storage_client_options'],
+        );
+    }
+
+    public function testStorageClientOptionsRunIdGeneratorAllowedAlongsideServiceForm(): void
+    {
+        // run_id_generator is not a ClientOptions value, so it is exempt from the
+        // service-vs-individual-options exclusivity and may accompany the service form.
+        $config = $this->process([
+            'storage_client_options' => [
+                'service' => 'app.storage_options',
+                'run_id_generator' => 'app.run_id_generator',
+            ],
+        ]);
+
+        self::assertSame(
+            ['service' => 'app.storage_options', 'run_id_generator' => 'app.run_id_generator'],
+            $config['storage_client_options'],
+        );
+    }
+
     public function testStorageClientOptionsRejectsNonIntegerBackoff(): void
     {
         $this->expectException(InvalidConfigurationException::class);

--- a/libs/api-bundle/tests/DependencyInjection/KeboolaApiExtensionTest.php
+++ b/libs/api-bundle/tests/DependencyInjection/KeboolaApiExtensionTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Keboola\ApiBundle\Tests\DependencyInjection;
 
+use Closure;
 use Keboola\ApiBundle\DependencyInjection\KeboolaApiExtension;
 use Keboola\ApiBundle\Security\ApplicationToken\ManageApiClientFactory;
 use Keboola\ApiBundle\Security\StorageApiToken\StorageApiTokenAuthenticator;
@@ -12,11 +13,13 @@ use Keboola\ApiBundle\StorageApiClient\StorageClientApiFactoryResolver;
 use Keboola\ApiBundle\StorageApiClient\StorageClientRequestFactory;
 use Keboola\ManageApi\Client as ManageApiClient;
 use Keboola\ServiceClient\ServiceClient;
+use Keboola\StorageApiBranch\Factory\AuthType;
 use Keboola\StorageApiBranch\Factory\ClientOptions;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Reference;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 
 class KeboolaApiExtensionTest extends TestCase
@@ -259,5 +262,103 @@ class KeboolaApiExtensionTest extends TestCase
             ['$url', '$logger', '$userAgent'],
             array_keys($base->getArguments()),
         );
+    }
+
+    // -------------------------------------------------------------------------
+    // run_id_generator
+    // -------------------------------------------------------------------------
+
+    public function testRunIdGeneratorServiceIsWiredIntoRequestFactory(): void
+    {
+        $container = $this->buildContainer([[
+            'storage_client_options' => [
+                'run_id_generator' => 'app.run_id_generator',
+            ],
+        ]]);
+
+        $generator = $container->getDefinition(StorageClientRequestFactory::class)
+            ->getArgument('$runIdGenerator');
+
+        self::assertInstanceOf(Reference::class, $generator);
+        self::assertSame('app.run_id_generator', (string) $generator);
+    }
+
+    public function testRunIdGeneratorCoexistsWithCustomClientOptionsService(): void
+    {
+        $container = $this->buildContainer([[
+            'storage_client_options' => [
+                'service' => 'app.storage_options',
+                'run_id_generator' => 'app.run_id_generator',
+            ],
+        ]]);
+
+        // The custom ClientOptions service is still merged onto the base options,
+        $base = $this->resolveSharedBaseClientOptions($container);
+        $calls = $base->getMethodCalls();
+        self::assertCount(1, $calls);
+
+        $call = $calls[0];
+        self::assertIsArray($call);
+        self::assertSame('addValuesFrom', $call[0]);
+        self::assertIsArray($call[1]);
+        self::assertInstanceOf(Reference::class, $call[1][0]);
+        self::assertSame('app.storage_options', (string) $call[1][0]);
+
+        // ...and the generator is still wired into the factory, since it is not a ClientOptions value.
+        $generator = $container->getDefinition(StorageClientRequestFactory::class)
+            ->getArgument('$runIdGenerator');
+        self::assertInstanceOf(Reference::class, $generator);
+        self::assertSame('app.run_id_generator', (string) $generator);
+    }
+
+    public function testRunIdGeneratorAbsentLeavesRequestFactoryWithoutGeneratorArg(): void
+    {
+        $container = $this->buildContainer([[]]);
+
+        // No $runIdGenerator argument means the factory's constructor default (null) applies,
+        // preserving the uniqid('run-') fallback.
+        self::assertArrayNotHasKey(
+            '$runIdGenerator',
+            $container->getDefinition(StorageClientRequestFactory::class)->getArguments(),
+        );
+    }
+
+    /**
+     * The knob passes a service Reference into the factory's {@see Closure} run id generator
+     * argument, so the referenced service must resolve to an actual Closure. This compiles a
+     * container built exactly like the extension wires it (base options + generator Reference) and
+     * instantiates the factory, proving a Closure-typed service is injectable and gets called.
+     */
+    public function testRunIdGeneratorClosureServiceIsInjectedAndUsedOnceCompiled(): void
+    {
+        $container = new ContainerBuilder();
+
+        // A Closure cannot be constructed directly, so a consumer exposes it through a factory;
+        // here a static test factory stands in for that service.
+        $container->register('app.run_id_generator', Closure::class)
+            ->setPublic(true)
+            ->setFactory([self::class, 'createRunIdGenerator']);
+
+        $container->register(StorageClientRequestFactory::class)
+            ->setPublic(true)
+            ->setArgument('$baseClientOptions', new Definition(ClientOptions::class, ['https://connection.test']))
+            ->setArgument('$runIdGenerator', new Reference('app.run_id_generator'));
+
+        $container->compile();
+
+        $factory = $container->get(StorageClientRequestFactory::class);
+        self::assertInstanceOf(StorageClientRequestFactory::class, $factory);
+
+        $runId = $factory
+            ->createClientWrapper('my-token', AuthType::STORAGE_TOKEN, new Request())
+            ->getClientOptionsReadOnly()
+            ->getRunId();
+
+        self::assertSame('generated-run-id', $runId);
+    }
+
+    public static function createRunIdGenerator(): Closure
+    {
+        return static fn (ClientOptions $options): string => 'generated-run-id';
     }
 }

--- a/libs/api-bundle/tests/StorageApiClient/StorageClientApiFactoryTest.php
+++ b/libs/api-bundle/tests/StorageApiClient/StorageClientApiFactoryTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Keboola\ApiBundle\Tests\StorageApiClient;
 
+use Closure;
 use Keboola\ApiBundle\Security\StorageApiToken\StorageApiToken;
 use Keboola\ApiBundle\StorageApiClient\StorageClientApiFactory;
 use Keboola\ApiBundle\StorageApiClient\StorageClientRequestFactory;
@@ -18,9 +19,10 @@ class StorageClientApiFactoryTest extends TestCase
         ClientOptions $baseClientOptions,
         Request $request,
         ?StorageApiToken $token = null,
+        ?Closure $runIdGenerator = null,
     ): StorageClientApiFactory {
         return new StorageClientApiFactory(
-            new StorageClientRequestFactory($baseClientOptions),
+            new StorageClientRequestFactory($baseClientOptions, $runIdGenerator),
             $request,
             $token ?? new StorageApiToken([], 'bound-token', AuthType::STORAGE_TOKEN),
         );
@@ -70,9 +72,11 @@ class StorageClientApiFactoryTest extends TestCase
 
     public function testRunIdGeneratorUsedWhenHeaderMissing(): void
     {
-        $baseOptions = new ClientOptions('https://connection.test');
-        $baseOptions->setRunIdGenerator(fn (ClientOptions $o): string => 'gen-' . $o->getUrl());
-        $factory = self::factory($baseOptions, new Request());
+        $factory = self::factory(
+            new ClientOptions('https://connection.test'),
+            new Request(),
+            runIdGenerator: fn (ClientOptions $o): string => 'gen-' . $o->getUrl(),
+        );
 
         self::assertSame(
             'gen-https://connection.test',

--- a/libs/api-bundle/tests/StorageApiClient/StorageClientRequestFactoryTest.php
+++ b/libs/api-bundle/tests/StorageApiClient/StorageClientRequestFactoryTest.php
@@ -52,9 +52,10 @@ class StorageClientRequestFactoryTest extends TestCase
 
     public function testRunIdGeneratorUsedWhenHeaderMissing(): void
     {
-        $base = new ClientOptions('https://connection.test');
-        $base->setRunIdGenerator(fn (ClientOptions $o): string => 'gen-' . $o->getUrl());
-        $factory = new StorageClientRequestFactory($base);
+        $factory = new StorageClientRequestFactory(
+            new ClientOptions('https://connection.test'),
+            fn (ClientOptions $o): string => 'gen-' . $o->getUrl(),
+        );
 
         $runId = $factory
             ->createClientWrapper('my-token', AuthType::STORAGE_TOKEN, new Request())
@@ -62,6 +63,27 @@ class StorageClientRequestFactoryTest extends TestCase
             ->getRunId();
 
         self::assertSame('gen-https://connection.test', $runId);
+    }
+
+    public function testRunIdGeneratorNotCalledWhenHeaderPresent(): void
+    {
+        $factory = new StorageClientRequestFactory(
+            new ClientOptions('https://connection.test'),
+            static function (ClientOptions $o): string {
+                self::fail('run id generator must not be called when the X-KBC-RunId header is present');
+            },
+        );
+
+        $runId = $factory
+            ->createClientWrapper(
+                'my-token',
+                AuthType::STORAGE_TOKEN,
+                new Request([], [], [], [], [], ['HTTP_X_KBC_RUNID' => '42']),
+            )
+            ->getClientOptionsReadOnly()
+            ->getRunId();
+
+        self::assertSame('42', $runId);
     }
 
     public function testPerCallOverridesAreMergedButResolvedTokenAndAuthTypeWin(): void


### PR DESCRIPTION
## Release Notes
https://linear.app/keboola/issue/PAT-1959/api-bundle-own-the-runid-generator-drop-client-wrapper

Related `storage-api-php-client-branch-wrapper` 7.0: https://github.com/keboola/storage-api-php-client-branch-wrapper/pull/39 (PAT-1954)

branch-wrapper 7.0 removed `ClientOptions::runIdGenerator` (and its `get/setRunIdGenerator()`) together with `Keboola\StorageApiBranch\Factory\StorageClientRequestFactory`, so api-bundle's `StorageClientRequestFactory::resolveRunId()` — which read the generator off `ClientOptions` — no longer compiles against it. The bundle now **owns** the generator: `StorageClientRequestFactory` takes it as an optional `?Closure(ClientOptions): string` constructor dependency and resolves from it, with the run id order unchanged — `X-KBC-RunId` header → configured generator → `uniqid('run-')`.

Because the generator is a closure and therefore not YAML-expressible, consumers inject it through a new `keboola_api.storage_client_options.run_id_generator: <service-id>` knob, wired in `KeboolaApiExtension` to the factory's `$runIdGenerator` argument. The referenced service must resolve to a `Closure` (exposed via a factory, since `Closure` is not directly constructible). It is grouped under `storage_client_options` for config cohesion but — unlike the other keys — is passed to the factory rather than merged into `ClientOptions`, so it is exempt from the `service`-vs-individual-options exclusivity and may accompany either form. This replaces the previous approach of setting `runIdGenerator` on a custom `ClientOptions` service, which the client wrapper no longer supports.

Key changes:
* `StorageClientRequestFactory` owns the run id generator (`?Closure` ctor dep); no more `ClientOptions::getRunIdGenerator()`.
* New `keboola_api.storage_client_options.run_id_generator` config knob + `KeboolaApiExtension` wiring.
* `keboola/storage-api-php-client-branch-wrapper` bumped to `^7.0`.
* README: dropped `runIdGenerator` from the custom-`ClientOptions`-service docs; added a "Customizing the run id" section.
* Audited all `StorageApiToken` / `ClientOptions`-with-token construction — every site already passes `authType`/`tokenType`, so 7.0's "token requires authType" enforcement is satisfied; no code changes were needed there.

## Plans for customer communication
None.

## Impact analysis
To be released as api-bundle **6.1.0**. It moves the `keboola/storage-api-php-client-branch-wrapper` requirement to `^7.0`; the only service affected by the runId-generator change is `runner-sync-api` (the sole user of a custom generator), migrated in lockstep via PAT-1960. Any service that injected a run id generator through a custom `ClientOptions` service must move to the `keboola_api.storage_client_options.run_id_generator` knob. No end-user (runtime) impact — run id resolution behaviour is unchanged.

## Change type
Refactoring

## Justification
Adapt api-bundle to storage-api-php-client-branch-wrapper 7.0, which removed `ClientOptions::runIdGenerator` and `Factory\StorageClientRequestFactory`.

## Deployment
Merge & automatic deploy.

## Rollback plan
Revert of this PR.

## Post release support plan
None.
