### PR TITLE
PAT-1981 Pass int timeouts instead of strings in ClientConfigurator

### DIFF
--- a/libs/k8s-client/src/ClientFactory/ClientConfigurator.php
+++ b/libs/k8s-client/src/ClientFactory/ClientConfigurator.php
@@ -35,8 +35,8 @@ class ClientConfigurator
             ],
             [
                 'handler' => $guzzleHandler,
-                'connect_timeout' => '30',
-                'timeout' => '60',
+                'connect_timeout' => 30,
+                'timeout' => 60,
             ],
         );
 


### PR DESCRIPTION
## Release Notes
https://linear.app/keboola/issue/PAT-1981/k8s-client-pass-int-timeouts-instead-of-strings-in-clientconfigurator

`ClientConfigurator::configureBaseClient` was passing Guzzle's `connect_timeout` and `timeout` options as strings (`'30'`, `'60'`). guzzlehttp/guzzle 7.11+ deprecates non-numeric string timeout values and 8.0 will require `int|float`, so every request through `k8s-client` was emitting a deprecation notice — 117x for each option in `sandboxes-service`'s test output alone.

Both values are now passed as real integers (`30`, `60`), with no change to the actual timeout behavior.

## Plans for customer communication
None.

## Impact analysis
No end-user impact; purely a PHP type change with identical timeout values.

## Change type
Maintenance

## Justification
Remove Guzzle deprecation notices ahead of guzzlehttp/guzzle 8.0.

## Deployment
Merge & automatic deploy.

## Rollback plan
Revert of this PR.

## Post release support plan
None.