### PR TITLE
fix(output-mapping): wait for the direct-grant metadata refresh job (DMD-1828)

### DIFF
--- a/libs/output-mapping/src/DeferredTasks/DeferredTaskInterface.php
+++ b/libs/output-mapping/src/DeferredTasks/DeferredTaskInterface.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Keboola\OutputMapping\DeferredTasks;
+
+use Keboola\StorageApiBranch\ClientWrapper;
+
+/**
+ * A Storage job enqueued by output mapping and awaited by LoadTableQueue.
+ */
+interface DeferredTaskInterface
+{
+    /**
+     * Enqueues the Storage job(s) of this task.
+     *
+     * A Storage failure which is the user's fault must be converted to an InvalidOutputException here.
+     */
+    public function start(ClientWrapper $clientWrapper): void;
+
+    /**
+     * @return string[] ids of the Storage jobs enqueued by start()
+     */
+    public function getStorageJobIds(): array;
+
+    /**
+     * @param array $jobResult job detail of a job which ended with an error
+     * @return string message to report to the user
+     */
+    public function getFailedJobError(string $storageJobId, array $jobResult): string;
+}

--- a/libs/output-mapping/src/DeferredTasks/LoadTableQueue.php
+++ b/libs/output-mapping/src/DeferredTasks/LoadTableQueue.php
@@ -27,22 +27,27 @@ class LoadTableQueue
     /** @var array<string, TableDescription> table id => descriptions of a table created by this run */
     private array $createdTableDescriptions;
 
+    /** @var int[] */
+    private array $unloadJobIds;
     private Result $tableResult;
 
     /**
      * @param LoadTableTaskInterface[] $loadTableTasks
      * @param array<string, TableDescription> $createdTableDescriptions
+     * @param int[] $unloadJobIds Storage metadata refresh jobs enqueued for direct-grant tables
      */
     public function __construct(
         ClientWrapper $clientWrapper,
         LoggerInterface $logger,
         array $loadTableTasks,
         array $createdTableDescriptions = [],
+        array $unloadJobIds = [],
     ) {
         $this->clientWrapper = $clientWrapper;
         $this->logger = $logger;
         $this->loadTableTasks = $loadTableTasks;
         $this->createdTableDescriptions = $createdTableDescriptions;
+        $this->unloadJobIds = $unloadJobIds;
         $this->tableResult = new Result();
     }
 
@@ -65,6 +70,9 @@ class LoadTableQueue
         }
     }
 
+    /**
+     * @return string[] ids of the table load jobs
+     */
     public function waitForAll(): array
     {
         $metadataApiClient = new Metadata($this->clientWrapper->getTableAndFileStorageClient());
@@ -154,6 +162,20 @@ class LoadTableQueue
 
         $this->tableResult->setMetrics(new Metrics($jobResults));
 
+        // the metadata refresh dispatches trigger events; it must finish before the workspace is dropped
+        foreach ($this->unloadJobIds as $unloadJobId) {
+            /** @var array $unloadJobResult */
+            $unloadJobResult = $this->clientWrapper->getBranchClient()->waitForJob($unloadJobId);
+
+            if ($unloadJobResult['status'] === 'error') {
+                $errors[] = sprintf(
+                    'Failed to refresh metadata of direct-grant tables (Storage job "%s"): %s',
+                    $unloadJobId,
+                    $unloadJobResult['error']['message'],
+                );
+            }
+        }
+
         if ($errors) {
             throw new InvalidOutputException(implode("\n", $errors));
         }
@@ -179,9 +201,12 @@ class LoadTableQueue
         $descriptionModifier->updateDescriptions(new StorageTableInfo($tableData), $descriptions);
     }
 
+    /**
+     * Number of Storage jobs waitForAll() waits for.
+     */
     public function getTaskCount(): int
     {
-        return count($this->loadTableTasks);
+        return count($this->loadTableTasks) + count($this->unloadJobIds);
     }
 
     public function getTableResult(): Result

--- a/libs/output-mapping/src/DeferredTasks/LoadTableQueue.php
+++ b/libs/output-mapping/src/DeferredTasks/LoadTableQueue.php
@@ -21,57 +21,40 @@ class LoadTableQueue
     private ClientWrapper $clientWrapper;
     private LoggerInterface $logger;
 
-    /** @var LoadTableTaskInterface[] */
-    private array $loadTableTasks;
+    /** @var DeferredTaskInterface[] */
+    private array $tasks;
 
     /** @var array<string, TableDescription> table id => descriptions of a table created by this run */
     private array $createdTableDescriptions;
 
-    /** @var int[] */
-    private array $unloadJobIds;
     private Result $tableResult;
 
     /**
-     * @param LoadTableTaskInterface[] $loadTableTasks
+     * @param DeferredTaskInterface[] $tasks
      * @param array<string, TableDescription> $createdTableDescriptions
-     * @param int[] $unloadJobIds Storage metadata refresh jobs enqueued for direct-grant tables
      */
     public function __construct(
         ClientWrapper $clientWrapper,
         LoggerInterface $logger,
-        array $loadTableTasks,
+        array $tasks,
         array $createdTableDescriptions = [],
-        array $unloadJobIds = [],
     ) {
         $this->clientWrapper = $clientWrapper;
         $this->logger = $logger;
-        $this->loadTableTasks = $loadTableTasks;
+        $this->tasks = $tasks;
         $this->createdTableDescriptions = $createdTableDescriptions;
-        $this->unloadJobIds = $unloadJobIds;
         $this->tableResult = new Result();
     }
 
     public function start(): void
     {
-        foreach ($this->loadTableTasks as $loadTableTask) {
-            try {
-                $loadTableTask->startImport($this->clientWrapper->getTableAndFileStorageClient());
-            } catch (ClientException $e) {
-                if ($e->getCode() < 500) {
-                    throw new InvalidOutputException(
-                        sprintf('%s [%s]', $e->getMessage(), $loadTableTask->getDestinationTableName()),
-                        $e->getCode(),
-                        $e,
-                    );
-                }
-
-                throw $e;
-            }
+        foreach ($this->tasks as $task) {
+            $task->start($this->clientWrapper);
         }
     }
 
     /**
-     * @return string[] ids of the table load jobs
+     * @return string[] ids of the Storage jobs waited for
      */
     public function waitForAll(): array
     {
@@ -80,74 +63,79 @@ class LoadTableQueue
         $jobIds = [];
         $errors = [];
         $jobResults = [];
-        foreach ($this->loadTableTasks as $task) {
-            $jobId = $task->getStorageJobId();
-            $jobIds[] = $jobId;
-            /** @var array $jobResult */
-            $jobResult = $this->clientWrapper->getBranchClient()->waitForJob($jobId);
+        foreach ($this->tasks as $task) {
+            foreach ($task->getStorageJobIds() as $jobId) {
+                $jobIds[] = $jobId;
+                /** @var array $jobResult */
+                $jobResult = $this->clientWrapper->getBranchClient()->waitForJob($jobId);
 
-            if ($jobResult['status'] === 'error') {
-                $destinationTableName = $task->getDestinationTableName();
-                $errors[] = sprintf(
-                    'Failed to load table "%s": %s',
-                    $destinationTableName,
-                    $jobResult['error']['message'],
-                );
-                // The load failed, so there is no table to describe - it is about to be dropped below or it
-                // keeps the description it already had. Dropping the pending description here keeps it out of
-                // the "was not stored" warning, which is meant for descriptions lost by mistake.
-                unset($this->createdTableDescriptions[$destinationTableName]);
-
-                if (FailedLoadTableDecider::decideTableDelete($this->logger, $this->clientWrapper, $task)) {
-                    $this->clientWrapper->getTableAndFileStorageClient()->dropTable(
-                        $destinationTableName,
-                        ['force' => true],
-                    );
-                }
-            } else {
-                try {
-                    $task->applyMetadata($metadataApiClient);
-                } catch (ClientException $e) {
-                    if ($e->getCode() >= 500) {
-                        throw $e;
+                if (!$task instanceof LoadTableTaskInterface) {
+                    // a job without a destination table carries nothing to describe, annotate or measure
+                    if ($jobResult['status'] === 'error') {
+                        $errors[] = $task->getFailedJobError($jobId, $jobResult);
                     }
-                    $extendedInfo = $e->getContextParams()['errors'] ?? [];
-                    $errors[] = sprintf(
-                        'Failed to update metadata for table "%s": %s (%s)',
-                        $task->getDestinationTableName(),
-                        $e->getMessage(),
-                        json_encode($extendedInfo),
-                    );
+                    continue;
                 }
 
-                switch ($jobResult['operationName']) {
-                    case 'tableImport':
-                        $tableData = $this->clientWrapper->getTableAndFileStorageClient()->getTable(
-                            $jobResult['tableId'],
+                if ($jobResult['status'] === 'error') {
+                    $destinationTableName = $task->getDestinationTableName();
+                    $errors[] = $task->getFailedJobError($jobId, $jobResult);
+                    // The load failed, so there is no table to describe - it is about to be dropped below or it
+                    // keeps the description it already had. Dropping the pending description here keeps it out of
+                    // the "was not stored" warning, which is meant for descriptions lost by mistake.
+                    unset($this->createdTableDescriptions[$destinationTableName]);
+
+                    if (FailedLoadTableDecider::decideTableDelete($this->logger, $this->clientWrapper, $task)) {
+                        $this->clientWrapper->getTableAndFileStorageClient()->dropTable(
+                            $destinationTableName,
+                            ['force' => true],
                         );
-                        $this->tableResult->addTable(new TableInfo($tableData));
-                        $this->tableResult->addGenericVariable(
-                            $jobResult['tableId'],
-                            'importedRowsCount',
-                            (int) ($jobResult['results']['importedRowsCount'] ?? 0),
-                        );
-                        $jobResults[] = $jobResult;
-                        break;
-                    case 'tableCreate':
-                        $tableData = $this->clientWrapper->getTableAndFileStorageClient()->getTable(
-                            $jobResult['results']['id'],
-                        );
-                        $this->tableResult->addTable(new TableInfo($tableData));
-                        // Only a table created by the load job itself (CreateAndLoadTableTask) can have a
-                        // pending description - every other table is created through a table definition,
-                        // which carries the description in its create payload.
-                        try {
-                            $this->applyCreatedTableDescriptions($task, $tableData);
-                        } catch (InvalidOutputException $e) {
-                            $errors[] = $e->getMessage();
+                    }
+                } else {
+                    try {
+                        $task->applyMetadata($metadataApiClient);
+                    } catch (ClientException $e) {
+                        if ($e->getCode() >= 500) {
+                            throw $e;
                         }
-                        $jobResults[] = $jobResult;
-                        break;
+                        $extendedInfo = $e->getContextParams()['errors'] ?? [];
+                        $errors[] = sprintf(
+                            'Failed to update metadata for table "%s": %s (%s)',
+                            $task->getDestinationTableName(),
+                            $e->getMessage(),
+                            json_encode($extendedInfo),
+                        );
+                    }
+
+                    switch ($jobResult['operationName']) {
+                        case 'tableImport':
+                            $tableData = $this->clientWrapper->getTableAndFileStorageClient()->getTable(
+                                $jobResult['tableId'],
+                            );
+                            $this->tableResult->addTable(new TableInfo($tableData));
+                            $this->tableResult->addGenericVariable(
+                                $jobResult['tableId'],
+                                'importedRowsCount',
+                                (int) ($jobResult['results']['importedRowsCount'] ?? 0),
+                            );
+                            $jobResults[] = $jobResult;
+                            break;
+                        case 'tableCreate':
+                            $tableData = $this->clientWrapper->getTableAndFileStorageClient()->getTable(
+                                $jobResult['results']['id'],
+                            );
+                            $this->tableResult->addTable(new TableInfo($tableData));
+                            // Only a table created by the load job itself (CreateAndLoadTableTask) can have a
+                            // pending description - every other table is created through a table definition,
+                            // which carries the description in its create payload.
+                            try {
+                                $this->applyCreatedTableDescriptions($task, $tableData);
+                            } catch (InvalidOutputException $e) {
+                                $errors[] = $e->getMessage();
+                            }
+                            $jobResults[] = $jobResult;
+                            break;
+                    }
                 }
             }
         }
@@ -161,20 +149,6 @@ class LoadTableQueue
         }
 
         $this->tableResult->setMetrics(new Metrics($jobResults));
-
-        // the metadata refresh dispatches trigger events; it must finish before the workspace is dropped
-        foreach ($this->unloadJobIds as $unloadJobId) {
-            /** @var array $unloadJobResult */
-            $unloadJobResult = $this->clientWrapper->getBranchClient()->waitForJob($unloadJobId);
-
-            if ($unloadJobResult['status'] === 'error') {
-                $errors[] = sprintf(
-                    'Failed to refresh metadata of direct-grant tables (Storage job "%s"): %s',
-                    $unloadJobId,
-                    $unloadJobResult['error']['message'],
-                );
-            }
-        }
 
         if ($errors) {
             throw new InvalidOutputException(implode("\n", $errors));
@@ -202,11 +176,14 @@ class LoadTableQueue
     }
 
     /**
-     * Number of Storage jobs waitForAll() waits for.
+     * Number of Storage jobs waitForAll() waits for. Only meaningful once the queue has been started.
      */
     public function getTaskCount(): int
     {
-        return count($this->loadTableTasks) + count($this->unloadJobIds);
+        return array_sum(array_map(
+            fn(DeferredTaskInterface $task) => count($task->getStorageJobIds()),
+            $this->tasks,
+        ));
     }
 
     public function getTableResult(): Result
@@ -214,9 +191,15 @@ class LoadTableQueue
         return $this->tableResult;
     }
 
+    /**
+     * @return LoadTableTaskInterface[]
+     */
     public function getLoadTableTasks(): array
     {
-        return $this->loadTableTasks;
+        return array_values(array_filter(
+            $this->tasks,
+            fn(DeferredTaskInterface $task) => $task instanceof LoadTableTaskInterface,
+        ));
     }
 
     public function loadCustomVariables(string $variablesFilePath): void

--- a/libs/output-mapping/src/DeferredTasks/LoadTableTaskInterface.php
+++ b/libs/output-mapping/src/DeferredTasks/LoadTableTaskInterface.php
@@ -5,20 +5,18 @@ declare(strict_types=1);
 namespace Keboola\OutputMapping\DeferredTasks;
 
 use Keboola\OutputMapping\DeferredTasks\Metadata\MetadataInterface;
-use Keboola\StorageApi\Client;
 use Keboola\StorageApi\Metadata;
 
-interface LoadTableTaskInterface
+/**
+ * A Storage job which writes a single destination table.
+ */
+interface LoadTableTaskInterface extends DeferredTaskInterface
 {
-    public function startImport(Client $client): void;
-
     public function applyMetadata(Metadata $metadataApiClient): void;
 
     public function getMetadata(): array;
 
     public function getDestinationTableName(): string;
-
-    public function getStorageJobId(): string;
 
     public function isUsingFreshlyCreatedTable(): bool;
 

--- a/libs/output-mapping/src/DeferredTasks/TableWriter/AbstractLoadTableTask.php
+++ b/libs/output-mapping/src/DeferredTasks/TableWriter/AbstractLoadTableTask.php
@@ -6,8 +6,13 @@ namespace Keboola\OutputMapping\DeferredTasks\TableWriter;
 
 use Keboola\OutputMapping\DeferredTasks\LoadTableTaskInterface;
 use Keboola\OutputMapping\DeferredTasks\Metadata\MetadataInterface;
+use Keboola\OutputMapping\Exception\InvalidOutputException;
 use Keboola\OutputMapping\Writer\Table\MappingDestination;
+use Keboola\StorageApi\Client;
+use Keboola\StorageApi\ClientException;
 use Keboola\StorageApi\Metadata;
+use Keboola\StorageApiBranch\ClientWrapper;
+use LogicException;
 
 abstract class AbstractLoadTableTask implements LoadTableTaskInterface
 {
@@ -23,6 +28,25 @@ abstract class AbstractLoadTableTask implements LoadTableTaskInterface
         $this->destination = $destination;
         $this->options = $options;
         $this->freshlyCreatedTable = $freshlyCreatedTable;
+    }
+
+    abstract protected function queueStorageJob(Client $client): string;
+
+    public function start(ClientWrapper $clientWrapper): void
+    {
+        try {
+            $this->storageJobId = $this->queueStorageJob($clientWrapper->getTableAndFileStorageClient());
+        } catch (ClientException $e) {
+            if ($e->getCode() < 500) {
+                throw new InvalidOutputException(
+                    sprintf('%s [%s]', $e->getMessage(), $this->getDestinationTableName()),
+                    $e->getCode(),
+                    $e,
+                );
+            }
+
+            throw $e;
+        }
     }
 
     public function addMetadata(MetadataInterface $metadataDefinition): void
@@ -47,9 +71,25 @@ abstract class AbstractLoadTableTask implements LoadTableTaskInterface
         return $this->destination->getTableId();
     }
 
-    public function getStorageJobId(): string
+    public function getStorageJobIds(): array
     {
-        return $this->storageJobId;
+        if (!isset($this->storageJobId)) {
+            throw new LogicException(sprintf(
+                'Load of table "%s" has not been started yet.',
+                $this->getDestinationTableName(),
+            ));
+        }
+
+        return [$this->storageJobId];
+    }
+
+    public function getFailedJobError(string $storageJobId, array $jobResult): string
+    {
+        return sprintf(
+            'Failed to load table "%s": %s',
+            $this->getDestinationTableName(),
+            $jobResult['error']['message'],
+        );
     }
 
     public function isUsingFreshlyCreatedTable(): bool

--- a/libs/output-mapping/src/DeferredTasks/TableWriter/CreateAndLoadTableTask.php
+++ b/libs/output-mapping/src/DeferredTasks/TableWriter/CreateAndLoadTableTask.php
@@ -8,11 +8,11 @@ use Keboola\StorageApi\Client;
 
 class CreateAndLoadTableTask extends AbstractLoadTableTask
 {
-    public function startImport(Client $client): void
+    protected function queueStorageJob(Client $client): string
     {
         $options = $this->options;
         $options['name'] = $this->destination->getTableName();
 
-        $this->storageJobId = (string) $client->queueTableCreate($this->destination->getBucketId(), $options);
+        return (string) $client->queueTableCreate($this->destination->getBucketId(), $options);
     }
 }

--- a/libs/output-mapping/src/DeferredTasks/TableWriter/DirectGrantMetadataRefreshTask.php
+++ b/libs/output-mapping/src/DeferredTasks/TableWriter/DirectGrantMetadataRefreshTask.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Keboola\OutputMapping\DeferredTasks\TableWriter;
+
+use Keboola\OutputMapping\DeferredTasks\DeferredTaskInterface;
+use Keboola\OutputMapping\Exception\InvalidOutputException;
+use Keboola\StorageApi\ClientException;
+use Keboola\StorageApi\Workspaces;
+use Keboola\StorageApiBranch\ClientWrapper;
+
+/**
+ * Tables written through direct grants are already in their Storage bucket when output mapping runs, so there is
+ * no table load job for them. This task enqueues the Storage job which refreshes their metadata and dispatches the
+ * table import events downstream triggers listen to.
+ */
+class DirectGrantMetadataRefreshTask implements DeferredTaskInterface
+{
+    /** @var string[] */
+    private array $storageJobIds = [];
+
+    public function __construct(private readonly int $workspaceId)
+    {
+    }
+
+    public function start(ClientWrapper $clientWrapper): void
+    {
+        // the workspace is a branch object, so the refresh has to be enqueued through the branch client
+        $workspaces = new Workspaces($clientWrapper->getBranchClient());
+
+        try {
+            $jobIds = $workspaces->queueUnload($this->workspaceId, ['only-direct-grants' => true]);
+        } catch (ClientException $e) {
+            // only a 4xx is the user's fault; a connection failure or a client-side error carries code 0
+            if ($e->getCode() >= 400 && $e->getCode() < 500) {
+                throw new InvalidOutputException(
+                    sprintf('Failed to refresh metadata of direct-grant tables: %s', $e->getMessage()),
+                    $e->getCode(),
+                    $e,
+                );
+            }
+
+            throw $e;
+        }
+
+        $this->storageJobIds = array_map(strval(...), $jobIds);
+    }
+
+    public function getStorageJobIds(): array
+    {
+        return $this->storageJobIds;
+    }
+
+    public function getFailedJobError(string $storageJobId, array $jobResult): string
+    {
+        return sprintf(
+            'Failed to refresh metadata of direct-grant tables (Storage job "%s"): %s',
+            $storageJobId,
+            $jobResult['error']['message'],
+        );
+    }
+}

--- a/libs/output-mapping/src/DeferredTasks/TableWriter/DirectGrantMetadataRefreshTask.php
+++ b/libs/output-mapping/src/DeferredTasks/TableWriter/DirectGrantMetadataRefreshTask.php
@@ -9,6 +9,7 @@ use Keboola\OutputMapping\Exception\InvalidOutputException;
 use Keboola\StorageApi\ClientException;
 use Keboola\StorageApi\Workspaces;
 use Keboola\StorageApiBranch\ClientWrapper;
+use LogicException;
 
 /**
  * Tables written through direct grants are already in their Storage bucket when output mapping runs, so there is
@@ -20,10 +21,18 @@ class DirectGrantMetadataRefreshTask implements DeferredTaskInterface
     /** @var string[] */
     private array $storageJobIds = [];
 
+    private bool $started = false;
+
     public function __construct(private readonly int $workspaceId)
     {
     }
 
+    /**
+     * Storage enqueues a single refreshStorageBuckets job covering every direct-grant bucket of the workspace, but
+     * the endpoint is typed as a list of jobs and will grow the jobs of the remaining unload strategies, so every
+     * returned id has to be awaited. An empty list is a valid answer - a workspace with no direct-grant output
+     * mapping in its configuration has nothing to refresh.
+     */
     public function start(ClientWrapper $clientWrapper): void
     {
         // the workspace is a branch object, so the refresh has to be enqueued through the branch client
@@ -45,10 +54,15 @@ class DirectGrantMetadataRefreshTask implements DeferredTaskInterface
         }
 
         $this->storageJobIds = array_map(strval(...), $jobIds);
+        $this->started = true;
     }
 
     public function getStorageJobIds(): array
     {
+        if (!$this->started) {
+            throw new LogicException('Metadata refresh of direct-grant tables has not been started yet.');
+        }
+
         return $this->storageJobIds;
     }
 

--- a/libs/output-mapping/src/DeferredTasks/TableWriter/LoadTableTask.php
+++ b/libs/output-mapping/src/DeferredTasks/TableWriter/LoadTableTask.php
@@ -8,12 +8,12 @@ use Keboola\StorageApi\Client;
 
 class LoadTableTask extends AbstractLoadTableTask
 {
-    public function startImport(Client $client): void
+    protected function queueStorageJob(Client $client): string
     {
         // https://keboolaglobal.slack.com/archives/C05BK5V8N1Z/p1686822278887999?thread_ts=1686821168.533139&cid=C05BK5V8N1Z
         if (isset($this->options['columns']) && $this->options['columns'] === []) {
             unset($this->options['columns']);
         }
-        $this->storageJobId = (string) $client->queueTableImport($this->destination->getTableId(), $this->options);
+        return (string) $client->queueTableImport($this->destination->getTableId(), $this->options);
     }
 }

--- a/libs/output-mapping/src/TableLoader.php
+++ b/libs/output-mapping/src/TableLoader.php
@@ -25,6 +25,7 @@ use Keboola\OutputMapping\Writer\Table\StrategyInterface;
 use Keboola\OutputMapping\Writer\Table\TableConfigurationResolver;
 use Keboola\OutputMapping\Writer\Table\TableConfigurationValidator;
 use Keboola\OutputMapping\Writer\Table\TableHintsConfigurationSchemaResolver;
+use Keboola\StorageApi\ClientException;
 use Keboola\StorageApi\Workspaces;
 use Keboola\StorageApiBranch\ClientWrapper;
 use LogicException;
@@ -170,6 +171,7 @@ class TableLoader
             $loadTableTasks[] = $loadTableTask;
         }
 
+        $unloadJobIds = [];
         if ($strategy->hasDirectGrantUnloadStrategy()) {
             if (!$strategy instanceof SqlWorkspaceTableStrategy) {
                 throw new LogicException(sprintf(
@@ -179,7 +181,7 @@ class TableLoader
                 ));
             }
             // enqueue unload for direct-grant tables
-            $this->callWorkspaceUnload($strategy);
+            $unloadJobIds = $this->callWorkspaceUnload($strategy);
         }
 
         $tableQueue = new LoadTableQueue(
@@ -187,6 +189,7 @@ class TableLoader
             $this->logger,
             $loadTableTasks,
             $createdTableDescriptions,
+            $unloadJobIds,
         );
         $tableQueue->start();
         $tableQueue->loadCustomVariables(Path::join(
@@ -233,18 +236,30 @@ class TableLoader
         );
     }
 
-    private function callWorkspaceUnload(SqlWorkspaceTableStrategy $strategy): void
+    /**
+     * @return int[] ids of the enqueued Storage metadata refresh jobs
+     */
+    private function callWorkspaceUnload(SqlWorkspaceTableStrategy $strategy): array
     {
+        $workspaces = new Workspaces(
+            $this->clientWrapper->getBranchClient(),
+        );
+
         try {
-            $workspaces = new Workspaces(
-                $this->clientWrapper->getBranchClient(),
-            );
-            $workspaces->queueUnload(
+            return $workspaces->queueUnload(
                 (int) $strategy->getDataStorage()->getWorkspaceId(),
                 ['only-direct-grants' => true],
             );
-        } catch (Throwable $e) {
-            $this->logger->warning('Workspace unload failed: ' . $e->getMessage());
+        } catch (ClientException $e) {
+            if ($e->getCode() < 500) {
+                throw new InvalidOutputException(
+                    sprintf('Failed to refresh metadata of direct-grant tables: %s', $e->getMessage()),
+                    $e->getCode(),
+                    $e,
+                );
+            }
+
+            throw $e;
         }
     }
 }

--- a/libs/output-mapping/src/TableLoader.php
+++ b/libs/output-mapping/src/TableLoader.php
@@ -59,7 +59,23 @@ class TableLoader
             $combinedSources = $this->getCombinedSources($strategy, $configuration);
         }
 
-        $loadTableTasks = [];
+        $tasks = [];
+        if ($strategy->hasDirectGrantUnloadStrategy()) {
+            if (!$strategy instanceof SqlWorkspaceTableStrategy) {
+                throw new LogicException(sprintf(
+                    'Direct-grant unload strategy is only supported for %s strategy but got %s.',
+                    SqlWorkspaceTableStrategy::class,
+                    $strategy::class,
+                ));
+            }
+
+            // First in the list, so the refresh is enqueued even when enqueuing a table load fails - the
+            // direct-grant tables are already written at this point and their metadata must catch up.
+            $tasks[] = new DirectGrantMetadataRefreshTask(
+                (int) $strategy->getDataStorage()->getWorkspaceId(),
+            );
+        }
+
         /** @var array<string, TableDescription> $createdTableDescriptions */
         $createdTableDescriptions = [];
         $tableConfigurationResolver = new TableConfigurationResolver($this->logger);
@@ -167,27 +183,13 @@ class TableLoader
                     $descriptionsToStoreAfterLoad;
             }
 
-            $loadTableTasks[] = $loadTableTask;
-        }
-
-        if ($strategy->hasDirectGrantUnloadStrategy()) {
-            if (!$strategy instanceof SqlWorkspaceTableStrategy) {
-                throw new LogicException(sprintf(
-                    'Direct-grant unload strategy is only supported for %s strategy but got %s.',
-                    SqlWorkspaceTableStrategy::class,
-                    $strategy::class,
-                ));
-            }
-
-            $loadTableTasks[] = new DirectGrantMetadataRefreshTask(
-                (int) $strategy->getDataStorage()->getWorkspaceId(),
-            );
+            $tasks[] = $loadTableTask;
         }
 
         $tableQueue = new LoadTableQueue(
             $this->clientWrapper,
             $this->logger,
-            $loadTableTasks,
+            $tasks,
             $createdTableDescriptions,
         );
         $tableQueue->start();

--- a/libs/output-mapping/src/TableLoader.php
+++ b/libs/output-mapping/src/TableLoader.php
@@ -251,7 +251,8 @@ class TableLoader
                 ['only-direct-grants' => true],
             );
         } catch (ClientException $e) {
-            if ($e->getCode() < 500) {
+            // only a 4xx is the user's fault; a connection failure or a client-side error carries code 0
+            if ($e->getCode() >= 400 && $e->getCode() < 500) {
                 throw new InvalidOutputException(
                     sprintf('Failed to refresh metadata of direct-grant tables: %s', $e->getMessage()),
                     $e->getCode(),

--- a/libs/output-mapping/src/TableLoader.php
+++ b/libs/output-mapping/src/TableLoader.php
@@ -6,6 +6,7 @@ namespace Keboola\OutputMapping;
 
 use Keboola\OutputMapping\Configuration\Table\Webalizer;
 use Keboola\OutputMapping\DeferredTasks\LoadTableQueue;
+use Keboola\OutputMapping\DeferredTasks\TableWriter\DirectGrantMetadataRefreshTask;
 use Keboola\OutputMapping\Exception\InvalidOutputException;
 use Keboola\OutputMapping\Exception\InvalidTableStructureException;
 use Keboola\OutputMapping\Exception\TableNotFoundException;
@@ -25,8 +26,6 @@ use Keboola\OutputMapping\Writer\Table\StrategyInterface;
 use Keboola\OutputMapping\Writer\Table\TableConfigurationResolver;
 use Keboola\OutputMapping\Writer\Table\TableConfigurationValidator;
 use Keboola\OutputMapping\Writer\Table\TableHintsConfigurationSchemaResolver;
-use Keboola\StorageApi\ClientException;
-use Keboola\StorageApi\Workspaces;
 use Keboola\StorageApiBranch\ClientWrapper;
 use LogicException;
 use Psr\Log\LoggerInterface;
@@ -171,7 +170,6 @@ class TableLoader
             $loadTableTasks[] = $loadTableTask;
         }
 
-        $unloadJobIds = [];
         if ($strategy->hasDirectGrantUnloadStrategy()) {
             if (!$strategy instanceof SqlWorkspaceTableStrategy) {
                 throw new LogicException(sprintf(
@@ -180,8 +178,10 @@ class TableLoader
                     $strategy::class,
                 ));
             }
-            // enqueue unload for direct-grant tables
-            $unloadJobIds = $this->callWorkspaceUnload($strategy);
+
+            $loadTableTasks[] = new DirectGrantMetadataRefreshTask(
+                (int) $strategy->getDataStorage()->getWorkspaceId(),
+            );
         }
 
         $tableQueue = new LoadTableQueue(
@@ -189,7 +189,6 @@ class TableLoader
             $this->logger,
             $loadTableTasks,
             $createdTableDescriptions,
-            $unloadJobIds,
         );
         $tableQueue->start();
         $tableQueue->loadCustomVariables(Path::join(
@@ -234,33 +233,5 @@ class TableLoader
             $combinedSources,
             $physicalManifests,
         );
-    }
-
-    /**
-     * @return int[] ids of the enqueued Storage metadata refresh jobs
-     */
-    private function callWorkspaceUnload(SqlWorkspaceTableStrategy $strategy): array
-    {
-        $workspaces = new Workspaces(
-            $this->clientWrapper->getBranchClient(),
-        );
-
-        try {
-            return $workspaces->queueUnload(
-                (int) $strategy->getDataStorage()->getWorkspaceId(),
-                ['only-direct-grants' => true],
-            );
-        } catch (ClientException $e) {
-            // only a 4xx is the user's fault; a connection failure or a client-side error carries code 0
-            if ($e->getCode() >= 400 && $e->getCode() < 500) {
-                throw new InvalidOutputException(
-                    sprintf('Failed to refresh metadata of direct-grant tables: %s', $e->getMessage()),
-                    $e->getCode(),
-                    $e,
-                );
-            }
-
-            throw $e;
-        }
     }
 }

--- a/libs/output-mapping/tests/AbstractTestCase.php
+++ b/libs/output-mapping/tests/AbstractTestCase.php
@@ -13,6 +13,8 @@ use Keboola\StagingProvider\Staging\File\FileStagingInterface;
 use Keboola\StagingProvider\Staging\StagingProvider;
 use Keboola\StagingProvider\Staging\StagingType;
 use Keboola\StorageApi\ClientException;
+use Keboola\StorageApi\Components;
+use Keboola\StorageApi\Options\Components\Configuration;
 use Keboola\StorageApi\Options\ListFilesOptions;
 use Keboola\StorageApi\WorkspaceLoginType;
 use Keboola\StorageApi\Workspaces;
@@ -38,6 +40,9 @@ abstract class AbstractTestCase extends TestCase
     protected ?string $workspaceId = null;
     protected array $workspaceCredentials = [];
     protected array $workspace;
+
+    /** @var array{componentId: string, configurationId: string}|null */
+    protected ?array $workspaceConfiguration = null;
 
     protected string $emptyInputBucketId;
     protected string $emptyOutputBucketId;
@@ -128,6 +133,22 @@ abstract class AbstractTestCase extends TestCase
             }
             $this->workspaceId = null;
         }
+
+        if ($this->workspaceConfiguration !== null) {
+            $components = new Components($this->clientWrapper->getBranchClient());
+            try {
+                $components->deleteConfiguration(
+                    $this->workspaceConfiguration['componentId'],
+                    $this->workspaceConfiguration['configurationId'],
+                );
+            } catch (ClientException $e) {
+                if ($e->getCode() !== 404) {
+                    throw $e;
+                }
+            }
+            $this->workspaceConfiguration = null;
+        }
+
         parent::tearDown();
     }
 
@@ -139,6 +160,60 @@ abstract class AbstractTestCase extends TestCase
             $workspaces->deleteWorkspace((int) $this->workspaceId, async: true);
         }
 
+        $workspace = $workspaces->createWorkspace($this->getWorkspaceCreateOptions(), true);
+
+        $this->workspaceId = (string) $workspace['id'];
+        $this->workspaceCredentials = $workspace['connection'];
+    }
+
+    /**
+     * Storage resolves the direct-grant output tables of a workspace from the component configuration the workspace
+     * was created from, so only a workspace created this way can produce the metadata refresh job.
+     *
+     * @param list<array<string, mixed>> $outputTables items of storage.output.tables of the configuration
+     */
+    protected function initConfigurationWorkspace(array $outputTables): void
+    {
+        $stagingType = StagingType::from('workspace-' . $this->clientWrapper->getToken()->getProjectBackend());
+        $componentId = match ($stagingType) {
+            StagingType::WorkspaceSnowflake => 'keboola.snowflake-transformation',
+            StagingType::WorkspaceBigquery => 'keboola.google-bigquery-transformation',
+            default => throw new InvalidArgumentException(sprintf(
+                'Unknown staging %s',
+                $stagingType->value,
+            )),
+        };
+        $configurationId = uniqid('output-mapping-test-');
+
+        $components = new Components($this->clientWrapper->getBranchClient());
+        $components->addConfiguration(
+            (new Configuration())
+                ->setComponentId($componentId)
+                ->setConfigurationId($configurationId)
+                ->setName($configurationId)
+                ->setConfiguration(['storage' => ['output' => ['tables' => $outputTables]]]),
+        );
+        $this->workspaceConfiguration = [
+            'componentId' => $componentId,
+            'configurationId' => $configurationId,
+        ];
+
+        $workspace = $components->createConfigurationWorkspace(
+            $componentId,
+            $configurationId,
+            $this->getWorkspaceCreateOptions(),
+            true,
+        );
+
+        $this->workspaceId = (string) $workspace['id'];
+        $this->workspaceCredentials = $workspace['connection'];
+    }
+
+    /**
+     * @return array{backend: string, loginType?: WorkspaceLoginType}
+     */
+    private function getWorkspaceCreateOptions(): array
+    {
         $stagingType = StagingType::from('workspace-' . $this->clientWrapper->getToken()->getProjectBackend());
 
         $options = ['backend' => match ($stagingType) {
@@ -157,10 +232,7 @@ abstract class AbstractTestCase extends TestCase
             $options['loginType'] = WorkspaceLoginType::NONE;
         }
 
-        $workspace = $workspaces->createWorkspace($options, true);
-
-        $this->workspaceId = (string) $workspace['id'];
-        $this->workspaceCredentials = $workspace['connection'];
+        return $options;
     }
 
     protected function getWorkspaceStagingFactory(

--- a/libs/output-mapping/tests/DeferredTasks/CreateAndLoadTableTaskTest.php
+++ b/libs/output-mapping/tests/DeferredTasks/CreateAndLoadTableTaskTest.php
@@ -7,11 +7,12 @@ namespace Keboola\OutputMapping\Tests\DeferredTasks;
 use Keboola\OutputMapping\DeferredTasks\TableWriter\CreateAndLoadTableTask;
 use Keboola\OutputMapping\Writer\Table\MappingDestination;
 use Keboola\StorageApi\Client;
+use Keboola\StorageApiBranch\ClientWrapper;
 use PHPUnit\Framework\TestCase;
 
 class CreateAndLoadTableTaskTest extends TestCase
 {
-    public function testStartImport(): void
+    public function testStart(): void
     {
         $destinationMock = $this->createMock(MappingDestination::class);
         $destinationMock->expects(self::once())
@@ -34,10 +35,15 @@ class CreateAndLoadTableTaskTest extends TestCase
             ->willReturn('123456')
         ;
 
-        $loadTableTask = new CreateAndLoadTableTask($destinationMock, ['foo' => 'bar'], true);
-        $loadTableTask->startImport($storageApiMock);
+        $clientWrapperMock = $this->createMock(ClientWrapper::class);
+        $clientWrapperMock->expects(self::once())
+            ->method('getTableAndFileStorageClient')
+            ->willReturn($storageApiMock);
 
-        self::assertSame('123456', $loadTableTask->getStorageJobId());
+        $loadTableTask = new CreateAndLoadTableTask($destinationMock, ['foo' => 'bar'], true);
+        $loadTableTask->start($clientWrapperMock);
+
+        self::assertSame(['123456'], $loadTableTask->getStorageJobIds());
         self::assertTrue($loadTableTask->isUsingFreshlyCreatedTable());
     }
 }

--- a/libs/output-mapping/tests/DeferredTasks/DirectGrantMetadataRefreshTaskTest.php
+++ b/libs/output-mapping/tests/DeferredTasks/DirectGrantMetadataRefreshTaskTest.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Keboola\OutputMapping\Tests\DeferredTasks;
+
+use Keboola\OutputMapping\DeferredTasks\TableWriter\DirectGrantMetadataRefreshTask;
+use Keboola\StorageApi\BranchAwareClient;
+use Keboola\StorageApiBranch\ClientWrapper;
+use LogicException;
+use PHPUnit\Framework\TestCase;
+
+class DirectGrantMetadataRefreshTaskTest extends TestCase
+{
+    public function testGetStorageJobIdsBeforeStartThrowsLogicException(): void
+    {
+        $task = new DirectGrantMetadataRefreshTask(1234);
+
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('Metadata refresh of direct-grant tables has not been started yet.');
+        $task->getStorageJobIds();
+    }
+
+    public function testStartWithNothingToRefreshReturnsNoJobIds(): void
+    {
+        $branchClient = $this->createMock(BranchAwareClient::class);
+        $branchClient->expects(self::once())
+            ->method('apiPostJson')
+            ->with('workspaces/1234/unload?only-direct-grants=1', [], false)
+            ->willReturn([])
+        ;
+
+        $clientWrapper = $this->createMock(ClientWrapper::class);
+        $clientWrapper->expects(self::once())
+            ->method('getBranchClient')
+            ->willReturn($branchClient)
+        ;
+
+        $task = new DirectGrantMetadataRefreshTask(1234);
+        $task->start($clientWrapper);
+
+        self::assertSame([], $task->getStorageJobIds());
+    }
+}

--- a/libs/output-mapping/tests/DeferredTasks/LoadTableQueueTest.php
+++ b/libs/output-mapping/tests/DeferredTasks/LoadTableQueueTest.php
@@ -64,6 +64,127 @@ class LoadTableQueueTest extends TestCase
         self::assertSame(2, $loadQueue->getTaskCount());
     }
 
+    public function testTaskCountIncludesUnloadJobs(): void
+    {
+        $clientWrapperMock = $this->createMock(ClientWrapper::class);
+        $clientWrapperMock->method('getTableAndFileStorageClient')
+            ->willReturn($this->createMock(Client::class));
+
+        $loadQueue = new LoadTableQueue(
+            $clientWrapperMock,
+            new NullLogger(),
+            [
+                $this->createMock(LoadTableTask::class),
+            ],
+            [],
+            [456, 789],
+        );
+
+        self::assertSame(3, $loadQueue->getTaskCount());
+    }
+
+    public function testWaitForAllWaitsForUnloadJobsAfterLoadTasks(): void
+    {
+        $expectedTableId = 'in.c-myBucket.myTable';
+        $awaitedJobIds = [];
+
+        $branchClientMock = $this->createMock(BranchAwareClient::class);
+        $branchClientMock->expects(self::exactly(2))
+            ->method('waitForJob')
+            ->willReturnCallback(
+                function ($jobId) use (&$awaitedJobIds, $expectedTableId): array {
+                    $awaitedJobIds[] = $jobId;
+
+                    if ($jobId === 456) {
+                        return [
+                            'operationName' => 'refreshStorageBuckets',
+                            'status' => 'success',
+                        ];
+                    }
+
+                    return [
+                        'operationName' => 'tableImport',
+                        'status' => 'success',
+                        'tableId' => $expectedTableId,
+                        'metrics' => [
+                            'inBytes' => 123,
+                            'inBytesUncompressed' => 456,
+                        ],
+                    ];
+                },
+            )
+        ;
+
+        $clientMock = $this->createMock(Client::class);
+        $clientMock->expects(self::once())
+            ->method('getTable')
+            ->with($expectedTableId)
+            ->willReturn([
+                'id' => $expectedTableId,
+                'displayName' => 'my-name',
+                'name' => 'my-name',
+                'columns' => [],
+                'lastImportDate' => null,
+                'lastChangeDate' => null,
+            ])
+        ;
+
+        $loadTask = $this->createMock(LoadTableTask::class);
+        $loadTask->expects(self::once())
+            ->method('getStorageJobId')
+            ->willReturn('123')
+        ;
+        $loadTask->expects(self::once())
+            ->method('applyMetadata')
+        ;
+
+        $clientWrapperMock = $this->createMock(ClientWrapper::class);
+        $clientWrapperMock->method('getTableAndFileStorageClient')
+            ->willReturn($clientMock);
+        $clientWrapperMock->method('getBranchClient')
+            ->willReturn($branchClientMock);
+
+        $loadQueue = new LoadTableQueue($clientWrapperMock, new NullLogger(), [$loadTask], [], [456]);
+        $jobIds = $loadQueue->waitForAll();
+
+        self::assertSame(['123', 456], $awaitedJobIds);
+        self::assertSame(['123'], $jobIds);
+
+        $tablesMetrics = $loadQueue->getTableResult()->getMetrics()?->getTableMetrics();
+        self::assertNotNull($tablesMetrics);
+        self::assertCount(1, $tablesMetrics);
+    }
+
+    public function testWaitForAllWithFailedUnloadJobThrowsInvalidOutputException(): void
+    {
+        $branchClientMock = $this->createMock(BranchAwareClient::class);
+        $branchClientMock->expects(self::once())
+            ->method('waitForJob')
+            ->with(456)
+            ->willReturn([
+                'operationName' => 'refreshStorageBuckets',
+                'status' => 'error',
+                'error' => [
+                    'message' => 'Workspace "1234" not found.',
+                ],
+            ])
+        ;
+
+        $clientWrapperMock = $this->createMock(ClientWrapper::class);
+        $clientWrapperMock->method('getTableAndFileStorageClient')
+            ->willReturn($this->createMock(Client::class));
+        $clientWrapperMock->method('getBranchClient')
+            ->willReturn($branchClientMock);
+
+        $loadQueue = new LoadTableQueue($clientWrapperMock, new NullLogger(), [], [], [456]);
+
+        $this->expectException(InvalidOutputException::class);
+        $this->expectExceptionMessage(
+            'Failed to refresh metadata of direct-grant tables (Storage job "456"): Workspace "1234" not found.',
+        );
+        $loadQueue->waitForAll();
+    }
+
     public function testStart(): void
     {
         $loadTask = $this->createMock(LoadTableTask::class);

--- a/libs/output-mapping/tests/DeferredTasks/LoadTableQueueTest.php
+++ b/libs/output-mapping/tests/DeferredTasks/LoadTableQueueTest.php
@@ -6,6 +6,7 @@ namespace Keboola\OutputMapping\Tests\DeferredTasks;
 
 use Generator;
 use Keboola\InputMapping\Table\Result\TableInfo;
+use Keboola\OutputMapping\DeferredTasks\DeferredTaskInterface;
 use Keboola\OutputMapping\DeferredTasks\LoadTableQueue;
 use Keboola\OutputMapping\DeferredTasks\TableWriter\LoadTableTask;
 use Keboola\OutputMapping\Exception\InvalidOutputException;
@@ -52,38 +53,34 @@ class LoadTableQueueTest extends TestCase
         $clientWrapperMock->method('getTableAndFileStorageClient')
             ->willReturn($this->createMock(Client::class));
 
-        $loadQueue = new LoadTableQueue(
-            $clientWrapperMock,
-            new NullLogger(),
-            [
-                $this->createMock(LoadTableTask::class),
-                $this->createMock(LoadTableTask::class),
-            ],
-        );
+        $loadTask1 = $this->createMock(LoadTableTask::class);
+        $loadTask1->method('getStorageJobIds')->willReturn(['123']);
+        $loadTask2 = $this->createMock(LoadTableTask::class);
+        $loadTask2->method('getStorageJobIds')->willReturn(['456']);
+
+        $loadQueue = new LoadTableQueue($clientWrapperMock, new NullLogger(), [$loadTask1, $loadTask2]);
 
         self::assertSame(2, $loadQueue->getTaskCount());
     }
 
-    public function testTaskCountIncludesUnloadJobs(): void
+    public function testTaskCountCountsEveryStorageJobOfATask(): void
     {
         $clientWrapperMock = $this->createMock(ClientWrapper::class);
         $clientWrapperMock->method('getTableAndFileStorageClient')
             ->willReturn($this->createMock(Client::class));
 
-        $loadQueue = new LoadTableQueue(
-            $clientWrapperMock,
-            new NullLogger(),
-            [
-                $this->createMock(LoadTableTask::class),
-            ],
-            [],
-            [456, 789],
-        );
+        $loadTask = $this->createMock(LoadTableTask::class);
+        $loadTask->method('getStorageJobIds')->willReturn(['123']);
+
+        $refreshTask = $this->createMock(DeferredTaskInterface::class);
+        $refreshTask->method('getStorageJobIds')->willReturn(['456', '789']);
+
+        $loadQueue = new LoadTableQueue($clientWrapperMock, new NullLogger(), [$loadTask, $refreshTask]);
 
         self::assertSame(3, $loadQueue->getTaskCount());
     }
 
-    public function testWaitForAllWaitsForUnloadJobsAfterLoadTasks(): void
+    public function testWaitForAllWaitsForTaskWithoutDestinationTable(): void
     {
         $expectedTableId = 'in.c-myBucket.myTable';
         $awaitedJobIds = [];
@@ -95,7 +92,7 @@ class LoadTableQueueTest extends TestCase
                 function ($jobId) use (&$awaitedJobIds, $expectedTableId): array {
                     $awaitedJobIds[] = $jobId;
 
-                    if ($jobId === 456) {
+                    if ($jobId === '456') {
                         return [
                             'operationName' => 'refreshStorageBuckets',
                             'status' => 'success',
@@ -131,11 +128,17 @@ class LoadTableQueueTest extends TestCase
 
         $loadTask = $this->createMock(LoadTableTask::class);
         $loadTask->expects(self::once())
-            ->method('getStorageJobId')
-            ->willReturn('123')
+            ->method('getStorageJobIds')
+            ->willReturn(['123'])
         ;
         $loadTask->expects(self::once())
             ->method('applyMetadata')
+        ;
+
+        $refreshTask = $this->createMock(DeferredTaskInterface::class);
+        $refreshTask->expects(self::once())
+            ->method('getStorageJobIds')
+            ->willReturn(['456'])
         ;
 
         $clientWrapperMock = $this->createMock(ClientWrapper::class);
@@ -144,30 +147,45 @@ class LoadTableQueueTest extends TestCase
         $clientWrapperMock->method('getBranchClient')
             ->willReturn($branchClientMock);
 
-        $loadQueue = new LoadTableQueue($clientWrapperMock, new NullLogger(), [$loadTask], [], [456]);
+        $loadQueue = new LoadTableQueue($clientWrapperMock, new NullLogger(), [$loadTask, $refreshTask]);
         $jobIds = $loadQueue->waitForAll();
 
-        self::assertSame(['123', 456], $awaitedJobIds);
-        self::assertSame(['123'], $jobIds);
+        self::assertSame(['123', '456'], $awaitedJobIds);
+        self::assertSame(['123', '456'], $jobIds);
 
+        // a job without a destination table contributes no table metrics
         $tablesMetrics = $loadQueue->getTableResult()->getMetrics()?->getTableMetrics();
         self::assertNotNull($tablesMetrics);
         self::assertCount(1, $tablesMetrics);
     }
 
-    public function testWaitForAllWithFailedUnloadJobThrowsInvalidOutputException(): void
+    public function testWaitForAllWithFailedTaskWithoutDestinationTableThrowsInvalidOutputException(): void
     {
+        $jobResult = [
+            'operationName' => 'refreshStorageBuckets',
+            'status' => 'error',
+            'error' => [
+                'message' => 'Workspace "1234" not found.',
+            ],
+        ];
+
         $branchClientMock = $this->createMock(BranchAwareClient::class);
         $branchClientMock->expects(self::once())
             ->method('waitForJob')
-            ->with(456)
-            ->willReturn([
-                'operationName' => 'refreshStorageBuckets',
-                'status' => 'error',
-                'error' => [
-                    'message' => 'Workspace "1234" not found.',
-                ],
-            ])
+            ->with('456')
+            ->willReturn($jobResult)
+        ;
+
+        $refreshTask = $this->createMock(DeferredTaskInterface::class);
+        $refreshTask->expects(self::once())
+            ->method('getStorageJobIds')
+            ->willReturn(['456'])
+        ;
+        $refreshTask->expects(self::once())
+            ->method('getFailedJobError')
+            ->with('456', $jobResult)
+            ->willReturn('Failed to refresh metadata of direct-grant tables (Storage job "456"): '
+                . 'Workspace "1234" not found.')
         ;
 
         $clientWrapperMock = $this->createMock(ClientWrapper::class);
@@ -176,7 +194,7 @@ class LoadTableQueueTest extends TestCase
         $clientWrapperMock->method('getBranchClient')
             ->willReturn($branchClientMock);
 
-        $loadQueue = new LoadTableQueue($clientWrapperMock, new NullLogger(), [], [], [456]);
+        $loadQueue = new LoadTableQueue($clientWrapperMock, new NullLogger(), [$refreshTask]);
 
         $this->expectException(InvalidOutputException::class);
         $this->expectExceptionMessage(
@@ -187,75 +205,31 @@ class LoadTableQueueTest extends TestCase
 
     public function testStart(): void
     {
+        $clientWrapperMock = $this->createMock(ClientWrapper::class);
+
         $loadTask = $this->createMock(LoadTableTask::class);
         $loadTask->expects(self::once())
-            ->method('startImport')
-            ->with($this->callback(function ($client) {
-                self::assertInstanceOf(Client::class, $client);
-                return true;
-            }))
+            ->method('start')
+            ->with($clientWrapperMock)
         ;
-        $clientWrapperMock = $this->createMock(ClientWrapper::class);
-        $clientWrapperMock->method('getTableAndFileStorageClient')
-            ->willReturn($this->createMock(Client::class));
 
         $loadQueue = new LoadTableQueue($clientWrapperMock, new NullLogger(), [$loadTask]);
         $loadQueue->start();
     }
 
-    public function testStartFailureWithSapiUserErrorThrowsInvalidOutputException(): void
+    public function testStartPropagatesFailureOfTask(): void
     {
         $clientException = new ClientException('Hi', 444);
 
         $loadTask = $this->createMock(LoadTableTask::class);
         $loadTask->expects(self::once())
-            ->method('startImport')
-            ->with($this->callback(function ($client) {
-                self::assertInstanceOf(Client::class, $client);
-                return true;
-            }))
-            ->willThrowException($clientException)
-        ;
-        $loadTask->expects(self::once())
-            ->method('getDestinationTableName')
-            ->willReturn('out.c-test.test-table')
-        ;
-
-        $clientWrapperMock = $this->createMock(ClientWrapper::class);
-        $clientWrapperMock->method('getTableAndFileStorageClient')
-            ->willReturn($this->createMock(Client::class));
-
-        try {
-            $loadQueue = new LoadTableQueue($clientWrapperMock, new NullLogger(), [$loadTask]);
-            $loadQueue->start();
-            self::fail('LoadTableQueue should fail with InvalidOutputException');
-        } catch (InvalidOutputException $e) {
-            self::assertSame('Hi [out.c-test.test-table]', $e->getMessage());
-            self::assertSame(444, $e->getCode());
-            self::assertSame($clientException, $e->getPrevious());
-        }
-    }
-
-    public function testStartFailureWithSapiAppErrorPropagatesErrorFromClient(): void
-    {
-        $clientException = new ClientException('Hi', 500);
-
-        $loadTask = $this->createMock(LoadTableTask::class);
-        $loadTask->expects(self::once())
-            ->method('startImport')
-            ->with($this->callback(function ($client) {
-                self::assertInstanceOf(Client::class, $client);
-                return true;
-            }))
+            ->method('start')
             ->willThrowException($clientException)
         ;
 
-        $clientWrapperMock = $this->createMock(ClientWrapper::class);
-        $clientWrapperMock->method('getTableAndFileStorageClient')
-            ->willReturn($this->createMock(Client::class));
+        $loadQueue = new LoadTableQueue($this->createMock(ClientWrapper::class), new NullLogger(), [$loadTask]);
 
         try {
-            $loadQueue = new LoadTableQueue($clientWrapperMock, new NullLogger(), [$loadTask]);
             $loadQueue->start();
             self::fail('LoadTableQueue should fail with ClientException');
         } catch (ClientException $e) {
@@ -282,15 +256,20 @@ class LoadTableQueueTest extends TestCase
 
         $loadTask = $this->createMock(LoadTableTask::class);
         $loadTask->expects(self::never())
-            ->method('startImport')
+            ->method('start')
         ;
         $loadTask->expects(self::exactly(2))
             ->method('getDestinationTableName')
             ->willReturn('myTable')
         ;
         $loadTask->expects($this->atLeastOnce())
-            ->method('getStorageJobId')
-            ->willReturn('123')
+            ->method('getStorageJobIds')
+            ->willReturn(['123'])
+        ;
+        $loadTask->expects(self::once())
+            ->method('getFailedJobError')
+            ->with('123', $this->anything())
+            ->willReturn('Failed to load table "myTable": Table with displayName "test" already exists.')
         ;
 
         $clientWrapperMock = $this->createMock(ClientWrapper::class);
@@ -358,15 +337,15 @@ class LoadTableQueueTest extends TestCase
 
         $loadTask = $this->createMock(LoadTableTask::class);
         $loadTask->expects(self::never())
-            ->method('startImport')
+            ->method('start')
         ;
         $loadTask->expects(self::once())
             ->method('getDestinationTableName')
             ->willReturn('myTable')
         ;
         $loadTask->expects(self::once())
-            ->method('getStorageJobId')
-            ->willReturn('123')
+            ->method('getStorageJobIds')
+            ->willReturn(['123'])
         ;
 
         $clientException = new ClientException('Hi', 444, null, null, ['errors' => ['bar' => 'Kochba']]);
@@ -447,11 +426,11 @@ class LoadTableQueueTest extends TestCase
 
         $loadTask = $this->createMock(LoadTableTask::class);
         $loadTask->expects(self::never())
-            ->method('startImport')
+            ->method('start')
         ;
         $loadTask->expects(self::once())
-            ->method('getStorageJobId')
-            ->willReturn('123')
+            ->method('getStorageJobIds')
+            ->willReturn(['123'])
         ;
         $loadTask->expects(self::once())
             ->method('applyMetadata')
@@ -509,11 +488,11 @@ class LoadTableQueueTest extends TestCase
 
         $loadTask = $this->createMock(LoadTableTask::class);
         $loadTask->expects(self::never())
-            ->method('startImport')
+            ->method('start')
         ;
         $loadTask->expects(self::once())
-            ->method('getStorageJobId')
-            ->willReturn('123')
+            ->method('getStorageJobIds')
+            ->willReturn(['123'])
         ;
 
         $clientException = new ClientException('Hi', 500);
@@ -614,11 +593,11 @@ class LoadTableQueueTest extends TestCase
 
         $loadTask = $this->createMock(LoadTableTask::class);
         $loadTask->expects(self::never())
-            ->method('startImport')
+            ->method('start')
         ;
         $loadTask->expects(self::once())
-            ->method('getStorageJobId')
-            ->willReturn('123')
+            ->method('getStorageJobIds')
+            ->willReturn(['123'])
         ;
         $loadTask->expects(self::once())
             ->method('applyMetadata')
@@ -738,6 +717,10 @@ class LoadTableQueueTest extends TestCase
             ->willReturn(true);
         $loadTask->method('getDestinationTableName')
             ->willReturn('my-table');
+        $loadTask->method('getStorageJobIds')
+            ->willReturn(['123']);
+        $loadTask->method('getFailedJobError')
+            ->willReturn('Failed to load table "my-table": Hi');
 
         $clientWrapperMock = $this->createMock(ClientWrapper::class);
         $clientWrapperMock->method('getTableAndFileStorageClient')
@@ -821,8 +804,8 @@ class LoadTableQueueTest extends TestCase
 
         $loadTask = $this->createMock(LoadTableTask::class);
         $loadTask->expects(self::once())
-            ->method('getStorageJobId')
-            ->willReturn('123')
+            ->method('getStorageJobIds')
+            ->willReturn(['123'])
         ;
         $loadTask->expects(self::once())
             ->method('applyMetadata')
@@ -888,7 +871,7 @@ class LoadTableQueueTest extends TestCase
         ;
 
         $loadTask = $this->createMock(LoadTableTask::class);
-        $loadTask->method('getStorageJobId')->willReturn('123');
+        $loadTask->method('getStorageJobIds')->willReturn(['123']);
         $loadTask->method('getDestinationTableName')->willReturn($tableId);
         $loadTask->expects(self::once())->method('applyMetadata');
 
@@ -960,7 +943,7 @@ class LoadTableQueueTest extends TestCase
         ;
 
         $loadTask = $this->createMock(LoadTableTask::class);
-        $loadTask->expects(self::once())->method('getStorageJobId')->willReturn('123');
+        $loadTask->expects(self::once())->method('getStorageJobIds')->willReturn(['123']);
         $loadTask->expects(self::once())->method('applyMetadata');
 
         $clientWrapperMock = $this->createMock(ClientWrapper::class);
@@ -1014,9 +997,10 @@ class LoadTableQueueTest extends TestCase
         ;
 
         $loadTask = $this->createMock(LoadTableTask::class);
-        $loadTask->expects(self::once())->method('getStorageJobId')->willReturn('123');
+        $loadTask->expects(self::once())->method('getStorageJobIds')->willReturn(['123']);
         $loadTask->expects(self::once())->method('isUsingFreshlyCreatedTable')->willReturn(true);
         $loadTask->method('getDestinationTableName')->willReturn($tableId);
+        $loadTask->method('getFailedJobError')->willReturn(sprintf('Failed to load table "%s": Hi', $tableId));
 
         $clientWrapperMock = $this->createMock(ClientWrapper::class);
         $clientWrapperMock->method('getTableAndFileStorageClient')
@@ -1103,7 +1087,7 @@ class LoadTableQueueTest extends TestCase
         $loadTasks = [];
         foreach (['123', '456'] as $jobId) {
             $loadTask = $this->createMock(LoadTableTask::class);
-            $loadTask->expects(self::once())->method('getStorageJobId')->willReturn($jobId);
+            $loadTask->expects(self::once())->method('getStorageJobIds')->willReturn([$jobId]);
             $loadTask->expects(self::once())->method('applyMetadata');
             $loadTask->method('getDestinationTableName')->willReturn($tableId);
             $loadTasks[] = $loadTask;

--- a/libs/output-mapping/tests/DeferredTasks/LoadTableQueueTest.php
+++ b/libs/output-mapping/tests/DeferredTasks/LoadTableQueueTest.php
@@ -237,6 +237,46 @@ class LoadTableQueueTest extends TestCase
         }
     }
 
+    public function testStartEnqueuesTasksInOrderUntilOneFails(): void
+    {
+        $startedTasks = [];
+
+        $firstTask = $this->createMock(DeferredTaskInterface::class);
+        $firstTask->expects(self::once())
+            ->method('start')
+            ->willReturnCallback(function () use (&$startedTasks): void {
+                $startedTasks[] = 'first';
+            })
+        ;
+
+        $failingTask = $this->createMock(LoadTableTask::class);
+        $failingTask->expects(self::once())
+            ->method('start')
+            ->willReturnCallback(function () use (&$startedTasks): void {
+                $startedTasks[] = 'failing';
+                throw new ClientException('Hi', 444);
+            })
+        ;
+
+        $lastTask = $this->createMock(LoadTableTask::class);
+        $lastTask->expects(self::never())
+            ->method('start')
+        ;
+
+        $loadQueue = new LoadTableQueue(
+            $this->createMock(ClientWrapper::class),
+            new NullLogger(),
+            [$firstTask, $failingTask, $lastTask],
+        );
+
+        try {
+            $loadQueue->start();
+            self::fail('LoadTableQueue should fail with ClientException');
+        } catch (ClientException) {
+            self::assertSame(['first', 'failing'], $startedTasks);
+        }
+    }
+
     public function testWaitForAllWithErrorThrowsInvalidOutputException(): void
     {
         $clientMock = $this->createMock(BranchAwareClient::class);

--- a/libs/output-mapping/tests/DeferredTasks/LoadTableTaskTest.php
+++ b/libs/output-mapping/tests/DeferredTasks/LoadTableTaskTest.php
@@ -5,13 +5,17 @@ declare(strict_types=1);
 namespace Keboola\OutputMapping\Tests\DeferredTasks;
 
 use Keboola\OutputMapping\DeferredTasks\TableWriter\LoadTableTask;
+use Keboola\OutputMapping\Exception\InvalidOutputException;
 use Keboola\OutputMapping\Writer\Table\MappingDestination;
 use Keboola\StorageApi\Client;
+use Keboola\StorageApi\ClientException;
+use Keboola\StorageApiBranch\ClientWrapper;
+use LogicException;
 use PHPUnit\Framework\TestCase;
 
 class LoadTableTaskTest extends TestCase
 {
-    public function testStartImport(): void
+    public function testStart(): void
     {
         $destinationMock = $this->createMock(MappingDestination::class);
         $destinationMock->expects(self::once())
@@ -25,10 +29,88 @@ class LoadTableTaskTest extends TestCase
             ->willReturn('123456')
         ;
 
+        $clientWrapperMock = $this->createMock(ClientWrapper::class);
+        $clientWrapperMock->expects(self::once())
+            ->method('getTableAndFileStorageClient')
+            ->willReturn($storageApiMock);
+
         $loadTableTask = new LoadTableTask($destinationMock, ['foo' => 'bar'], false);
-        $loadTableTask->startImport($storageApiMock);
+        $loadTableTask->start($clientWrapperMock);
 
         self::assertFalse($loadTableTask->isUsingFreshlyCreatedTable());
-        self::assertSame('123456', $loadTableTask->getStorageJobId());
+        self::assertSame(['123456'], $loadTableTask->getStorageJobIds());
+    }
+
+    public function testStartFailureWithSapiUserErrorThrowsInvalidOutputException(): void
+    {
+        $clientException = new ClientException('Hi', 444);
+
+        try {
+            $this->startFailingTask($clientException);
+            self::fail('Start should fail with InvalidOutputException');
+        } catch (InvalidOutputException $e) {
+            self::assertSame('Hi [out.c-test.test-table]', $e->getMessage());
+            self::assertSame(444, $e->getCode());
+            self::assertSame($clientException, $e->getPrevious());
+        }
+    }
+
+    public function testStartFailureWithSapiAppErrorPropagatesErrorFromClient(): void
+    {
+        $clientException = new ClientException('Hi', 500);
+
+        try {
+            $this->startFailingTask($clientException);
+            self::fail('Start should fail with ClientException');
+        } catch (ClientException $e) {
+            self::assertSame($clientException, $e);
+        }
+    }
+
+    public function testGetStorageJobIdsBeforeStartThrowsLogicException(): void
+    {
+        $destinationMock = $this->createMock(MappingDestination::class);
+        $destinationMock->method('getTableId')->willReturn('out.c-test.test-table');
+
+        $loadTableTask = new LoadTableTask($destinationMock, [], false);
+
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('Load of table "out.c-test.test-table" has not been started yet.');
+        $loadTableTask->getStorageJobIds();
+    }
+
+    public function testGetFailedJobError(): void
+    {
+        $destinationMock = $this->createMock(MappingDestination::class);
+        $destinationMock->method('getTableId')->willReturn('out.c-test.test-table');
+
+        $loadTableTask = new LoadTableTask($destinationMock, [], false);
+
+        self::assertSame(
+            'Failed to load table "out.c-test.test-table": Table already exists.',
+            $loadTableTask->getFailedJobError('123456', [
+                'status' => 'error',
+                'error' => ['message' => 'Table already exists.'],
+            ]),
+        );
+    }
+
+    private function startFailingTask(ClientException $clientException): void
+    {
+        $destinationMock = $this->createMock(MappingDestination::class);
+        $destinationMock->method('getTableId')->willReturn('out.c-test.test-table');
+
+        $storageApiMock = $this->createMock(Client::class);
+        $storageApiMock->expects(self::once())
+            ->method('queueTableImport')
+            ->willThrowException($clientException)
+        ;
+
+        $clientWrapperMock = $this->createMock(ClientWrapper::class);
+        $clientWrapperMock->expects(self::once())
+            ->method('getTableAndFileStorageClient')
+            ->willReturn($storageApiMock);
+
+        (new LoadTableTask($destinationMock, [], false))->start($clientWrapperMock);
     }
 }

--- a/libs/output-mapping/tests/TableLoaderDirectGrantMetadataRefreshTest.php
+++ b/libs/output-mapping/tests/TableLoaderDirectGrantMetadataRefreshTest.php
@@ -26,12 +26,12 @@ use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\NullLogger;
 
-class TableLoaderDirectGrantUnloadTest extends TestCase
+class TableLoaderDirectGrantMetadataRefreshTest extends TestCase
 {
     private const WORKSPACE_ID = '1234';
     private const UNLOAD_URL = 'workspaces/' . self::WORKSPACE_ID . '/unload?only-direct-grants=1';
 
-    public function testUnloadJobIsAwaitedByTheQueue(): void
+    public function testRefreshJobIsAwaitedByTheQueue(): void
     {
         $branchClient = $this->createMock(BranchAwareClient::class);
         $branchClient->expects(self::once())
@@ -41,7 +41,7 @@ class TableLoaderDirectGrantUnloadTest extends TestCase
         ;
         $branchClient->expects(self::once())
             ->method('waitForJob')
-            ->with(456)
+            ->with('456')
             ->willReturn([
                 'operationName' => 'refreshStorageBuckets',
                 'status' => 'success',
@@ -51,10 +51,35 @@ class TableLoaderDirectGrantUnloadTest extends TestCase
         $tableQueue = $this->uploadTables($branchClient);
 
         self::assertSame(1, $tableQueue->getTaskCount());
-        self::assertSame([], $tableQueue->waitForAll());
+        self::assertSame(['456'], $tableQueue->waitForAll());
     }
 
-    public function testFailedUnloadJobFailsTheQueue(): void
+    public function testEveryRefreshJobReturnedByStorageIsAwaited(): void
+    {
+        $awaitedJobIds = [];
+
+        $branchClient = $this->createMock(BranchAwareClient::class);
+        $branchClient->expects(self::once())
+            ->method('apiPostJson')
+            ->with(self::UNLOAD_URL, [], false)
+            ->willReturn([['id' => '456'], ['id' => '789']])
+        ;
+        $branchClient->expects(self::exactly(2))
+            ->method('waitForJob')
+            ->willReturnCallback(function ($jobId) use (&$awaitedJobIds): array {
+                $awaitedJobIds[] = $jobId;
+                return ['operationName' => 'refreshStorageBuckets', 'status' => 'success'];
+            })
+        ;
+
+        $tableQueue = $this->uploadTables($branchClient);
+
+        self::assertSame(2, $tableQueue->getTaskCount());
+        self::assertSame(['456', '789'], $tableQueue->waitForAll());
+        self::assertSame(['456', '789'], $awaitedJobIds);
+    }
+
+    public function testFailedRefreshJobFailsTheQueue(): void
     {
         $branchClient = $this->createMock(BranchAwareClient::class);
         $branchClient->expects(self::once())
@@ -64,7 +89,7 @@ class TableLoaderDirectGrantUnloadTest extends TestCase
         ;
         $branchClient->expects(self::once())
             ->method('waitForJob')
-            ->with(456)
+            ->with('456')
             ->willReturn([
                 'operationName' => 'refreshStorageBuckets',
                 'status' => 'error',
@@ -83,7 +108,7 @@ class TableLoaderDirectGrantUnloadTest extends TestCase
         $tableQueue->waitForAll();
     }
 
-    public function testUnloadFailureWithSapiUserErrorThrowsInvalidOutputException(): void
+    public function testRefreshFailureWithSapiUserErrorThrowsInvalidOutputException(): void
     {
         $clientException = new ClientException('Workspace "1234" not found.', 404);
 
@@ -116,7 +141,7 @@ class TableLoaderDirectGrantUnloadTest extends TestCase
     /**
      * @dataProvider nonUserErrorProvider
      */
-    public function testUnloadFailureWithSapiAppErrorPropagatesErrorFromClient(string $message, int $code): void
+    public function testRefreshFailureWithSapiAppErrorPropagatesErrorFromClient(string $message, int $code): void
     {
         $clientException = new ClientException($message, $code);
 

--- a/libs/output-mapping/tests/TableLoaderDirectGrantUnloadTest.php
+++ b/libs/output-mapping/tests/TableLoaderDirectGrantUnloadTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Keboola\OutputMapping\Tests;
 
+use Generator;
 use Keboola\OutputMapping\DeferredTasks\LoadTableQueue;
 use Keboola\OutputMapping\Exception\InvalidOutputException;
 use Keboola\OutputMapping\MappingCombiner\MappingCombinerInterface;
@@ -106,9 +107,18 @@ class TableLoaderDirectGrantUnloadTest extends TestCase
         }
     }
 
-    public function testUnloadFailureWithSapiAppErrorPropagatesErrorFromClient(): void
+    public static function nonUserErrorProvider(): Generator
     {
-        $clientException = new ClientException('Internal Server Error', 500);
+        yield 'server error' => ['Internal Server Error', 500];
+        yield 'connection failure' => ['cURL error 6: Could not resolve host', 0];
+    }
+
+    /**
+     * @dataProvider nonUserErrorProvider
+     */
+    public function testUnloadFailureWithSapiAppErrorPropagatesErrorFromClient(string $message, int $code): void
+    {
+        $clientException = new ClientException($message, $code);
 
         $branchClient = $this->createMock(BranchAwareClient::class);
         $branchClient->expects(self::once())

--- a/libs/output-mapping/tests/TableLoaderDirectGrantUnloadTest.php
+++ b/libs/output-mapping/tests/TableLoaderDirectGrantUnloadTest.php
@@ -1,0 +1,195 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Keboola\OutputMapping\Tests;
+
+use Keboola\OutputMapping\DeferredTasks\LoadTableQueue;
+use Keboola\OutputMapping\Exception\InvalidOutputException;
+use Keboola\OutputMapping\MappingCombiner\MappingCombinerInterface;
+use Keboola\OutputMapping\OutputMappingSettings;
+use Keboola\OutputMapping\SourcesValidator\SourcesValidatorInterface;
+use Keboola\OutputMapping\Staging\StrategyFactory;
+use Keboola\OutputMapping\SystemMetadata;
+use Keboola\OutputMapping\TableLoader;
+use Keboola\OutputMapping\Writer\Table\Strategy\SqlWorkspaceTableStrategy;
+use Keboola\StagingProvider\Staging\File\FileStagingInterface;
+use Keboola\StagingProvider\Staging\Workspace\WorkspaceStagingInterface;
+use Keboola\StorageApi\BranchAwareClient;
+use Keboola\StorageApi\Client;
+use Keboola\StorageApi\ClientException;
+use Keboola\StorageApiBranch\ClientWrapper;
+use Keboola\StorageApiBranch\Factory\AuthType;
+use Keboola\StorageApiBranch\StorageApiToken;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+
+class TableLoaderDirectGrantUnloadTest extends TestCase
+{
+    private const WORKSPACE_ID = '1234';
+    private const UNLOAD_URL = 'workspaces/' . self::WORKSPACE_ID . '/unload?only-direct-grants=1';
+
+    public function testUnloadJobIsAwaitedByTheQueue(): void
+    {
+        $branchClient = $this->createMock(BranchAwareClient::class);
+        $branchClient->expects(self::once())
+            ->method('apiPostJson')
+            ->with(self::UNLOAD_URL, [], false)
+            ->willReturn([['id' => '456']])
+        ;
+        $branchClient->expects(self::once())
+            ->method('waitForJob')
+            ->with(456)
+            ->willReturn([
+                'operationName' => 'refreshStorageBuckets',
+                'status' => 'success',
+            ])
+        ;
+
+        $tableQueue = $this->uploadTables($branchClient);
+
+        self::assertSame(1, $tableQueue->getTaskCount());
+        self::assertSame([], $tableQueue->waitForAll());
+    }
+
+    public function testFailedUnloadJobFailsTheQueue(): void
+    {
+        $branchClient = $this->createMock(BranchAwareClient::class);
+        $branchClient->expects(self::once())
+            ->method('apiPostJson')
+            ->with(self::UNLOAD_URL, [], false)
+            ->willReturn([['id' => '456']])
+        ;
+        $branchClient->expects(self::once())
+            ->method('waitForJob')
+            ->with(456)
+            ->willReturn([
+                'operationName' => 'refreshStorageBuckets',
+                'status' => 'error',
+                'error' => [
+                    'message' => 'Workspace "1234" not found.',
+                ],
+            ])
+        ;
+
+        $tableQueue = $this->uploadTables($branchClient);
+
+        $this->expectException(InvalidOutputException::class);
+        $this->expectExceptionMessage(
+            'Failed to refresh metadata of direct-grant tables (Storage job "456"): Workspace "1234" not found.',
+        );
+        $tableQueue->waitForAll();
+    }
+
+    public function testUnloadFailureWithSapiUserErrorThrowsInvalidOutputException(): void
+    {
+        $clientException = new ClientException('Workspace "1234" not found.', 404);
+
+        $branchClient = $this->createMock(BranchAwareClient::class);
+        $branchClient->expects(self::once())
+            ->method('apiPostJson')
+            ->with(self::UNLOAD_URL, [], false)
+            ->willThrowException($clientException)
+        ;
+
+        try {
+            $this->uploadTables($branchClient);
+            self::fail('Upload should fail with InvalidOutputException.');
+        } catch (InvalidOutputException $e) {
+            self::assertSame(
+                'Failed to refresh metadata of direct-grant tables: Workspace "1234" not found.',
+                $e->getMessage(),
+            );
+            self::assertSame(404, $e->getCode());
+            self::assertSame($clientException, $e->getPrevious());
+        }
+    }
+
+    public function testUnloadFailureWithSapiAppErrorPropagatesErrorFromClient(): void
+    {
+        $clientException = new ClientException('Internal Server Error', 500);
+
+        $branchClient = $this->createMock(BranchAwareClient::class);
+        $branchClient->expects(self::once())
+            ->method('apiPostJson')
+            ->with(self::UNLOAD_URL, [], false)
+            ->willThrowException($clientException)
+        ;
+
+        try {
+            $this->uploadTables($branchClient);
+            self::fail('Upload should fail with ClientException.');
+        } catch (ClientException $e) {
+            self::assertSame($clientException, $e);
+        }
+    }
+
+    private function uploadTables(BranchAwareClient&MockObject $branchClient): LoadTableQueue
+    {
+        $clientWrapper = $this->createMock(ClientWrapper::class);
+        $clientWrapper->method('getBranchClient')->willReturn($branchClient);
+        $clientWrapper->method('getTableAndFileStorageClient')->willReturn($this->createMock(Client::class));
+
+        $tableLoader = new TableLoader(
+            new NullLogger(),
+            $clientWrapper,
+            $this->createStrategyFactory(),
+        );
+
+        return $tableLoader->uploadTables(
+            new OutputMappingSettings(
+                ['mapping' => [['source' => 'table1a', 'unload_strategy' => 'direct-grant']]],
+                'upload',
+                new StorageApiToken(['owner' => ['features' => []]], 'token', AuthType::STORAGE_TOKEN),
+                false,
+                OutputMappingSettings::DATA_TYPES_SUPPORT_NONE,
+            ),
+            new SystemMetadata(['componentId' => 'testComponent']),
+        );
+    }
+
+    private function createStrategyFactory(): StrategyFactory&MockObject
+    {
+        $dataStorage = $this->createMock(WorkspaceStagingInterface::class);
+        $dataStorage->expects(self::once())
+            ->method('getWorkspaceId')
+            ->willReturn(self::WORKSPACE_ID)
+        ;
+
+        $metadataStorage = $this->createMock(FileStagingInterface::class);
+        $metadataStorage->expects(self::atMost(1))
+            ->method('getPath')
+            ->willReturn('/tmp/output-mapping-metadata-does-not-exist')
+        ;
+
+        $mappingCombiner = $this->createMock(MappingCombinerInterface::class);
+        $mappingCombiner->expects(self::once())
+            ->method('combineDataItemsWithConfigurations')
+            ->willReturn([])
+        ;
+        $mappingCombiner->expects(self::once())
+            ->method('combineSourcesWithManifests')
+            ->willReturn([])
+        ;
+
+        $strategy = $this->createMock(SqlWorkspaceTableStrategy::class);
+        $strategy->method('getSourcesValidator')->willReturn($this->createMock(SourcesValidatorInterface::class));
+        $strategy->method('getMappingCombiner')->willReturn($mappingCombiner);
+        $strategy->method('getMapping')->willReturn([]);
+        $strategy->method('listSources')->willReturn([]);
+        $strategy->method('listManifests')->willReturn([]);
+        $strategy->method('hasSlicer')->willReturn(false);
+        $strategy->method('hasDirectGrantUnloadStrategy')->willReturn(true);
+        $strategy->method('getDataStorage')->willReturn($dataStorage);
+        $strategy->method('getMetadataStorage')->willReturn($metadataStorage);
+
+        $strategyFactory = $this->createMock(StrategyFactory::class);
+        $strategyFactory->expects(self::once())
+            ->method('getTableOutputStrategy')
+            ->willReturn($strategy)
+        ;
+
+        return $strategyFactory;
+    }
+}

--- a/libs/output-mapping/tests/Writer/TableDefinitionV2Test.php
+++ b/libs/output-mapping/tests/Writer/TableDefinitionV2Test.php
@@ -1090,43 +1090,4 @@ class TableDefinitionV2Test extends AbstractTestCase
         }
         return $result;
     }
-
-    #[NeedsEmptyOutputBucket]
-    public function testDirectGrantUnloadStrategySkipsTableUpload(): void
-    {
-        $this->initWorkspace();
-        $tableId = $this->emptyOutputBucketId . '.tableDefinition';
-
-        $config = [
-            'destination' => $tableId,
-            'unload_strategy' => 'direct-grant',
-        ];
-
-        $strategyFactory = $this->getWorkspaceStagingFactory(
-            clientWrapper: $this->clientWrapper,
-            logger: $this->testLogger,
-        );
-
-        $tableLoader = $this->getTableLoader(
-            clientWrapper: $this->clientWrapper,
-            logger: $this->testLogger,
-            strategyFactory: $strategyFactory,
-        );
-
-        $tableQueue = $tableLoader->uploadTables(
-            configuration: new OutputMappingSettings(
-                configuration: ['mapping' => [$config]],
-                sourcePathPrefix: 'upload',
-                storageApiToken: $this->clientWrapper->getToken(),
-                isFailedJob: false,
-                dataTypeSupport: 'none',
-            ),
-            systemMetadata: new SystemMetadata(['componentId' => 'foo']),
-        );
-        $jobIds = $tableQueue->waitForAll();
-        self::assertCount(0, $jobIds, 'No table load job should be created when unload_strategy is direct-grant');
-
-        $tables = $this->clientWrapper->getTableAndFileStorageClient()->listTables($this->emptyOutputBucketId);
-        self::assertCount(0, $tables, 'No tables should be imported when unload_strategy is direct-grant');
-    }
 }

--- a/libs/output-mapping/tests/Writer/TableDefinitionV2Test.php
+++ b/libs/output-mapping/tests/Writer/TableDefinitionV2Test.php
@@ -1124,7 +1124,7 @@ class TableDefinitionV2Test extends AbstractTestCase
             systemMetadata: new SystemMetadata(['componentId' => 'foo']),
         );
         $jobIds = $tableQueue->waitForAll();
-        self::assertCount(0, $jobIds, 'No jobs should be created when unload_strategy is direct-grant');
+        self::assertCount(0, $jobIds, 'No table load job should be created when unload_strategy is direct-grant');
 
         $tables = $this->clientWrapper->getTableAndFileStorageClient()->listTables($this->emptyOutputBucketId);
         self::assertCount(0, $tables, 'No tables should be imported when unload_strategy is direct-grant');

--- a/libs/output-mapping/tests/Writer/Workspace/TableLoaderUnloadStrategyTest.php
+++ b/libs/output-mapping/tests/Writer/Workspace/TableLoaderUnloadStrategyTest.php
@@ -11,7 +11,6 @@ use Keboola\OutputMapping\SystemMetadata;
 use Keboola\OutputMapping\Tests\Needs\NeedsEmptyOutputBucket;
 use Keboola\OutputMapping\Tests\Needs\NeedsTestTables;
 use Keboola\StorageApi\Workspaces;
-use RuntimeException;
 
 class TableLoaderUnloadStrategyTest extends AbstractTestCase
 {
@@ -257,26 +256,6 @@ class TableLoaderUnloadStrategyTest extends AbstractTestCase
         self::assertSame('refreshStorageBuckets', $job['operationName']);
     }
 
-    #[NeedsEmptyOutputBucket]
-    public function testDirectGrantTableIsRegisteredWhenUploadTablesReturns(): void
-    {
-        if ($this->clientWrapper->getToken()->getProjectBackend() !== 'snowflake') {
-            self::markTestSkipped('The table is written into the bucket schema with Snowflake SQL.');
-        }
-
-        $destinationTableId = $this->emptyOutputBucketId . '.table1';
-        $this->initDirectGrantWorkspace($destinationTableId);
-        $this->createTableThroughDirectGrant($this->emptyOutputBucketId, 'table1');
-
-        $this->uploadDirectGrantTable($destinationTableId)->waitForAll();
-
-        // The refresh job is what registers the table written through the direct grant, so it is in Storage only
-        // if uploadTables() really waited for that job.
-        $tables = $this->clientWrapper->getTableAndFileStorageClient()->listTables($this->emptyOutputBucketId);
-        self::assertCount(1, $tables);
-        self::assertSame($destinationTableId, $tables[0]['id']);
-    }
-
     private function initDirectGrantWorkspace(string $destinationTableId): void
     {
         $this->initConfigurationWorkspace([
@@ -321,33 +300,5 @@ class TableLoaderUnloadStrategyTest extends AbstractTestCase
                 'runId' => '1234567',
             ]),
         );
-    }
-
-    /**
-     * Writes a table straight into the bucket schema, which is what a transformation using direct grants does -
-     * the table exists in the backend before output mapping runs and only its Storage metadata is missing.
-     */
-    private function createTableThroughDirectGrant(string $bucketId, string $tableName): void
-    {
-        $bucket = $this->clientWrapper->getTableAndFileStorageClient()->getBucket($bucketId);
-        $backendPath = $bucket['backendPath'] ?? throw new RuntimeException(sprintf(
-            'Bucket "%s" detail carries no backendPath.',
-            $bucketId,
-        ));
-        [$database, $schema] = $backendPath;
-
-        $workspaces = new Workspaces($this->clientWrapper->getBranchClient());
-        $workspaces->executeQuery((int) $this->workspaceId, sprintf(
-            'CREATE TABLE "%s"."%s"."%s" ("id" VARCHAR, "name" VARCHAR)',
-            $database,
-            $schema,
-            $tableName,
-        ));
-        $workspaces->executeQuery((int) $this->workspaceId, sprintf(
-            'INSERT INTO "%s"."%s"."%s" VALUES (\'1\', \'test\')',
-            $database,
-            $schema,
-            $tableName,
-        ));
     }
 }

--- a/libs/output-mapping/tests/Writer/Workspace/TableLoaderUnloadStrategyTest.php
+++ b/libs/output-mapping/tests/Writer/Workspace/TableLoaderUnloadStrategyTest.php
@@ -174,18 +174,12 @@ class TableLoaderUnloadStrategyTest extends AbstractTestCase
         );
 
         $result = $tableLoader->uploadTables($configuration, $systemMetadata);
+        self::assertSame(1, $result->getTaskCount(), 'Only the table load job is queued, no metadata refresh');
         $result->waitForAll();
 
         $tables = $this->clientWrapper->getTableAndFileStorageClient()->listTables($this->emptyOutputBucketId);
         self::assertCount(1, $tables, 'Table should be imported when unload_strategy is not set');
         self::assertEquals($this->emptyOutputBucketId . '.table1', $tables[0]['id']);
-
-        $logRecords = $this->testHandler->getRecords();
-        $unloadWarnings = array_filter(
-            $logRecords,
-            fn($record) => is_string($record['message']) && str_contains($record['message'], 'Workspace unload failed'),
-        );
-        self::assertCount(0, $unloadWarnings, 'Should not attempt workspace unload when no direct-grant mappings');
     }
 
     #[NeedsEmptyOutputBucket]

--- a/libs/output-mapping/tests/Writer/Workspace/TableLoaderUnloadStrategyTest.php
+++ b/libs/output-mapping/tests/Writer/Workspace/TableLoaderUnloadStrategyTest.php
@@ -4,12 +4,14 @@ declare(strict_types=1);
 
 namespace Keboola\OutputMapping\Tests;
 
+use Keboola\OutputMapping\DeferredTasks\LoadTableQueue;
 use Keboola\OutputMapping\Mapping\MappingFromRawConfiguration;
 use Keboola\OutputMapping\OutputMappingSettings;
 use Keboola\OutputMapping\SystemMetadata;
 use Keboola\OutputMapping\Tests\Needs\NeedsEmptyOutputBucket;
 use Keboola\OutputMapping\Tests\Needs\NeedsTestTables;
 use Keboola\StorageApi\Workspaces;
+use RuntimeException;
 
 class TableLoaderUnloadStrategyTest extends AbstractTestCase
 {
@@ -64,9 +66,6 @@ class TableLoaderUnloadStrategyTest extends AbstractTestCase
 
         $tables = $this->clientWrapper->getTableAndFileStorageClient()->listTables($this->emptyOutputBucketId);
         self::assertCount(0, $tables, 'No tables should be imported when unload_strategy is direct-grant');
-
-        // Direct-grant configurations are filtered,
-        // so they don't go through the loading cycle and no loading message is logged
     }
 
     #[NeedsEmptyOutputBucket]
@@ -238,5 +237,117 @@ class TableLoaderUnloadStrategyTest extends AbstractTestCase
         $tables = $this->clientWrapper->getTableAndFileStorageClient()->listTables($this->emptyOutputBucketId);
         self::assertCount(1, $tables, 'Only non-direct-grant table should be imported');
         self::assertEquals($this->emptyOutputBucketId . '.table2', $tables[0]['id']);
+    }
+
+    #[NeedsEmptyOutputBucket]
+    public function testDirectGrantMetadataRefreshIsAwaited(): void
+    {
+        $destinationTableId = $this->emptyOutputBucketId . '.table1';
+        $this->initDirectGrantWorkspace($destinationTableId);
+
+        $tableQueue = $this->uploadDirectGrantTable($destinationTableId);
+
+        self::assertSame(1, $tableQueue->getTaskCount(), 'The metadata refresh job is the only queued job');
+        self::assertSame([], $tableQueue->getLoadTableTasks(), 'A direct-grant table has no table load job');
+
+        $jobIds = $tableQueue->waitForAll();
+        self::assertCount(1, $jobIds, 'The refresh job of the workspace is awaited');
+
+        $job = $this->clientWrapper->getBranchClient()->getJob((int) $jobIds[0]);
+        self::assertSame('refreshStorageBuckets', $job['operationName']);
+    }
+
+    #[NeedsEmptyOutputBucket]
+    public function testDirectGrantTableIsRegisteredWhenUploadTablesReturns(): void
+    {
+        if ($this->clientWrapper->getToken()->getProjectBackend() !== 'snowflake') {
+            self::markTestSkipped('The table is written into the bucket schema with Snowflake SQL.');
+        }
+
+        $destinationTableId = $this->emptyOutputBucketId . '.table1';
+        $this->initDirectGrantWorkspace($destinationTableId);
+        $this->createTableThroughDirectGrant($this->emptyOutputBucketId, 'table1');
+
+        $this->uploadDirectGrantTable($destinationTableId)->waitForAll();
+
+        // The refresh job is what registers the table written through the direct grant, so it is in Storage only
+        // if uploadTables() really waited for that job.
+        $tables = $this->clientWrapper->getTableAndFileStorageClient()->listTables($this->emptyOutputBucketId);
+        self::assertCount(1, $tables);
+        self::assertSame($destinationTableId, $tables[0]['id']);
+    }
+
+    private function initDirectGrantWorkspace(string $destinationTableId): void
+    {
+        $this->initConfigurationWorkspace([
+            [
+                'source' => 'table1a',
+                'destination' => $destinationTableId,
+                'unload_strategy' => 'direct-grant',
+            ],
+        ]);
+    }
+
+    private function uploadDirectGrantTable(string $destinationTableId): LoadTableQueue
+    {
+        $tableLoader = $this->getTableLoader(
+            clientWrapper: $this->clientWrapper,
+            logger: $this->testLogger,
+            strategyFactory: $this->getWorkspaceStagingFactory(
+                clientWrapper: $this->clientWrapper,
+                logger: $this->testLogger,
+            ),
+        );
+
+        return $tableLoader->uploadTables(
+            new OutputMappingSettings(
+                [
+                    'mapping' => [
+                        [
+                            'source' => 'table1a',
+                            'destination' => $destinationTableId,
+                            'unload_strategy' => 'direct-grant',
+                        ],
+                    ],
+                ],
+                '',
+                $this->clientWrapper->getToken(),
+                false,
+                OutputMappingSettings::DATA_TYPES_SUPPORT_NONE,
+            ),
+            new SystemMetadata([
+                'componentId' => 'testComponent',
+                'configurationId' => 'metadata-write-test',
+                'runId' => '1234567',
+            ]),
+        );
+    }
+
+    /**
+     * Writes a table straight into the bucket schema, which is what a transformation using direct grants does -
+     * the table exists in the backend before output mapping runs and only its Storage metadata is missing.
+     */
+    private function createTableThroughDirectGrant(string $bucketId, string $tableName): void
+    {
+        $bucket = $this->clientWrapper->getTableAndFileStorageClient()->getBucket($bucketId);
+        $backendPath = $bucket['backendPath'] ?? throw new RuntimeException(sprintf(
+            'Bucket "%s" detail carries no backendPath.',
+            $bucketId,
+        ));
+        [$database, $schema] = $backendPath;
+
+        $workspaces = new Workspaces($this->clientWrapper->getBranchClient());
+        $workspaces->executeQuery((int) $this->workspaceId, sprintf(
+            'CREATE TABLE "%s"."%s"."%s" ("id" VARCHAR, "name" VARCHAR)',
+            $database,
+            $schema,
+            $tableName,
+        ));
+        $workspaces->executeQuery((int) $this->workspaceId, sprintf(
+            'INSERT INTO "%s"."%s"."%s" VALUES (\'1\', \'test\')',
+            $database,
+            $schema,
+            $tableName,
+        ));
     }
 }


### PR DESCRIPTION
**Linear**: DMD-1828
Other repositories: keboola/connection#7992, keboola/connection#7993

This is **PR 3/3** of the DMD-1828

## What changed and why

Customer symptom (SUPPORT-17181): a Flow trigger on a table written by direct-grant output mapping fired only intermittently, although the transformation succeeded on every scheduled run.

Direct-grant output mapping does not create a `tableImport` job — `TableLoader` calls
`POST /workspaces/{id}/unload?only-direct-grants=true`, and the async `refreshStorageBuckets` job
that returns is what refreshes table metadata and dispatches the `TABLE_IMPORT_DONE` events Flow
triggers listen to. That call threw the returned job ids away and swallowed every `Throwable` into
a log warning, so:

- nothing waited for the refresh, and `docker-bundle` drops the staging workspace right after
  output mapping — so the refresh could reach its workspace lookup after the workspace was already
  deleted, fail, and never dispatch an event;
- that failure was invisible: the transformation reported Success with stale metadata and an
  untriggered flow.

The refresh is now a task in `LoadTableQueue` like any other Storage job, which closes the race by
construction: `Runner::waitForStorageJobs()` calls `waitForAll()` first and only cleans up the
staging workspace in its `finally` block. An errored refresh job lands in the same `$errors` list
as a failed table load, i.e. in the single `InvalidOutputException`. Enqueuing the refresh no
longer swallows failures either: a 4xx becomes an `InvalidOutputException`, anything else is
rethrown.

## How it is wired

`DeferredTaskInterface` describes what the queue needs from any Storage job it awaits — `start()`,
`getStorageJobIds()` and `getFailedJobError()`. `LoadTableTaskInterface` extends it with the
table-load specifics (metadata, destination table, freshly-created flag). The refresh is
`DirectGrantMetadataRefreshTask`, first in the same task list, so it is enqueued by
`LoadTableQueue::start()` and awaited by the same loop as the table loads. It goes first because
`start()` walks the list and a failing enqueue aborts it — the direct-grant tables are already
written at that point, so their metadata has to catch up even when a table load is rejected. A task
without a destination table only contributes its error message — it has nothing to annotate,
describe or measure, so `refreshStorageBuckets` never reaches `$jobResults` / `Metrics` /
`TableInfo`.

Mapping a Storage failure of the enqueue call to `InvalidOutputException` moved from
`LoadTableQueue::start()` into the tasks, because the two differ: a table load treats any code
`< 500` as the user's fault (unchanged behaviour), while the refresh treats only a 4xx that way.
`ClientException` carries code `0` when there is no HTTP response (connection failure, DNS, read
timeout) or when the client throws before the request, and those must not be reported as the
user's fault. Fixing the table-load condition changes the behaviour of an existing path and
belongs in its own PR.

## BEHAVIOUR CHANGE

`docker-bundle` converts `InvalidOutputException` to a `UserException`, so **transformations using
`unload_strategy: direct-grant` will now FAIL when the Storage metadata refresh fails**, where they
previously reported Success. Enqueuing the refresh can also fail the job outright (4xx) instead of
logging a warning.

**This must be released after the two connection-side fixes for DMD-1828 land**
(per-table tolerance of a missing backend object, and bucket-scoped locking for the refresh job).
Today's dominant refresh failures are exactly the ones those PRs remove — project 15 reproduces
hourly — so releasing this first would convert existing silent failures into hard transformation
failures. Note also that `Client::waitForJob()` polls without a timeout, so before those fixes a
starved refresh would additionally block the transformation for minutes.

## API changes in the published library

- `LoadTableTaskInterface`: `startImport(Client)` → `start(ClientWrapper)` (a task now picks the
  client it needs — the refresh has to go through the branch client), and
  `getStorageJobId(): string` → `getStorageJobIds(): array`. `POST /workspaces/{id}/unload` is typed
  as a list of jobs: today it enqueues a single `refreshStorageBuckets` job carrying every
  direct-grant bucket of the workspace (bucket-scoped locking in keboola/connection#7993 splits the
  locks, not the job), it returns an empty list when the workspace configuration has no direct-grant
  output table, and it will grow the jobs of the remaining unload strategies. Only
  `AbstractLoadTableTask` implements the interface.
- `LoadTableQueue::waitForAll()` returns the ids of **all** Storage jobs it waited for, not just
  the table load ones. No production consumer reads the return value — `docker-bundle`
  `Runner.php:407`, sandboxes `WorkspaceManager.php:248` and data-loader-api `DataExporter.php:96`
  all discard it.
- `LoadTableQueue::getTaskCount()` counts Storage jobs, so `docker-bundle`'s
  "Waiting for N Storage jobs to finish." is truthful; a pure direct-grant run used to log `0` and
  then wait for one job. It is only meaningful once the queue has been started.
- `LoadTableQueue::getLoadTableTasks()` still returns table load tasks only.

## Testing

- `tests/DeferredTasks/LoadTableQueueTest.php` — the queue now delegates the error message to the
  task; new tests for a task without a destination table (awaited, excluded from metrics, its
  error surfaces), for `getTaskCount()` over every job id of a task, and for `start()` enqueuing in
  list order up to the first failure (what puts the refresh first).
- `tests/DeferredTasks/DirectGrantMetadataRefreshTaskTest.php` — the "not started yet" guard and an
  empty job list as a valid result of the unload call.
- `tests/DeferredTasks/LoadTableTaskTest.php` — the enqueue error mapping (4xx →
  `InvalidOutputException` with code and previous preserved, 5xx rethrown), the "not started yet"
  guard, and the failed-job message.
- `tests/TableLoaderDirectGrantMetadataRefreshTest.php` (renamed from
  `TableLoaderDirectGrantUnloadTest`) — 6 cases driving `TableLoader::uploadTables()`: the refresh
  is enqueued with `only-direct-grants`, every returned job id is awaited, an errored job surfaces,
  a 404 becomes `InvalidOutputException`, a 500 and a connection failure (code `0`) are both
  rethrown as `ClientException`.
- `tests/Writer/Workspace/TableLoaderUnloadStrategyTest.php` — `testDirectGrantMetadataRefreshIsAwaited`
  really goes through the direct-grant path: the refresh job is the only queued job, it is a
  `refreshStorageBuckets` job and the queue waits for it. Storage resolves the direct-grant output
  tables of a workspace from the component configuration the workspace was created from
  (`WorkspaceUnloadProcessor::process()`), so a workspace created by `Workspaces::createWorkspace()` —
  what `initWorkspace()` does — always gets an empty list of jobs back and can never produce a
  refresh job; that is why the existing tests in this file only ever asserted that a direct-grant
  mapping uploads nothing. The new `AbstractTestCase::initConfigurationWorkspace()` creates a
  `keboola.snowflake-transformation` configuration with a direct-grant output table and the workspace
  from it.
  Asserting that the table itself ends up registered in Storage is out of reach for a test:
  `/workspaces/{id}/query` restricts every statement to the workspace schema
  (`ExecuteQueryProcessor` passes `pathRestriction`), so the test cannot write the table into the
  bucket schema the way a transformation holding the direct grant does.
- `testDirectGrantUnloadStrategySkipsTableUpload` removed from `TableDefinitionV2Test`: it belonged
  to table definitions, duplicated `testDirectGrantSkipsTableImport`, and its job-count assertion
  held for a workspace which had nothing to unload in the first place.
- A now-impossible log-based check in `TableLoaderUnloadStrategyTest` replaced by a task-count
  assertion with the same intent.
- `vendor/bin/phpunit tests/DeferredTasks` → **54 tests, 201 assertions, OK**;
  `vendor/bin/phpunit tests/TableLoaderDirectGrantMetadataRefreshTest.php` → **6 tests, 42
  assertions, OK**. `composer check` (validate + phpcs + PHPStan level max) → clean.
- Functional suites run in CI. `Workspace writer tests` cover the new direct-grant test.
- **Unrelated red CI:** `General tests`
  (`TableStructureModifierTest::testUpdateTableStructureAddColumnsFromMetadata`) and `Native types`
  (`TableDefinitionTest::testWriterUpdateTableDefinitionWithNativeTypes`) fail on column types
  Storage now returns — `INTEGER` → `NUMBER` with `length: 38,0`, `DECIMAL` → `NUMBER`. Both
  reproduce on the branch point without any of the changes in this PR, so they need their own fix
  before `tests-result` can go green.

