### PR TITLE
Require storage-api-php-client-branch-wrapper ^7.0 across platform libs

### DIFF
--- a/libs/configuration-variables-resolver/composer.json
+++ b/libs/configuration-variables-resolver/composer.json
@@ -41,7 +41,7 @@
         "keboola/php-api-client-base": "*@dev",
         "keboola/service-client": "*@dev",
         "keboola/storage-api-client": "^17.0|^18.0",
-        "keboola/storage-api-php-client-branch-wrapper": "^6.0",
+        "keboola/storage-api-php-client-branch-wrapper": "^7.0",
         "keboola/vault-api-client": "*@dev",
         "mustache/mustache": "^2.13",
         "psr/log": "^1.1|^2.0|^3.0",

--- a/libs/configuration-variables-resolver/tests/SharedCodeResolverTest.php
+++ b/libs/configuration-variables-resolver/tests/SharedCodeResolverTest.php
@@ -14,6 +14,7 @@ use Keboola\StorageApi\Options\Components\Configuration as StorageConfiguration;
 use Keboola\StorageApi\Options\Components\ConfigurationRow;
 use Keboola\StorageApi\Options\Components\ListComponentConfigurationsOptions;
 use Keboola\StorageApiBranch\ClientWrapper;
+use Keboola\StorageApiBranch\Factory\AuthType;
 use Keboola\StorageApiBranch\Factory\ClientOptions;
 use Monolog\Handler\TestHandler;
 use Monolog\Logger;
@@ -35,6 +36,7 @@ class SharedCodeResolverTest extends TestCase
             new ClientOptions(
                 (string) getenv('STORAGE_API_URL'),
                 (string) getenv('STORAGE_API_TOKEN'),
+                authType: AuthType::STORAGE_TOKEN,
             ),
         );
         $components = new Components($this->clientWrapper->getBasicClient());
@@ -315,6 +317,7 @@ class SharedCodeResolverTest extends TestCase
             new ClientOptions(
                 (string) getenv('STORAGE_API_URL'),
                 (string) getenv('STORAGE_API_TOKEN_MASTER'),
+                authType: AuthType::STORAGE_TOKEN,
             ),
         );
         $branchId = $this->createBranch('my-dev-branch', $clientWrapper);
@@ -323,6 +326,7 @@ class SharedCodeResolverTest extends TestCase
                 (string) getenv('STORAGE_API_URL'),
                 (string) getenv('STORAGE_API_TOKEN'),
                 (string) $branchId,
+                authType: AuthType::STORAGE_TOKEN,
             ),
         );
 

--- a/libs/configuration-variables-resolver/tests/UnifiedConfigurationResolverFactoryTest.php
+++ b/libs/configuration-variables-resolver/tests/UnifiedConfigurationResolverFactoryTest.php
@@ -9,6 +9,7 @@ use Keboola\ConfigurationVariablesResolver\VaultVariablesApiClientConfiguration;
 use Keboola\ServiceClient\ServiceClient;
 use Keboola\StorageApi\BranchAwareClient;
 use Keboola\StorageApiBranch\ClientWrapper;
+use Keboola\StorageApiBranch\Factory\AuthType;
 use Keboola\StorageApiBranch\StorageApiToken;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\NullLogger;
@@ -79,7 +80,7 @@ class UnifiedConfigurationResolverFactoryTest extends TestCase
         $clientWrapperMock->method('getBranchClient')
             ->willReturn($branchAwareClientMock);
         $clientWrapperMock->method('getToken')
-            ->willReturn(new StorageApiToken([], 'token'));
+            ->willReturn(new StorageApiToken([], 'token', AuthType::STORAGE_TOKEN));
 
         $unifiedVariablesResolver = $this->getFactory()->createResolver($clientWrapperMock);
 
@@ -154,7 +155,7 @@ class UnifiedConfigurationResolverFactoryTest extends TestCase
         $clientWrapperMock->method('getBranchClient')
             ->willReturn($branchAwareClientMock);
         $clientWrapperMock->method('getToken')
-            ->willReturn(new StorageApiToken([], 'token'));
+            ->willReturn(new StorageApiToken([], 'token', AuthType::STORAGE_TOKEN));
 
         $unifiedVariablesResolver = $this->getFactory()->createResolver(
             $clientWrapperMock,
@@ -195,7 +196,7 @@ class UnifiedConfigurationResolverFactoryTest extends TestCase
         $clientWrapperMock->method('getBranchClient')
             ->willReturn($branchAwareClientMock);
         $clientWrapperMock->method('getToken')
-            ->willReturn(new StorageApiToken([], 'token'));
+            ->willReturn(new StorageApiToken([], 'token', AuthType::STORAGE_TOKEN));
 
         $unifiedVariablesResolver = $this->getFactory()->createResolver(
             $clientWrapperMock,

--- a/libs/configuration-variables-resolver/tests/VariableResolverTest.php
+++ b/libs/configuration-variables-resolver/tests/VariableResolverTest.php
@@ -13,6 +13,7 @@ use Keboola\StorageApi\DevBranches;
 use Keboola\StorageApi\Options\Components\Configuration as StorageConfiguration;
 use Keboola\StorageApi\Options\Components\ConfigurationRow;
 use Keboola\StorageApiBranch\ClientWrapper;
+use Keboola\StorageApiBranch\Factory\AuthType;
 use Keboola\StorageApiBranch\Factory\ClientOptions;
 use Keboola\VaultApiClient\Variables\VariablesApiClient;
 use Monolog\Handler\TestHandler;
@@ -44,6 +45,7 @@ class VariableResolverTest extends TestCase
             new ClientOptions(
                 (string) getenv('STORAGE_API_URL'),
                 (string) getenv('STORAGE_API_TOKEN'),
+                authType: AuthType::STORAGE_TOKEN,
             ),
         );
     }
@@ -555,6 +557,7 @@ class VariableResolverTest extends TestCase
             new ClientOptions(
                 (string) getenv('STORAGE_API_URL'),
                 (string) getenv('STORAGE_API_TOKEN_MASTER'),
+                authType: AuthType::STORAGE_TOKEN,
             ),
         );
 
@@ -564,6 +567,7 @@ class VariableResolverTest extends TestCase
                 (string) getenv('STORAGE_API_URL'),
                 (string) getenv('STORAGE_API_TOKEN_MASTER'),
                 (string) $branchId,
+                authType: AuthType::STORAGE_TOKEN,
             ),
         );
 

--- a/libs/configuration-variables-resolver/tests/VariablesResolver/ConfigurationVariablesResolverTest.php
+++ b/libs/configuration-variables-resolver/tests/VariablesResolver/ConfigurationVariablesResolverTest.php
@@ -14,6 +14,7 @@ use Keboola\StorageApi\DevBranches;
 use Keboola\StorageApi\Options\Components\Configuration as StorageConfiguration;
 use Keboola\StorageApi\Options\Components\ConfigurationRow;
 use Keboola\StorageApiBranch\ClientWrapper;
+use Keboola\StorageApiBranch\Factory\AuthType;
 use Keboola\StorageApiBranch\Factory\ClientOptions;
 use Monolog\Handler\TestHandler;
 use Monolog\Logger;
@@ -42,6 +43,7 @@ class ConfigurationVariablesResolverTest extends TestCase
             new ClientOptions(
                 (string) getenv('STORAGE_API_URL'),
                 (string) getenv('STORAGE_API_TOKEN'),
+                authType: AuthType::STORAGE_TOKEN,
             ),
         );
     }
@@ -507,6 +509,7 @@ class ConfigurationVariablesResolverTest extends TestCase
             new ClientOptions(
                 (string) getenv('STORAGE_API_URL'),
                 (string) getenv('STORAGE_API_TOKEN_MASTER'),
+                authType: AuthType::STORAGE_TOKEN,
             ),
         );
 
@@ -516,6 +519,7 @@ class ConfigurationVariablesResolverTest extends TestCase
                 (string) getenv('STORAGE_API_URL'),
                 (string) getenv('STORAGE_API_TOKEN_MASTER'),
                 (string) $branchId,
+                authType: AuthType::STORAGE_TOKEN,
             ),
         );
 

--- a/libs/configuration-variables-resolver/tests/VariablesResolverFunctionalTest.php
+++ b/libs/configuration-variables-resolver/tests/VariablesResolverFunctionalTest.php
@@ -14,6 +14,7 @@ use Keboola\StorageApi\Options\Components\Configuration as StorageConfiguration;
 use Keboola\StorageApi\Options\Components\ConfigurationRow;
 use Keboola\StorageApi\Options\Components\ListComponentConfigurationsOptions;
 use Keboola\StorageApiBranch\ClientWrapper;
+use Keboola\StorageApiBranch\Factory\AuthType;
 use Keboola\StorageApiBranch\Factory\ClientOptions;
 use Keboola\VaultApiClient\Variables\Model\ListOptions;
 use Keboola\VaultApiClient\Variables\VariablesApiClient;
@@ -48,6 +49,7 @@ class VariablesResolverFunctionalTest extends TestCase
             new ClientOptions(
                 self::getRequiredEnv('STORAGE_API_URL'),
                 self::getRequiredEnv('STORAGE_API_TOKEN'),
+                authType: AuthType::STORAGE_TOKEN,
             ),
         );
 
@@ -189,6 +191,7 @@ class VariablesResolverFunctionalTest extends TestCase
             new ClientOptions(
                 (string) getenv('STORAGE_API_URL'),
                 (string) getenv('STORAGE_API_TOKEN_MASTER'),
+                authType: AuthType::STORAGE_TOKEN,
             ),
         );
         $branchesApiClient = new DevBranches($masterClientWrapper->getBasicClient());
@@ -205,6 +208,7 @@ class VariablesResolverFunctionalTest extends TestCase
                 (string) getenv('STORAGE_API_URL'),
                 (string) getenv('STORAGE_API_TOKEN_MASTER'),
                 (string) $devBranch['id'],
+                authType: AuthType::STORAGE_TOKEN,
             ),
         );
 

--- a/libs/input-mapping/composer.json
+++ b/libs/input-mapping/composer.json
@@ -22,7 +22,7 @@
         "keboola/key-generator": "*@dev",
         "keboola/staging-provider": "*@dev",
         "keboola/storage-api-client": "^18.9.0",
-        "keboola/storage-api-php-client-branch-wrapper": "^6.0",
+        "keboola/storage-api-php-client-branch-wrapper": "^7.0",
         "symfony/config": "^5.4|^6.0|^7.0",
         "symfony/finder": "^5.4|^6.0|^7.0",
         "symfony/serializer": "^5.4|^6.0|^7.0",

--- a/libs/input-mapping/tests/AbstractTestCase.php
+++ b/libs/input-mapping/tests/AbstractTestCase.php
@@ -19,6 +19,7 @@ use Keboola\StorageApi\Options\ListFilesOptions;
 use Keboola\StorageApi\WorkspaceLoginType;
 use Keboola\StorageApi\Workspaces;
 use Keboola\StorageApiBranch\ClientWrapper;
+use Keboola\StorageApiBranch\Factory\AuthType;
 use Keboola\StorageApiBranch\Factory\ClientOptions;
 use Keboola\Temp\Temp;
 use Monolog\Handler\TestHandler;
@@ -84,6 +85,7 @@ abstract class AbstractTestCase extends TestCase
         $clientOptions = (new ClientOptions())
             ->setUrl((string) getenv('STORAGE_API_URL'))
             ->setToken((string) getenv('STORAGE_API_TOKEN'))
+            ->setAuthType(AuthType::STORAGE_TOKEN)
             ->setBranchId($branchId)
             ->setBackoffMaxTries(1)
             ->setJobPollRetryDelay(function () {

--- a/libs/input-mapping/tests/Functional/DownloadTablesAdaptiveTest.php
+++ b/libs/input-mapping/tests/Functional/DownloadTablesAdaptiveTest.php
@@ -133,8 +133,9 @@ class DownloadTablesAdaptiveTest extends AbstractTestCase
         ]);
 
         $this->expectException(ClientException::class);
-        $this->expectExceptionMessage('Invalid parameters - changedSince: changedSince has to be '
-            . 'compatible with strtotime() or to be a unix timestamp.');
+        $this->expectExceptionMessage(
+            'changedSince has to be compatible with strtotime() or to be a unix timestamp.',
+        );
         $reader->downloadTables(
             $configuration,
             $inputTablesState,

--- a/libs/input-mapping/tests/Functional/DownloadTablesWorkspaceBigQueryTest.php
+++ b/libs/input-mapping/tests/Functional/DownloadTablesWorkspaceBigQueryTest.php
@@ -93,7 +93,7 @@ class DownloadTablesWorkspaceBigQueryTest extends AbstractTestCase
         self::assertNotEmpty($jobParams);
         self::assertCount(1, $jobParams['input']);
         self::assertEquals('test1', $jobParams['input'][0]['destination']);
-        self::assertEquals('VIEW', $jobParams['input'][0]['loadType']);
+        self::assertEquals('CLONE', $jobParams['input'][0]['loadType']);
 
         $workspaceCreateJob = array_shift($jobs);
         self::assertArrayHasKey('operationName', $workspaceCreateJob);

--- a/libs/input-mapping/tests/Helper/RealDevStorageTagsRewriteHelperTest.php
+++ b/libs/input-mapping/tests/Helper/RealDevStorageTagsRewriteHelperTest.php
@@ -12,6 +12,7 @@ use Keboola\StorageApi\DevBranches;
 use Keboola\StorageApi\Options\FileUploadOptions;
 use Keboola\StorageApi\Options\ListFilesOptions;
 use Keboola\StorageApiBranch\ClientWrapper;
+use Keboola\StorageApiBranch\Factory\AuthType;
 use Keboola\StorageApiBranch\Factory\ClientOptions;
 use Keboola\Temp\Temp;
 use Monolog\Handler\TestHandler;
@@ -69,6 +70,7 @@ class RealDevStorageTagsRewriteHelperTest extends TestCase
                 (string) getenv('STORAGE_API_URL'),
                 (string) getenv('STORAGE_API_TOKEN_MASTER'),
                 $branchId,
+                authType: AuthType::STORAGE_TOKEN,
             ),
         );
     }

--- a/libs/input-mapping/tests/Needs/TestSatisfyer.php
+++ b/libs/input-mapping/tests/Needs/TestSatisfyer.php
@@ -8,6 +8,7 @@ use Keboola\Csv\CsvFile;
 use Keboola\StorageApi\Client;
 use Keboola\StorageApi\DevBranches;
 use Keboola\StorageApiBranch\ClientWrapper;
+use Keboola\StorageApiBranch\Factory\AuthType;
 use Keboola\StorageApiBranch\Factory\ClientOptions;
 use Keboola\Temp\Temp;
 use ReflectionAttribute;
@@ -204,6 +205,7 @@ class TestSatisfyer
             new ClientOptions(
                 $clientWrapper->getClientOptionsReadOnly()->getUrl(),
                 (string) getenv('STORAGE_API_TOKEN_MASTER'),
+                authType: AuthType::STORAGE_TOKEN,
             ),
         );
 

--- a/libs/output-mapping/composer.json
+++ b/libs/output-mapping/composer.json
@@ -36,7 +36,7 @@
         "keboola/slicer": "*@dev",
         "keboola/staging-provider": "*@dev",
         "keboola/storage-api-client": "^18.5",
-        "keboola/storage-api-php-client-branch-wrapper": "^6.0",
+        "keboola/storage-api-php-client-branch-wrapper": "^7.0",
         "microsoft/azure-storage-blob": "^1.5",
         "psr/log": "^2.0|^3.0",
         "symfony/config": "^5.4|^6.0|^7.0",

--- a/libs/output-mapping/tests/AbstractTestCase.php
+++ b/libs/output-mapping/tests/AbstractTestCase.php
@@ -17,6 +17,7 @@ use Keboola\StorageApi\Options\ListFilesOptions;
 use Keboola\StorageApi\WorkspaceLoginType;
 use Keboola\StorageApi\Workspaces;
 use Keboola\StorageApiBranch\ClientWrapper;
+use Keboola\StorageApiBranch\Factory\AuthType;
 use Keboola\StorageApiBranch\Factory\ClientOptions;
 use Keboola\Temp\Temp;
 use Monolog\Handler\TestHandler;
@@ -95,6 +96,7 @@ abstract class AbstractTestCase extends TestCase
         $clientOptions = (new ClientOptions())
             ->setUrl((string) getenv('STORAGE_API_URL'))
             ->setToken((string) getenv('STORAGE_API_TOKEN'))
+            ->setAuthType(AuthType::STORAGE_TOKEN)
             ->setBranchId($branchId)
             ->setBackoffMaxTries(1)
             ->setJobPollRetryDelay(function () {

--- a/libs/output-mapping/tests/Configuration/Table/WebalizerTest.php
+++ b/libs/output-mapping/tests/Configuration/Table/WebalizerTest.php
@@ -8,6 +8,7 @@ use Generator;
 use Keboola\OutputMapping\Configuration\Table\Webalizer;
 use Keboola\StorageApi\Client;
 use Keboola\StorageApiBranch\ClientWrapper;
+use Keboola\StorageApiBranch\Factory\AuthType;
 use Keboola\StorageApiBranch\Factory\ClientOptions;
 use Monolog\Handler\TestHandler;
 use Monolog\Level;
@@ -243,6 +244,7 @@ class WebalizerTest extends TestCase
         $clientOptions = (new ClientOptions())
             ->setUrl((string) getenv('STORAGE_API_URL'))
             ->setToken((string) getenv('STORAGE_API_TOKEN'))
+            ->setAuthType(AuthType::STORAGE_TOKEN)
             ->setBranchId($branchId)
             ->setBackoffMaxTries(1)
             ->setJobPollRetryDelay(function () {

--- a/libs/output-mapping/tests/Needs/TestSatisfyer.php
+++ b/libs/output-mapping/tests/Needs/TestSatisfyer.php
@@ -10,6 +10,7 @@ use Keboola\StorageApi\Client;
 use Keboola\StorageApi\ClientException;
 use Keboola\StorageApi\DevBranches;
 use Keboola\StorageApiBranch\ClientWrapper;
+use Keboola\StorageApiBranch\Factory\AuthType;
 use Keboola\StorageApiBranch\Factory\ClientOptions;
 use Keboola\Temp\Temp;
 use ReflectionAttribute;
@@ -121,6 +122,7 @@ class TestSatisfyer
             new ClientOptions(
                 $clientWrapper->getClientOptionsReadOnly()->getUrl(),
                 (string) getenv('STORAGE_API_TOKEN_MASTER'),
+                authType: AuthType::STORAGE_TOKEN,
             ),
         );
 

--- a/libs/output-mapping/tests/Storage/BigqueryStoragePreparerTest.php
+++ b/libs/output-mapping/tests/Storage/BigqueryStoragePreparerTest.php
@@ -13,6 +13,7 @@ use Keboola\OutputMapping\SystemMetadata;
 use Keboola\OutputMapping\Tests\AbstractTestCase;
 use Keboola\OutputMapping\Tests\Needs\NeedsEmptyBigqueryOutputBucket;
 use Keboola\StorageApiBranch\ClientWrapper;
+use Keboola\StorageApiBranch\Factory\AuthType;
 use Keboola\StorageApiBranch\Factory\ClientOptions;
 use PHPUnit\Util\Test;
 
@@ -156,6 +157,7 @@ class BigqueryStoragePreparerTest extends AbstractTestCase
         $clientOptions = (new ClientOptions())
             ->setUrl((string) getenv('BIGQUERY_STORAGE_API_URL'))
             ->setToken((string) getenv('BIGQUERY_STORAGE_API_TOKEN'))
+            ->setAuthType(AuthType::STORAGE_TOKEN)
             ->setBranchId($branchId)
             ->setBackoffMaxTries(1)
             ->setJobPollRetryDelay(function () {

--- a/libs/output-mapping/tests/Storage/BigqueryTableStructureModifierFromSchemaTest.php
+++ b/libs/output-mapping/tests/Storage/BigqueryTableStructureModifierFromSchemaTest.php
@@ -14,6 +14,7 @@ use Keboola\OutputMapping\Storage\TableStructureModifierFromSchema;
 use Keboola\OutputMapping\Tests\AbstractTestCase;
 use Keboola\OutputMapping\Tests\Needs\NeedsEmptyBigqueryOutputBucket;
 use Keboola\StorageApiBranch\ClientWrapper;
+use Keboola\StorageApiBranch\Factory\AuthType;
 use Keboola\StorageApiBranch\Factory\ClientOptions;
 use PHPUnit\Util\Test;
 
@@ -212,6 +213,7 @@ class BigqueryTableStructureModifierFromSchemaTest extends AbstractTestCase
         $clientOptions = (new ClientOptions())
             ->setUrl((string) getenv('BIGQUERY_STORAGE_API_URL'))
             ->setToken((string) getenv('BIGQUERY_STORAGE_API_TOKEN'))
+            ->setAuthType(AuthType::STORAGE_TOKEN)
             ->setBranchId($branchId)
             ->setBackoffMaxTries(1)
             ->setJobPollRetryDelay(function () {

--- a/libs/output-mapping/tests/Writer/StorageApiFileWriterTest.php
+++ b/libs/output-mapping/tests/Writer/StorageApiFileWriterTest.php
@@ -12,6 +12,7 @@ use Keboola\OutputMapping\Writer\FileWriter;
 use Keboola\StorageApi\Options\FileUploadOptions;
 use Keboola\StorageApi\Options\ListFilesOptions;
 use Keboola\StorageApiBranch\ClientWrapper;
+use Keboola\StorageApiBranch\Factory\AuthType;
 use Keboola\StorageApiBranch\Factory\ClientOptions;
 
 class StorageApiFileWriterTest extends AbstractTestCase
@@ -277,6 +278,7 @@ class StorageApiFileWriterTest extends AbstractTestCase
             new ClientOptions(
                 url: (string) getenv('STORAGE_API_URL'),
                 token: (string) getenv('STORAGE_API_TOKEN'),
+                authType: AuthType::STORAGE_TOKEN,
                 branchId: $this->devBranchId,
                 useBranchStorage: true, // This is the important setting
             ),

--- a/libs/output-mapping/tests/Writer/TableDefinitionV2BigQueryTest.php
+++ b/libs/output-mapping/tests/Writer/TableDefinitionV2BigQueryTest.php
@@ -11,6 +11,7 @@ use Keboola\OutputMapping\SystemMetadata;
 use Keboola\OutputMapping\Tests\AbstractTestCase;
 use Keboola\OutputMapping\Tests\Needs\NeedsEmptyBigqueryOutputBucket;
 use Keboola\StorageApiBranch\ClientWrapper;
+use Keboola\StorageApiBranch\Factory\AuthType;
 use Keboola\StorageApiBranch\Factory\ClientOptions;
 use PHPUnit\Util\Test;
 
@@ -363,6 +364,7 @@ class TableDefinitionV2BigQueryTest extends AbstractTestCase
         $clientOptions = (new ClientOptions())
             ->setUrl((string) getenv('BIGQUERY_STORAGE_API_URL'))
             ->setToken((string) getenv('BIGQUERY_STORAGE_API_TOKEN'))
+            ->setAuthType(AuthType::STORAGE_TOKEN)
             ->setBranchId($branchId)
             ->setBackoffMaxTries(1)
             ->setJobPollRetryDelay(function () {

--- a/libs/permission-checker/composer.json
+++ b/libs/permission-checker/composer.json
@@ -32,7 +32,7 @@
     "require-dev": {
         "infection/infection": "^0.27.0",
         "keboola/coding-standard": "^15.0",
-        "keboola/storage-api-php-client-branch-wrapper": "^6.0",
+        "keboola/storage-api-php-client-branch-wrapper": "^7.0",
         "phpstan/phpstan": "^1.9",
         "phpstan/phpstan-phpunit": "^1.1",
         "phpunit/phpunit": "^9.5",

--- a/libs/permission-checker/tests/PermissionCheckerTest.php
+++ b/libs/permission-checker/tests/PermissionCheckerTest.php
@@ -7,6 +7,7 @@ namespace Keboola\PersmissionChecker\Tests;
 use Keboola\PermissionChecker\PermissionChecker;
 use Keboola\PermissionChecker\PermissionCheckInterface;
 use Keboola\PermissionChecker\StorageApiToken;
+use Keboola\StorageApiBranch\Factory\AuthType;
 use Keboola\StorageApiBranch\StorageApiToken as BaseStorageApiToken;
 use PHPUnit\Framework\TestCase;
 
@@ -17,7 +18,7 @@ class PermissionCheckerTest extends TestCase
         $token = new class extends BaseStorageApiToken {
             public function __construct()
             {
-                parent::__construct([], '');
+                parent::__construct([], '', AuthType::STORAGE_TOKEN);
             }
 
             public function getFeatures(): array

--- a/libs/permission-checker/tests/StorageApiTokenTest.php
+++ b/libs/permission-checker/tests/StorageApiTokenTest.php
@@ -8,6 +8,7 @@ use Keboola\PermissionChecker\Feature;
 use Keboola\PermissionChecker\Role;
 use Keboola\PermissionChecker\StorageApiToken;
 use Keboola\PermissionChecker\TokenPermission;
+use Keboola\StorageApiBranch\Factory\AuthType;
 use Keboola\StorageApiBranch\StorageApiToken as BaseStorageApiToken;
 use PHPUnit\Framework\TestCase;
 use ValueError;
@@ -79,7 +80,7 @@ class StorageApiTokenTest extends TestCase
         $token = StorageApiToken::fromTokenInterface(new class extends BaseStorageApiToken {
             public function __construct()
             {
-                parent::__construct([], '');
+                parent::__construct([], '', AuthType::STORAGE_TOKEN);
             }
 
             public function getFeatures(): array

--- a/libs/php-test-utils/composer.json
+++ b/libs/php-test-utils/composer.json
@@ -30,7 +30,7 @@
         "ext-json": "*",
         "doctrine/orm": "^3.5",
         "keboola/service-client": "^1.4",
-        "keboola/storage-api-php-client-branch-wrapper": "^6.4",
+        "keboola/storage-api-php-client-branch-wrapper": "^7.0",
         "psr/log": "^3.0",
         "symfony/framework-bundle": "^7.3",
         "symfony/uid": "^v7.3"

--- a/libs/php-test-utils/src/Fixtures/FixtureTraits/StorageApiAwareTrait.php
+++ b/libs/php-test-utils/src/Fixtures/FixtureTraits/StorageApiAwareTrait.php
@@ -6,6 +6,7 @@ namespace Keboola\PhpTestUtils\Fixtures\FixtureTraits;
 
 use Keboola\ServiceClient\ServiceClient;
 use Keboola\StorageApiBranch\ClientWrapper;
+use Keboola\StorageApiBranch\Factory\AuthType;
 use Keboola\StorageApiBranch\Factory\ClientOptions;
 
 trait StorageApiAwareTrait
@@ -20,6 +21,7 @@ trait StorageApiAwareTrait
         $storageClientOptions = new ClientOptions(
             url: (new ServiceClient($hostnameSuffix))->getConnectionServiceUrl(),
             token: $token,
+            authType: AuthType::STORAGE_TOKEN,
         );
         $this->clientWrapper = (new ClientWrapper($storageClientOptions));
     }

--- a/libs/staging-provider/composer.json
+++ b/libs/staging-provider/composer.json
@@ -31,7 +31,7 @@
         "ext-json": "*",
         "keboola/key-generator": "*@dev",
         "keboola/storage-api-client": "^18.1",
-        "keboola/storage-api-php-client-branch-wrapper": "^6.0"
+        "keboola/storage-api-php-client-branch-wrapper": "^7.0"
     },
     "require-dev": {
         "keboola/coding-standard": ">=14.0",

--- a/libs/staging-provider/tests/Workspace/WorkspaceProviderFunctionalTest.php
+++ b/libs/staging-provider/tests/Workspace/WorkspaceProviderFunctionalTest.php
@@ -18,6 +18,7 @@ use Keboola\StorageApi\Options\Components\Configuration;
 use Keboola\StorageApi\WorkspaceLoginType;
 use Keboola\StorageApi\Workspaces;
 use Keboola\StorageApiBranch\ClientWrapper;
+use Keboola\StorageApiBranch\Factory\AuthType;
 use Keboola\StorageApiBranch\Factory\ClientOptions;
 use Keboola\StorageApiBranch\StorageApiToken;
 use PHPUnit\Framework\TestCase;
@@ -43,6 +44,7 @@ class WorkspaceProviderFunctionalTest extends TestCase
         $clientWrapper = new ClientWrapper(new ClientOptions(
             url: self::getRequiredEnv('STORAGE_API_URL'),
             token: self::getRequiredEnv('STORAGE_API_TOKEN'),
+            authType: AuthType::STORAGE_TOKEN,
         ));
 
         $this->workspacesApiClient = new Workspaces($clientWrapper->getBranchClient());


### PR DESCRIPTION
## Release Notes
Driver: https://linear.app/keboola/issue/PAT-1960/runner-sync-api-migrate-custom-runid-generator-to-api-bundle-60-config

> [!NOTE]
> Bump client wrapper lib dependency na movou major verzi

Moves the platform libraries that depend on `keboola/storage-api-php-client-branch-wrapper` to require `^7.0`, so downstream services (starting with `runner-sync-api`, PAT-1960) can adopt branch-wrapper 7.0 + api-bundle 6.1. branch-wrapper 7.0's only breaking changes are: `ClientOptions::getClientConstructOptions()` now throws when a token is set without an `authType`, `StorageApiToken`'s 3rd constructor arg (`AuthType`) is now required, and the removal of `Factory\StorageClientRequestFactory` / `ClientOptions::runIdGenerator` (unused by these libs).

Every library's production `src/` was already compatible — the only production change is `php-test-utils`' `StorageApiAwareTrait`, which now sets `AuthType::STORAGE_TOKEN` on its `ClientOptions`. Everything else is test fixtures that construct a token-bearing `ClientOptions` (or a base `StorageApiToken`) now explicitly passing `AuthType::STORAGE_TOKEN` — accepted by both 6.x and 7.0, so the change is not runtime-behaviour-affecting.

Libraries bumped (one commit each): `staging-provider`, `input-mapping`, `output-mapping`, `configuration-variables-resolver`, `permission-checker`, `php-test-utils`.

Verified locally against branch-wrapper 7.0: `composer phpstan` (covers `src` + `tests`) and `phpcs` green for all six; `permission-checker` unit tests green (193). The credential-backed functional suites (input/output-mapping, staging-provider, configuration-variables-resolver) run in CI.

## Plans for customer communication
None.

## Impact analysis
Consumers of these libraries move to branch-wrapper `^7.0` when they pick up the new minor releases; runId/auth behaviour is unchanged. The constraint is strict `^7.0` (drops `^6.0`), so a consumer still pinning branch-wrapper 6.x must upgrade — this is the intended platform-wide move to 7.0. No end-user (runtime) impact.

## Change type
Maintenance

## Justification
Roll `storage-api-php-client-branch-wrapper` 7.0 through the platform libraries so downstream services can migrate (unblocks PAT-1960 / runner-sync-api).

## Deployment
Merge & automatic deploy.

## Rollback plan
Revert of this PR.

## Post release support plan
None.
