### PR TITLE
feat(api-bundle): Support form payloads and per-property wire keys

### DIFF
--- a/libs/api-bundle/README.md
+++ b/libs/api-bundle/README.md
@@ -145,6 +145,64 @@ which the bundle requires directly, so no extra installation is needed.
 > If you forget to install appropriate client, you will get exception like
 > `Service "Keboola\ApiBundle\Attribute\ApplicationTokenAuth" not found: the container inside "Symfony\Component\DependencyInjection\Argument\ServiceLocator" is a smaller service locator`
 
+## Request mapping
+
+Type-hint a payload object on a controller argument and annotate it with
+`#[RequestPayloadObject]` (request body) or `#[RequestQueryObject]` (query string). The bundle maps
+and validates the request with Valinor + the Symfony validator, and reports every failing field
+individually in the error `context` as `{path, message}`.
+
+```php
+public function __invoke(
+    #[RequestPayloadObject] CreateThingPayload $payload,
+    #[RequestQueryObject] ListFilters $filters,
+): Response {
+}
+```
+
+Both attributes accept `allowExtraKeys` (default `true`) to control whether unknown keys are
+rejected.
+
+### Form-encoded payloads
+
+`#[RequestPayloadObject]` expects `application/json` by default. Endpoints that receive
+`application/x-www-form-urlencoded` (or `multipart/form-data`) declare it with `format`:
+
+```php
+public function __invoke(
+    #[RequestPayloadObject(format: PayloadFormat::Form)] AuthorizePayload $payload,
+): Response {
+}
+```
+
+Form payloads are read from the request parameters rather than the raw body, and are mapped with
+casting enabled because form values are always strings. A request whose content type does not match
+the declared format is rejected with `406 Not Acceptable`.
+
+### Mapping wire keys that aren't valid property names
+
+Some payload fields arrive under a key that cannot be a PHP property — most commonly the Keboola
+`#` prefix marking an encrypted value. Annotate the property with `#[RequestKey]`:
+
+```php
+final readonly class CreateCredentialsPayload
+{
+    public function __construct(
+        #[RequestKey('#data')]
+        public string $data,
+    ) {
+    }
+}
+```
+
+Validation errors are reported under the wire key (`#data`), not the property name. A value sent
+directly under the property name (`data` here) is ignored — only the declared wire key may populate
+the property, so the result never depends on the order of keys in the request.
+
+`#[RequestKey]` applies to **top-level payload properties only**. Declaring it on a nested payload
+object, or declaring the same wire key on two properties, is a configuration error and throws
+`RequestMapperException`.
+
 ## Storage API client
 
 When `#[StorageApiTokenAuth]` is enabled, type-hint

--- a/libs/api-bundle/src/RequestMapper/ArgumentResolver.php
+++ b/libs/api-bundle/src/RequestMapper/ArgumentResolver.php
@@ -10,6 +10,7 @@ use Keboola\ApiBundle\RequestMapper\Attribute\RequestMapperAttributeInterface;
 use Keboola\ApiBundle\RequestMapper\Attribute\RequestPayloadObject;
 use Keboola\ApiBundle\RequestMapper\Attribute\RequestQueryObject;
 use Keboola\ApiBundle\RequestMapper\Exception\RequestMapperException;
+use Keboola\ApiBundle\RequestMapper\PayloadFormat;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Controller\ValueResolverInterface;
@@ -84,8 +85,23 @@ class ArgumentResolver implements ValueResolverInterface
         string $argumentType,
         RequestPayloadObject $attribute,
     ): object {
-        if ($request->getContentTypeFormat() !== 'json') {
-            throw new HttpException(Response::HTTP_NOT_ACCEPTABLE, 'Request content type must be application/json');
+        if ($request->getContentTypeFormat() !== $attribute->format->value) {
+            throw new HttpException(
+                Response::HTTP_NOT_ACCEPTABLE,
+                sprintf('Request content type must be %s', $attribute->format->contentType()),
+            );
+        }
+
+        if ($attribute->format === PayloadFormat::Form) {
+            return $this->dataMapper->mapData(
+                $argumentType,
+                $request->request->all(),
+                self::DATA_MAPPER_ERROR_MESSAGE,
+                self::DATA_MAPPER_ERROR_CODE,
+                // form values are always strings, so they need casting to reach typed properties
+                enableFlexibleCasting: true,
+                enableExtraKeys: $attribute->allowExtraKeys,
+            );
         }
 
         try {

--- a/libs/api-bundle/src/RequestMapper/Attribute/RequestKey.php
+++ b/libs/api-bundle/src/RequestMapper/Attribute/RequestKey.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Keboola\ApiBundle\RequestMapper\Attribute;
+
+use Attribute;
+
+/**
+ * Declares the wire key a payload property is read from, for fields whose key cannot be a PHP
+ * property name — typically the Keboola `#` prefix marking an encrypted value:
+ *
+ * ```php
+ * final readonly class CreateCredentialsPayload
+ * {
+ *     public function __construct(
+ *         #[RequestKey('#data')]
+ *         public string $data,
+ *     ) {}
+ * }
+ * ```
+ *
+ * Validation errors are reported under the wire key rather than the property name, so the client
+ * sees the field it actually sent. A value posted directly under the property name (`data` above)
+ * is dropped — only the declared wire key may populate the property, so the outcome never depends
+ * on the order of keys in the request.
+ *
+ * Supported on top-level payload properties only: the key map is applied to the payload root, so a
+ * declaration on a nested payload object is rejected with a
+ * {@see \Keboola\ApiBundle\RequestMapper\Exception\RequestMapperException} rather than being
+ * silently ignored.
+ */
+#[Attribute(Attribute::TARGET_PROPERTY | Attribute::TARGET_PARAMETER)]
+class RequestKey
+{
+    /**
+     * @param non-empty-string $key Key the value arrives under in the request.
+     */
+    public function __construct(
+        public readonly string $key,
+    ) {
+    }
+}

--- a/libs/api-bundle/src/RequestMapper/Attribute/RequestPayloadObject.php
+++ b/libs/api-bundle/src/RequestMapper/Attribute/RequestPayloadObject.php
@@ -5,12 +5,19 @@ declare(strict_types=1);
 namespace Keboola\ApiBundle\RequestMapper\Attribute;
 
 use Attribute;
+use Keboola\ApiBundle\RequestMapper\PayloadFormat;
 
 #[Attribute(Attribute::TARGET_PARAMETER)]
 class RequestPayloadObject implements RequestMapperAttributeInterface
 {
     public function __construct(
         public readonly bool $allowExtraKeys = true,
+        /**
+         * Wire format of the request body. Form payloads are read from the request parameters
+         * rather than the raw body, and are mapped with casting enabled because form values
+         * are always strings.
+         */
+        public readonly PayloadFormat $format = PayloadFormat::Json,
     ) {
     }
 }

--- a/libs/api-bundle/src/RequestMapper/DataMapper.php
+++ b/libs/api-bundle/src/RequestMapper/DataMapper.php
@@ -8,13 +8,20 @@ use CuyZ\Valinor\Mapper\MappingError;
 use CuyZ\Valinor\Mapper\Tree\Message\Messages;
 use CuyZ\Valinor\Mapper\Tree\Message\NodeMessage;
 use CuyZ\Valinor\MapperBuilder;
+use Keboola\ApiBundle\RequestMapper\Attribute\RequestKey;
 use Keboola\ApiBundle\RequestMapper\Exception\InvalidPayloadException;
+use Keboola\ApiBundle\RequestMapper\Exception\RequestMapperException;
+use ReflectionClass;
+use ReflectionNamedType;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use Symfony\Component\Validator\ConstraintViolationInterface;
 use Symfony\Component\Validator\Validator\ValidatorInterface;
 
 class DataMapper
 {
+    /** @var array<class-string, array<non-empty-string, non-empty-string>> */
+    private array $keyMapCache = [];
+
     public function __construct(
         private readonly MapperBuilder $mapperBuilder,
         private readonly ValidatorInterface $validator,
@@ -34,6 +41,12 @@ class DataMapper
         bool $enableFlexibleCasting = false,
         bool $enableExtraKeys = false,
     ): object {
+        $keyMap = $this->keyMap($objectType);
+        if ($keyMap !== []) {
+            $data = self::applyKeyMap($data, $keyMap);
+        }
+        $sourceKeys = array_flip($keyMap);
+
         $mapperBuilder = $this->mapperBuilder;
         if ($enableFlexibleCasting) {
             $mapperBuilder = $mapperBuilder->enableFlexibleCasting();
@@ -51,7 +64,7 @@ class DataMapper
                 $errorCode,
                 array_map(
                     fn(NodeMessage $message) => [
-                        'path' => $message->node()->path(),
+                        'path' => self::toSourcePath($message->node()->path(), $sourceKeys),
                         'message' => (string) $message,
                     ],
                     [...Messages::flattenFromNode($e->node())->errors()],
@@ -64,7 +77,7 @@ class DataMapper
         if (count($violations) > 0) {
             throw new InvalidPayloadException($errorMessage, $errorCode, array_map(
                 fn(ConstraintViolationInterface $error) => [
-                    'path' => $error->getPropertyPath(),
+                    'path' => self::toSourcePath($error->getPropertyPath(), $sourceKeys),
                     'message' => $error->getMessage(),
                 ],
                 [...$violations],
@@ -72,5 +85,156 @@ class DataMapper
         }
 
         return $object;
+    }
+
+    /**
+     * Wire key => property name, collected from {@see RequestKey} attributes on the mapped class,
+     * memoized per class.
+     *
+     * Promoted constructor properties expose the attribute on both the property and the parameter;
+     * plain properties only on the property. Scanning properties therefore covers both.
+     *
+     * @param class-string $objectType
+     * @return array<non-empty-string, non-empty-string>
+     */
+    private function keyMap(string $objectType): array
+    {
+        if (array_key_exists($objectType, $this->keyMapCache)) {
+            return $this->keyMapCache[$objectType];
+        }
+
+        ['keys' => $keys, 'nested' => $nested] = self::inspectClass($objectType);
+        self::assertNoNestedRequestKeys($objectType, $nested);
+
+        return $this->keyMapCache[$objectType] = $keys;
+    }
+
+    /**
+     * Single reflection pass over a class, collecting both the declared request keys and the
+     * property types that need walking for the nested-declaration check.
+     *
+     * @param class-string $objectType
+     * @return array{keys: array<non-empty-string, non-empty-string>, nested: list<class-string>}
+     */
+    private static function inspectClass(string $objectType): array
+    {
+        $keys = [];
+        $nested = [];
+
+        foreach ((new ReflectionClass($objectType))->getProperties() as $property) {
+            $attributes = $property->getAttributes(RequestKey::class);
+            if ($attributes !== []) {
+                $key = $attributes[0]->newInstance()->key;
+                if (isset($keys[$key])) {
+                    throw new RequestMapperException(sprintf(
+                        'Class "%s" maps request key "%s" to both "%s" and "%s"',
+                        $objectType,
+                        $key,
+                        $keys[$key],
+                        $property->getName(),
+                    ));
+                }
+
+                $keys[$key] = $property->getName();
+            }
+
+            $type = $property->getType();
+
+            // Unions and intersections carry no single resolvable name; builtins have no properties.
+            if (!$type instanceof ReflectionNamedType || $type->isBuiltin()) {
+                continue;
+            }
+
+            $name = $type->getName();
+            if (class_exists($name)) {
+                $nested[] = $name;
+            }
+        }
+
+        return ['keys' => $keys, 'nested' => $nested];
+    }
+
+    /**
+     * The key map is applied to the top-level payload only. A {@see RequestKey} declared deeper
+     * would be silently ignored — and worse, would invert its own guarantee, because the bare
+     * property name would then be accepted while the declared wire key was not. Reject it instead.
+     *
+     * Only statically resolvable property types are walked; element types of collections and union
+     * members cannot be resolved without Valinor's type parser, so a nested declaration reachable
+     * only through those is not detected.
+     *
+     * @param class-string $objectType
+     * @param list<class-string> $queue Class-typed properties of the root, from {@see inspectClass}.
+     */
+    private static function assertNoNestedRequestKeys(string $objectType, array $queue): void
+    {
+        $visited = [$objectType => true];
+
+        while ($queue !== []) {
+            $nestedType = array_shift($queue);
+            if (isset($visited[$nestedType])) {
+                continue;
+            }
+            $visited[$nestedType] = true;
+
+            ['keys' => $keys, 'nested' => $nested] = self::inspectClass($nestedType);
+            if ($keys !== []) {
+                throw new RequestMapperException(sprintf(
+                    'Class "%s" declares #[RequestKey] on nested payload object "%s"; ' .
+                    'only top-level payload properties are supported',
+                    $objectType,
+                    $nestedType,
+                ));
+            }
+
+            foreach ($nested as $furtherType) {
+                $queue[] = $furtherType;
+            }
+        }
+    }
+
+    /**
+     * Renames source keys to the property names the mapper expects.
+     *
+     * A value sent directly under a rename *target* is dropped: only the declared source key may
+     * populate the property, so the outcome never depends on the order of keys in the payload.
+     *
+     * @param array<non-empty-string, non-empty-string> $keyMap
+     */
+    private static function applyKeyMap(mixed $data, array $keyMap): mixed
+    {
+        if (!is_iterable($data)) {
+            return $data;
+        }
+
+        /** @var iterable<array-key, mixed> $data */
+        $result = [];
+        foreach ($data as $key => $value) {
+            if (in_array($key, $keyMap, true)) {
+                continue;
+            }
+
+            $result[$keyMap[$key] ?? $key] = $value;
+        }
+
+        return $result;
+    }
+
+    /**
+     * Reports an error against the key the client actually sent rather than the property name.
+     *
+     * @param array<non-empty-string, non-empty-string> $sourceKeys Property name => source key.
+     */
+    private static function toSourcePath(string $path, array $sourceKeys): string
+    {
+        if ($sourceKeys === []) {
+            return $path;
+        }
+
+        // Only the first segment can be renamed; the map applies to top-level payload keys.
+        $segments = explode('.', $path, 2);
+        $segments[0] = $sourceKeys[$segments[0]] ?? $segments[0];
+
+        return implode('.', $segments);
     }
 }

--- a/libs/api-bundle/src/RequestMapper/PayloadFormat.php
+++ b/libs/api-bundle/src/RequestMapper/PayloadFormat.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Keboola\ApiBundle\RequestMapper;
+
+/**
+ * Wire format of a request payload, as declared by {@see Attribute\RequestPayloadObject}.
+ *
+ * The case values match Symfony's request format names, so they can be compared directly
+ * against {@see \Symfony\Component\HttpFoundation\Request::getContentTypeFormat()}.
+ */
+enum PayloadFormat: string
+{
+    /** `application/json` request body. */
+    case Json = 'json';
+
+    /** `application/x-www-form-urlencoded` or `multipart/form-data` request body. */
+    case Form = 'form';
+
+    /**
+     * Content type advertised to the client when the request does not match this format.
+     */
+    public function contentType(): string
+    {
+        return match ($this) {
+            self::Json => 'application/json',
+            self::Form => 'application/x-www-form-urlencoded',
+        };
+    }
+}

--- a/libs/api-bundle/tests/RequestMapper/ArgumentResolverTest.php
+++ b/libs/api-bundle/tests/RequestMapper/ArgumentResolverTest.php
@@ -10,6 +10,7 @@ use Keboola\ApiBundle\RequestMapper\Attribute\RequestPayloadObject;
 use Keboola\ApiBundle\RequestMapper\Attribute\RequestQueryObject;
 use Keboola\ApiBundle\RequestMapper\DataMapper;
 use Keboola\ApiBundle\RequestMapper\Exception\RequestMapperException;
+use Keboola\ApiBundle\RequestMapper\PayloadFormat;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Request;
@@ -204,6 +205,102 @@ class ArgumentResolverTest extends TestCase
                 Response::HTTP_UNPROCESSABLE_ENTITY,
                 false,
                 $extraKeysEnabled,
+            )
+            ->willReturn($data)
+        ;
+
+        $resolver = new ArgumentResolver($dataMapper);
+        $result = $resolver->resolve($request, $this->createArgumentMetadataForController($controller, 'data'));
+        $result = [...$result];
+
+        self::assertCount(1, $result);
+        self::assertSame($data, $result[0]);
+    }
+
+    public static function provideInvalidFormPayloads(): iterable
+    {
+        yield 'json content type sent to a form endpoint' => [
+            'request' => new Request(
+                server: [
+                    'HTTP_CONTENT_TYPE' => 'application/json',
+                ],
+                content: '{"name": "my name"}',
+            ),
+        ];
+
+        yield 'no content type' => [
+            'request' => new Request(),
+        ];
+    }
+
+    #[DataProvider('provideInvalidFormPayloads')]
+    public function testFormPayloadRejectsNonFormContentType(Request $request): void
+    {
+        $controller = new class {
+            public function __invoke(
+                #[RequestPayloadObject(format: PayloadFormat::Form)] RequestData $data,
+            ): void {
+            }
+        };
+
+        $dataMapper = $this->createMock(DataMapper::class);
+        $dataMapper->expects(self::never())->method('mapData');
+
+        $resolver = new ArgumentResolver($dataMapper);
+
+        $error = null;
+        try {
+            $result = $resolver->resolve($request, $this->createArgumentMetadataForController($controller, 'data'));
+            // @phpstan-ignore-next-line
+            [...$result];
+        } catch (HttpException $error) {
+            // error is checked below
+        }
+
+        self::assertNotNull($error, 'HttpException was not thrown');
+        self::assertSame(Response::HTTP_NOT_ACCEPTABLE, $error->getStatusCode());
+        self::assertSame(
+            'Request content type must be application/x-www-form-urlencoded',
+            $error->getMessage(),
+        );
+    }
+
+    public static function provideFormContentTypes(): iterable
+    {
+        yield 'urlencoded' => ['contentType' => 'application/x-www-form-urlencoded'];
+        yield 'multipart' => ['contentType' => 'multipart/form-data'];
+    }
+
+    #[DataProvider('provideFormContentTypes')]
+    public function testValidFormPayloadRequest(string $contentType): void
+    {
+        $controller = new class {
+            public function __invoke(
+                #[RequestPayloadObject(format: PayloadFormat::Form)] RequestData $data,
+            ): void {
+            }
+        };
+
+        $request = new Request(
+            request: ['name' => 'my name'],
+            server: [
+                'HTTP_CONTENT_TYPE' => $contentType,
+            ],
+        );
+
+        $data = new RequestData(name: 'my name', config: null);
+
+        $dataMapper = $this->createMock(DataMapper::class);
+        $dataMapper->expects(self::once())
+            ->method('mapData')
+            ->with(
+                RequestData::class,
+                ['name' => 'my name'],
+                'Request contents is not valid',
+                Response::HTTP_UNPROCESSABLE_ENTITY,
+                // form values are always strings, so casting must be enabled
+                true,
+                true,
             )
             ->willReturn($data)
         ;

--- a/libs/api-bundle/tests/RequestMapper/DataMapperTest.php
+++ b/libs/api-bundle/tests/RequestMapper/DataMapperTest.php
@@ -7,6 +7,7 @@ namespace Keboola\ApiBundle\Tests\RequestMapper;
 use CuyZ\Valinor\MapperBuilder;
 use Keboola\ApiBundle\RequestMapper\DataMapper;
 use Keboola\ApiBundle\RequestMapper\Exception\InvalidPayloadException;
+use Keboola\ApiBundle\RequestMapper\Exception\RequestMapperException;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Validator\Validation;
@@ -203,5 +204,136 @@ class DataMapperTest extends TestCase
         self::assertSame('Invalid data', $error->getMessage());
         self::assertSame(400, $error->getCode());
         self::assertSame($errorContext, $error->getContext());
+    }
+
+    private function createMapper(): DataMapper
+    {
+        return new DataMapper(
+            new MapperBuilder(),
+            Validation::createValidatorBuilder()
+                ->enableAttributeMapping()
+                ->getValidator(),
+        );
+    }
+
+    /**
+     * @return array{0: ?KeyMappedRequestData, 1: ?InvalidPayloadException}
+     */
+    private function mapKeyMapped(array $data): array
+    {
+        try {
+            return [$this->createMapper()->mapData(KeyMappedRequestData::class, $data, 'Invalid data', 400), null];
+        } catch (InvalidPayloadException $e) {
+            return [null, $e];
+        }
+    }
+
+    public function testDuplicateRequestKeyIsRejected(): void
+    {
+        $this->expectException(RequestMapperException::class);
+        $this->expectExceptionMessage(
+            'Class "Keboola\ApiBundle\Tests\RequestMapper\DuplicateKeyRequestData" maps request key ' .
+            '"#data" to both "first" and "second"',
+        );
+
+        $this->createMapper()->mapData(DuplicateKeyRequestData::class, ['#data' => 'x'], 'Invalid data', 400);
+    }
+
+    public function testRequestKeyOnNestedObjectIsRejected(): void
+    {
+        // The key map is only applied to top-level payload keys. Declaring it deeper used to be
+        // silently ignored — which inverted the guarantee, since the bare property name then worked
+        // and the declared wire key did not. Fail loudly instead.
+        $this->expectException(RequestMapperException::class);
+        $this->expectExceptionMessage(
+            'Class "Keboola\ApiBundle\Tests\RequestMapper\NestedOuterWithKeyedInner" declares ' .
+            '#[RequestKey] on nested payload object ' .
+            '"Keboola\ApiBundle\Tests\RequestMapper\NestedInnerWithKey"; ' .
+            'only top-level payload properties are supported',
+        );
+
+        $this->createMapper()->mapData(
+            NestedOuterWithKeyedInner::class,
+            ['name' => 'n', 'inner' => ['#secret' => 's']],
+            'Invalid data',
+            400,
+        );
+    }
+
+    public function testNestedObjectWithoutRequestKeyStillMaps(): void
+    {
+        $result = $this->createMapper()->mapData(
+            NestedOuterPlain::class,
+            ['name' => 'n', 'inner' => ['secret' => 's'], 'union' => 3],
+            'Invalid data',
+            400,
+        );
+
+        self::assertSame('n', $result->name);
+        self::assertSame('s', $result->inner->secret);
+    }
+
+    public function testKeyMapDeclaredOnPropertyIsApplied(): void
+    {
+        [$result, $error] = $this->mapKeyMapped(['#data' => 'secret']);
+
+        self::assertNull($error);
+        self::assertNotNull($result);
+        self::assertSame('secret', $result->data);
+    }
+
+    public function testKeyMapRejectsBareTargetKey(): void
+    {
+        // `data` is a rename *target*, not a wire key — it must not populate the property.
+        [$result, $error] = $this->mapKeyMapped(['data' => 'secret']);
+
+        self::assertNull($result);
+        self::assertNotNull($error);
+        self::assertSame([['path' => '#data', 'message' => 'Cannot be empty and must be filled with a value ' .
+            'matching type `string`.']], $error->getContext());
+    }
+
+    public static function provideBothKeysOrderings(): iterable
+    {
+        yield 'wire key first' => ['data' => ['#data' => 'from-wire', 'data' => 'bare']];
+        yield 'bare key first' => ['data' => ['data' => 'bare', '#data' => 'from-wire']];
+    }
+
+    #[DataProvider('provideBothKeysOrderings')]
+    public function testKeyMapIsOrderIndependent(array $data): void
+    {
+        [$result, $error] = $this->mapKeyMapped($data);
+
+        self::assertNull($error);
+        self::assertNotNull($result);
+        self::assertSame('from-wire', $result->data);
+    }
+
+    public function testKeyMapInvertsMappingErrorPaths(): void
+    {
+        [, $error] = $this->mapKeyMapped([]);
+
+        self::assertNotNull($error);
+        self::assertSame(['#data'], array_column($error->getContext(), 'path'));
+    }
+
+    public function testKeyMapInvertsValidationErrorPaths(): void
+    {
+        [, $error] = $this->mapKeyMapped(['#data' => 'a value longer than allowed']);
+
+        self::assertNotNull($error);
+        self::assertSame(
+            [['path' => '#data', 'message' => 'This value is too long. It should have 16 characters or less.']],
+            $error->getContext(),
+        );
+    }
+
+    public function testUnmappedKeysAreLeftUntouched(): void
+    {
+        [$result, $error] = $this->mapKeyMapped(['#data' => 'secret', 'name' => 'my name']);
+
+        self::assertNull($error);
+        self::assertNotNull($result);
+        self::assertSame('my name', $result->name);
     }
 }

--- a/libs/api-bundle/tests/RequestMapper/DuplicateKeyRequestData.php
+++ b/libs/api-bundle/tests/RequestMapper/DuplicateKeyRequestData.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Keboola\ApiBundle\Tests\RequestMapper;
+
+use Keboola\ApiBundle\RequestMapper\Attribute\RequestKey;
+
+class DuplicateKeyRequestData
+{
+    public function __construct(
+        #[RequestKey('#data')]
+        public readonly string $first,
+        #[RequestKey('#data')]
+        public readonly string $second,
+    ) {
+    }
+}

--- a/libs/api-bundle/tests/RequestMapper/KeyMappedRequestData.php
+++ b/libs/api-bundle/tests/RequestMapper/KeyMappedRequestData.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Keboola\ApiBundle\Tests\RequestMapper;
+
+use Keboola\ApiBundle\RequestMapper\Attribute\RequestKey;
+use Symfony\Component\Validator\Constraints as Assert;
+
+class KeyMappedRequestData
+{
+    public function __construct(
+        #[RequestKey('#data')]
+        #[Assert\Length(max: 16)]
+        public readonly string $data,
+        public readonly ?string $name = null,
+    ) {
+    }
+}

--- a/libs/api-bundle/tests/RequestMapper/NestedInnerPlain.php
+++ b/libs/api-bundle/tests/RequestMapper/NestedInnerPlain.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Keboola\ApiBundle\Tests\RequestMapper;
+
+class NestedInnerPlain
+{
+    public function __construct(
+        public readonly string $secret,
+    ) {
+    }
+}

--- a/libs/api-bundle/tests/RequestMapper/NestedInnerWithKey.php
+++ b/libs/api-bundle/tests/RequestMapper/NestedInnerWithKey.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Keboola\ApiBundle\Tests\RequestMapper;
+
+use Keboola\ApiBundle\RequestMapper\Attribute\RequestKey;
+
+class NestedInnerWithKey
+{
+    public function __construct(
+        #[RequestKey('#secret')]
+        public readonly string $secret,
+    ) {
+    }
+}

--- a/libs/api-bundle/tests/RequestMapper/NestedOuterPlain.php
+++ b/libs/api-bundle/tests/RequestMapper/NestedOuterPlain.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Keboola\ApiBundle\Tests\RequestMapper;
+
+class NestedOuterPlain
+{
+    public function __construct(
+        public readonly string $name,
+        public readonly NestedInnerPlain $inner,
+        public readonly int|string $union = 0,
+    ) {
+    }
+}

--- a/libs/api-bundle/tests/RequestMapper/NestedOuterWithKeyedInner.php
+++ b/libs/api-bundle/tests/RequestMapper/NestedOuterWithKeyedInner.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Keboola\ApiBundle\Tests\RequestMapper;
+
+class NestedOuterWithKeyedInner
+{
+    public function __construct(
+        public readonly string $name,
+        public readonly ?NestedInnerWithKey $inner = null,
+    ) {
+    }
+}


### PR DESCRIPTION
## Release Notes

Adds two capabilities to the shared `RequestMapper` so services no longer have to fork it. Both come out of `oauth-service`, which currently ships a local copy of the bundle's resolver (`App\RequestMapper`) purely to serve two endpoints the shared one cannot: a form-encoded `POST /authorize` and a credentials payload whose encrypted field arrives under the wire key `#data`. With this change that local copy can be deleted.

`#[RequestPayloadObject]` gains a `format` option (`PayloadFormat::Json` by default, so nothing changes for existing callers). A `Form` payload is read from the request parameters rather than the raw body and mapped with casting enabled, because form values are always strings; a mismatched content type is rejected with `406` exactly as the JSON path already does. Separately, `#[RequestKey('#data')]` is declared **on the property itself**, so the wire contract sits next to the field it describes rather than being repeated at every call site. Two details are deliberate: validation errors are reported under the wire key (`#data`), not the property name, so the client sees the field it actually sent; and a value posted directly under the property name is dropped, so the result cannot depend on the order of keys in the request. Two properties claiming the same wire key throw `RequestMapperException`.

Alternatives considered:
* **Valinor 2 `#[AsConverter]` + the documented `RenameKeys` converter** — the natural fit on paper, but it reports errors under the property name (`data`), passes unmapped keys straight through (so a bare `data` still wins, order-dependently), and would require bumping `cuyz/valinor-bundle` `^0.4` → `^2.3`. That upgrade removes `MapperBuilder::enableFlexibleCasting()`, `Messages::flattenFromNode()` and `NodeMessage::node()` — all used by `DataMapper` — putting every consumer's query mapping in the blast radius.
* **A named constructor taking a shaped array with a quoted `'#data'` key** — reports the true wire key, but a missing body collapses into a single error on the constructor parameter instead of one error per field, which defeats the point of per-field reporting. Verified against both Valinor 1.17 and 2.5.1.

Keeping the mapping in the bundle avoids the upgrade entirely and gets a strictly better result than either.

## Plans for customer communication
None.

## Impact analysis
No impact on existing consumers. `format` defaults to `PayloadFormat::Json`, the JSON content-type error message is unchanged, and the key map only does anything on classes carrying `#[RequestKey]`. The added per-class reflection lookup is memoized and measures ~0.3 µs against ~71 µs for a single `map()` call.

## Change type
New feature

## Justification
Lets `oauth-service` drop its forked request mapper; both features are generic enough that the next service to hit either case won't fork it again.

## Deployment
Merge & release a new bundle version.

## Rollback plan
Revert of this PR.

## Post release support plan
None.
