### PR TITLE
refactor(output-mapping): create non-typed tables through the table-definition endpoint

### DIFF
--- a/libs/output-mapping/src/LoadTableTaskCreator.php
+++ b/libs/output-mapping/src/LoadTableTaskCreator.php
@@ -14,6 +14,7 @@ use Keboola\OutputMapping\Storage\NativeTypeDecisionHelper;
 use Keboola\OutputMapping\Storage\TableCreator;
 use Keboola\OutputMapping\Writer\Table\StrategyInterface;
 use Keboola\OutputMapping\Writer\Table\TableDefinition\TableDefinitionFactory;
+use Keboola\OutputMapping\Writer\Table\TableDefinition\TableDefinitionFromColumns;
 use Keboola\OutputMapping\Writer\Table\TableDefinitionFromSchema\TableDefinitionFromSchema;
 use Keboola\StorageApiBranch\ClientWrapper;
 use Psr\Log\LoggerInterface;
@@ -79,13 +80,14 @@ class LoadTableTaskCreator
             $this->tableCreator->createTableDefinition($source->getDestination()->getBucketId(), $tableDefinition);
             $loadTask = new LoadTableTask($source->getDestination(), $loadOptions, true);
         } elseif (!$storageSources->didTableExistBefore() && $source->hasColumns()) {
-            // tabulka neexistuje a známe sloupce z manifestu
-            $this->tableCreator->createTable(
-                $source->getDestination()->getBucketId(),
+            // tabulka neexistuje a známe sloupce z manifestu - vytvoříme ji přes table definition bez typů,
+            // takže vznikne netypovaná tabulka stejně jako dřív, ale bez uploadu hlavičkového CSV souboru
+            $tableDefinition = new TableDefinitionFromColumns(
                 $source->getDestination()->getTableName(),
                 $source->getColumns(),
-                $loadOptions,
+                $source->getPrimaryKey(),
             );
+            $this->tableCreator->createTableDefinition($source->getDestination()->getBucketId(), $tableDefinition);
             $loadTask = new LoadTableTask($source->getDestination(), $loadOptions, true);
         } elseif ($storageSources->didTableExistBefore()) {
             // tabulka existuje takže nahráváme data

--- a/libs/output-mapping/src/LoadTableTaskCreator.php
+++ b/libs/output-mapping/src/LoadTableTaskCreator.php
@@ -80,8 +80,7 @@ class LoadTableTaskCreator
             $this->tableCreator->createTableDefinition($source->getDestination()->getBucketId(), $tableDefinition);
             $loadTask = new LoadTableTask($source->getDestination(), $loadOptions, true);
         } elseif (!$storageSources->didTableExistBefore() && $source->hasColumns()) {
-            // tabulka neexistuje a známe sloupce z manifestu - vytvoříme ji přes table definition bez typů,
-            // takže vznikne netypovaná tabulka stejně jako dřív, ale bez uploadu hlavičkového CSV souboru
+            // tabulka neexistuje a známe sloupce z manifestu - vytváříme ji přes table definition bez typů
             $tableDefinition = new TableDefinitionFromColumns(
                 $source->getDestination()->getTableName(),
                 $source->getColumns(),

--- a/libs/output-mapping/src/Storage/TableCreator.php
+++ b/libs/output-mapping/src/Storage/TableCreator.php
@@ -4,12 +4,10 @@ declare(strict_types=1);
 
 namespace Keboola\OutputMapping\Storage;
 
-use Keboola\Csv\CsvFile;
 use Keboola\OutputMapping\Exception\InvalidOutputException;
 use Keboola\OutputMapping\Writer\Table\TableDefinitionInterface;
 use Keboola\StorageApi\ClientException;
 use Keboola\StorageApiBranch\ClientWrapper;
-use Keboola\Temp\Temp;
 
 class TableCreator
 {
@@ -32,37 +30,6 @@ class TableCreator
                 sprintf(
                     'Cannot create table "%s" definition in Storage API: %s',
                     $tableDefinition->getTableName(),
-                    json_encode((array) $e->getContextParams()),
-                ),
-                $e->getCode(),
-                $e,
-            );
-        }
-    }
-
-    public function createTable(
-        string $bucketId,
-        string $tableName,
-        array $columns,
-        array $loadOptions,
-    ): string {
-        $tmp = new Temp();
-
-        $headerCsvFile = new CsvFile($tmp->createFile($tableName.'.header.csv')->getPathname());
-        $headerCsvFile->writeRow($columns);
-
-        try {
-            return $this->clientWrapper->getTableAndFileStorageClient()->createTableAsync(
-                $bucketId,
-                $tableName,
-                $headerCsvFile,
-                $loadOptions,
-            );
-        } catch (ClientException $e) {
-            throw new InvalidOutputException(
-                sprintf(
-                    'Cannot create table "%s" in Storage API: %s',
-                    $tableName,
                     json_encode((array) $e->getContextParams()),
                 ),
                 $e->getCode(),

--- a/libs/output-mapping/src/Writer/Table/TableDefinition/TableDefinitionFromColumns.php
+++ b/libs/output-mapping/src/Writer/Table/TableDefinition/TableDefinitionFromColumns.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Keboola\OutputMapping\Writer\Table\TableDefinition;
+
+use Keboola\OutputMapping\Writer\Table\TableDefinitionInterface;
+
+/**
+ * Table definition for a non-typed table created from a plain list of column names, i.e. when the manifest
+ * declares `columns` but no data types.
+ *
+ * No column carries a type or a basetype, which is what makes Storage create the table as non-typed -
+ * Keboola\Connection\Storage\Request\Bucket\CreateTableDefinition\BaseCreateTableDefinitionRequest::isTypedTable()
+ * only reports a typed table when at least one column has `definition.type` or `basetype`.
+ */
+class TableDefinitionFromColumns implements TableDefinitionInterface
+{
+    /**
+     * @param string[] $columns
+     * @param string[] $primaryKeysNames
+     */
+    public function __construct(
+        private readonly string $tableName,
+        private readonly array $columns,
+        private readonly array $primaryKeysNames,
+    ) {
+    }
+
+    public function getRequestData(): array
+    {
+        return [
+            'name' => $this->tableName,
+            'primaryKeysNames' => array_values($this->primaryKeysNames),
+            'columns' => array_map(
+                static fn(string $columnName): array => ['name' => $columnName],
+                array_values($this->columns),
+            ),
+        ];
+    }
+
+    public function getTableName(): string
+    {
+        return $this->tableName;
+    }
+}

--- a/libs/output-mapping/tests/LoadTableTaskCreatorTest.php
+++ b/libs/output-mapping/tests/LoadTableTaskCreatorTest.php
@@ -231,7 +231,8 @@ class LoadTableTaskCreatorTest extends AbstractTestCase
         $source->expects(self::exactly(3))->method('getDestination')->willReturn(
             new MappingDestination($this->emptyOutputBucketId . '.destinationTable'),
         );
-        $source->expects(self::once())->method('getPrimaryKey')->willReturn([]);
+        // getPrimaryKey/getColumns are read twice - once for the load options, once for the table definition
+        $source->expects(self::exactly(2))->method('getPrimaryKey')->willReturn([]);
         $source->expects(self::exactly(2))->method('getColumns')->willReturn(['col1', 'col2']);
 
         $storageSources = self::createMock(MappingStorageSources::class);

--- a/libs/output-mapping/tests/Storage/TableCreatorTest.php
+++ b/libs/output-mapping/tests/Storage/TableCreatorTest.php
@@ -11,6 +11,7 @@ use Keboola\OutputMapping\Tests\AbstractTestCase;
 use Keboola\OutputMapping\Tests\Needs\NeedsEmptyOutputBucket;
 use Keboola\OutputMapping\Writer\Table\TableDefinition\TableDefinition;
 use Keboola\OutputMapping\Writer\Table\TableDefinition\TableDefinitionColumnFactory;
+use Keboola\OutputMapping\Writer\Table\TableDefinition\TableDefinitionFromColumns;
 use Keboola\StorageApi\ClientException;
 
 class TableCreatorTest extends AbstractTestCase
@@ -91,54 +92,38 @@ class TableCreatorTest extends AbstractTestCase
     }
 
     #[NeedsEmptyOutputBucket]
-    public function testCreateTable(): void
+    public function testCreateNonTypedTableFromColumns(): void
     {
         $tableCreator = new TableCreator($this->clientWrapper);
 
-        $tableId = $tableCreator->createTable(
+        $tableId = $tableCreator->createTableDefinition(
             $this->emptyOutputBucketId,
-            'testTable',
-            ['id'],
-            [
-                'primaryKey' => 'id',
-            ],
+            new TableDefinitionFromColumns('testTable', ['id', 'name'], ['id']),
         );
 
         $table = $this->clientWrapper->getTableAndFileStorageClient()->getTable($tableId);
 
-        self::assertIsArray($table);
-        self::assertArrayHasKey('isTyped', $table);
+        // no column carries a type, so Storage creates the table as non-typed
         self::assertFalse($table['isTyped']);
-        self::assertArrayHasKey('name', $table);
         self::assertSame('testTable', $table['name']);
-        self::assertArrayHasKey('columns', $table);
-        self::assertSame(['id'], $table['columns']);
-        self::assertArrayHasKey('primaryKey', $table);
+        self::assertSame(['id', 'name'], $table['columns']);
         self::assertSame(['id'], $table['primaryKey']);
     }
 
     #[NeedsEmptyOutputBucket]
-    public function testCreateTableErrorHandling(): void
+    public function testCreateNonTypedTableFromColumnsErrorHandling(): void
     {
         $tableCreator = new TableCreator($this->clientWrapper);
 
         try {
-            $tableCreator->createTable(
+            $tableCreator->createTableDefinition(
                 $this->emptyOutputBucketId,
-                'testTable',
-                ['id'],
-                [
-                    'primaryKey' => 'name',
-                ],
+                new TableDefinitionFromColumns('testTable', ['id'], ['name']),
             );
-            self::fail('CreateTable should fail with InvalidOutputException');
+            self::fail('CreateTableDefinition should fail with InvalidOutputException');
         } catch (InvalidOutputException $e) {
             self::assertStringContainsString(
-                'Cannot create table "testTable" in Storage API:',
-                $e->getMessage(),
-            );
-            self::assertStringContainsString(
-                'storage.tables.validation.invalidPrimaryKeyColumns',
+                'Cannot create table "testTable" definition in Storage API:',
                 $e->getMessage(),
             );
             self::assertNotNull($e->getPrevious());

--- a/libs/output-mapping/tests/Writer/StorageApiLocalTableWriterTest.php
+++ b/libs/output-mapping/tests/Writer/StorageApiLocalTableWriterTest.php
@@ -2275,9 +2275,11 @@ CSV;
             );
             $this->fail('Must throw exception');
         } catch (InvalidOutputException $e) {
+            // the table is created through the table-definition endpoint, which reports an invalid column
+            // name without spelling out the length limit
             $this->assertStringContainsString(
-                '\'LongLongLongLongLongLongLongLongLongLongLongLongLongLongLongLongName\' '.
-                'is more than 64 characters long',
+                'Invalid column name: '.
+                '\\"LongLongLongLongLongLongLongLongLongLongLongLongLongLongLongLongName\\"',
                 $e->getMessage(),
             );
         }

--- a/libs/output-mapping/tests/Writer/Table/TableDefinition/TableDefinitionFromColumnsTest.php
+++ b/libs/output-mapping/tests/Writer/Table/TableDefinition/TableDefinitionFromColumnsTest.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Keboola\OutputMapping\Tests\Writer\Table\TableDefinition;
+
+use Keboola\OutputMapping\Writer\Table\TableDefinition\TableDefinitionFromColumns;
+use PHPUnit\Framework\TestCase;
+
+class TableDefinitionFromColumnsTest extends TestCase
+{
+    public function testRequestDataCarriesNoTypes(): void
+    {
+        $tableDefinition = new TableDefinitionFromColumns('testTable', ['Id', 'Name'], ['Id']);
+
+        self::assertSame('testTable', $tableDefinition->getTableName());
+        self::assertSame(
+            [
+                'name' => 'testTable',
+                'primaryKeysNames' => ['Id'],
+                // neither `definition.type` nor `basetype`, otherwise Storage would create a typed table
+                'columns' => [
+                    ['name' => 'Id'],
+                    ['name' => 'Name'],
+                ],
+            ],
+            $tableDefinition->getRequestData(),
+        );
+    }
+
+    public function testRequestDataWithoutPrimaryKey(): void
+    {
+        $tableDefinition = new TableDefinitionFromColumns('testTable', ['Id'], []);
+
+        self::assertSame(
+            [
+                'name' => 'testTable',
+                'primaryKeysNames' => [],
+                'columns' => [['name' => 'Id']],
+            ],
+            $tableDefinition->getRequestData(),
+        );
+    }
+
+    /**
+     * The column list comes from the manifest through RestrictedColumnsHelper, which filters with array_filter
+     * and therefore leaves gaps in the keys - those must not turn the JSON arrays into objects.
+     */
+    public function testRequestDataReindexesSparseInput(): void
+    {
+        $tableDefinition = new TableDefinitionFromColumns(
+            'testTable',
+            [1 => 'Id', 3 => 'Name'],
+            [2 => 'Id'],
+        );
+
+        $requestData = $tableDefinition->getRequestData();
+
+        self::assertSame(['Id'], $requestData['primaryKeysNames']);
+        self::assertSame([['name' => 'Id'], ['name' => 'Name']], $requestData['columns']);
+        self::assertSame('[{"name":"Id"},{"name":"Name"}]', json_encode($requestData['columns']));
+    }
+}

--- a/libs/output-mapping/tests/Writer/TableDefinitionV2Test.php
+++ b/libs/output-mapping/tests/Writer/TableDefinitionV2Test.php
@@ -974,9 +974,11 @@ class TableDefinitionV2Test extends AbstractTestCase
             $tableQueue->waitForAll();
             $this->fail('Must throw exception');
         } catch (InvalidOutputException $e) {
+            // the table is created through the table-definition endpoint, which reports an invalid column
+            // name without spelling out the length limit
             $this->assertStringContainsString(
-                '\'LongLongLongLongLongLongLongLongLongLongLongLongLongLongLongLongName\' '.
-                'is more than 64 characters long',
+                'Invalid column name: '.
+                '\\"LongLongLongLongLongLongLongLongLongLongLongLongLongLongLongLongName\\"',
                 $e->getMessage(),
             );
         }


### PR DESCRIPTION
Preparation for [AJDA-2946](https://linear.app/keboola/issue/AJDA-2946/output-mapping-store-description-only-when-table-flag-is-system) (#550), useful on its own.

## Why

Output mapping has two ways of creating a table. Typed tables and tables declared by `schema` go through `createTableDefinition`. A table declared by manifest `columns` without data types went through `createTableAsync`, which requires a header CSV to be written to a temp file and uploaded to file storage before the table can be created.

The definition endpoint can create that table too: Storage reports a table as typed only when at least one column carries `definition.type` or `basetype` (`BaseCreateTableDefinitionRequest::isTypedTable()`), so a payload with plain column names produces a non-typed table. Verified against real Storage — same `isTyped=false`, same columns, same primary key, data loads normally.

So this switches the untyped path to `createTableDefinition`, which:
- drops a file upload and a storage job from every non-typed table creation,
- leaves output mapping with a single way of creating a table,
- lets the description ride along in the create payload later (that is #550's business, not this PR's).

## Changes

- new `TableDefinitionFromColumns` — builds `{name, primaryKeysNames, columns: [{name}]}` and nothing else, so no column can accidentally acquire a type
- `LoadTableTaskCreator` uses it for the `!didTableExistBefore() && hasColumns()` branch
- `TableCreator::createTable()` removed — this change made it unused, and with it the header-CSV plumbing (`Temp`, `CsvFile`)

## Observable differences

**`distributionKey` is no longer set on the created table.** Measured side by side, this is the only field that differs; everything else (isTyped, primaryKey, columns, column definitions, metadata rows, import) is identical.

That is acceptable because Storage documents the field as *"Distribution key columns (for Synapse)"*, Synapse is no longer a Storage backend, and on Snowflake it is inert metadata echoed back in the table detail. Note the typed and schema paths already do not set it — so today a typed table created from a config with `distribution_key` gets no distribution key while an untyped one does. This makes the two consistent.

**An invalid column name is reported differently.** `createTableAsync` said `'<name>' is more than 64 characters long`; the definition endpoint says `Invalid column name: "<name>"`. The new message does not spell out the limit. `testLongColumnName` was updated accordingly.

## Testing

- phpcs + phpstan (level max) clean.
- `TableCreatorTest` — the two tests covering the old `createTable()` were converted to the new path rather than deleted, so non-typed creation with a primary key and its error handling stay covered against real Storage.
- New unit test for `TableDefinitionFromColumns`, including that a sparse column list (RestrictedColumnsHelper filters with `array_filter` and leaves gaps) still serialises as a JSON array.
- `main-writer-tests-1` run against real Storage: the only failure caused by this change was `testLongColumnName` (message text, updated). The four `Can not resolve branchId` dev-branch errors are pre-existing — verified by re-running one of them with these changes stashed, where it fails identically.
