### PR TITLE
fix(input-mapping): report input file download failures as user errors (SUPPORT-17151)

### DIFF
--- a/libs/input-mapping/src/File/Strategy/AbstractStrategy.php
+++ b/libs/input-mapping/src/File/Strategy/AbstractStrategy.php
@@ -6,12 +6,14 @@ namespace Keboola\InputMapping\File\Strategy;
 
 use Keboola\InputMapping\Exception\FileNotFoundException;
 use Keboola\InputMapping\Exception\InputOperationException;
+use Keboola\InputMapping\Exception\InvalidInputException;
 use Keboola\InputMapping\File\StrategyInterface;
 use Keboola\InputMapping\Helper\ManifestCreator;
 use Keboola\InputMapping\Reader;
 use Keboola\InputMapping\State\InputFileStateList;
 use Keboola\StagingProvider\Staging\File\FileFormat;
 use Keboola\StagingProvider\Staging\File\FileStagingInterface;
+use Keboola\StorageApi\ClientException;
 use Keboola\StorageApi\Options\GetFileOptions;
 use Keboola\StorageApiBranch\ClientWrapper;
 use Psr\Log\LoggerInterface;
@@ -92,6 +94,18 @@ abstract class AbstractStrategy implements StrategyInterface
                         (string) $fileOptionsRewritten->getSourceBranchId(),
                         $fileDestinationPath,
                         $overwrite,
+                    );
+                } catch (ClientException $e) {
+                    // a missing or expired file is a user input problem, not a platform error
+                    throw new InvalidInputException(
+                        sprintf(
+                            'Failed to download file %s (%s): %s',
+                            $fileInfo['name'],
+                            $file['id'],
+                            $e->getMessage(),
+                        ),
+                        0,
+                        $e,
                     );
                 } catch (Throwable $e) {
                     throw new InputOperationException(

--- a/libs/input-mapping/tests/Functional/DownloadFilesTest.php
+++ b/libs/input-mapping/tests/Functional/DownloadFilesTest.php
@@ -7,14 +7,23 @@ namespace Keboola\InputMapping\Tests\Functional;
 use Keboola\InputMapping\Configuration\File\Manifest\Adapter;
 use Keboola\InputMapping\Exception\InputOperationException;
 use Keboola\InputMapping\Exception\InvalidInputException;
+use Keboola\InputMapping\File\Strategy\Local;
 use Keboola\InputMapping\Reader;
 use Keboola\InputMapping\State\InputFileStateList;
 use Keboola\InputMapping\Tests\Needs\NeedsTestTables;
 use Keboola\Settle\SettleFactory;
 use Keboola\StagingProvider\Staging\File\FileFormat;
+use Keboola\StagingProvider\Staging\File\FileStagingInterface;
+use Keboola\StorageApi\BranchAwareClient;
+use Keboola\StorageApi\Client;
+use Keboola\StorageApi\ClientException;
 use Keboola\StorageApi\Options\FileUploadOptions;
 use Keboola\StorageApi\Options\ListFilesOptions;
+use Keboola\StorageApiBranch\Branch;
+use Keboola\StorageApiBranch\ClientWrapper;
+use Keboola\StorageApiBranch\Factory\ClientOptions;
 use Psr\Log\NullLogger;
+use RuntimeException;
 use SplFileInfo;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Finder\Finder;
@@ -560,5 +569,79 @@ class DownloadFilesTest extends AbstractDownloadFilesTest
         self::assertEquals($id2, $manifest2['id']);
         self::assertTrue($this->testHandler->hasInfoThatContains(sprintf('Fetched file "%s_upload".', $id1)));
         self::assertTrue($this->testHandler->hasInfoThatContains(sprintf('Fetched file "%s_upload_second".', $id2)));
+    }
+
+    public function testStorageClientExceptionIsReportedAsUserError(): void
+    {
+        $storageClient = $this->createDownloadFailingStorageClient(function (): void {
+            throw new ClientException(
+                'Cannot download file "my-file.csv" (ID 123) from Storage, ' .
+                'please verify the contents of the file and that the file has not expired.',
+                404,
+            );
+        });
+        $strategy = $this->createLocalStrategyWithStorageClient($storageClient);
+
+        $this->expectException(InvalidInputException::class);
+        $this->expectExceptionMessage(
+            'Failed to download file my-file.csv (123): Cannot download file "my-file.csv" (ID 123) from Storage, ' .
+            'please verify the contents of the file and that the file has not expired.',
+        );
+
+        $strategy->downloadFiles([['tags' => ['my-tag'], 'overwrite' => true]], 'download');
+    }
+
+    public function testUnexpectedErrorIsReportedAsApplicationError(): void
+    {
+        $storageClient = $this->createDownloadFailingStorageClient(function (): void {
+            throw new RuntimeException('Something went wrong internally.');
+        });
+        $strategy = $this->createLocalStrategyWithStorageClient($storageClient);
+
+        $this->expectException(InputOperationException::class);
+        $this->expectExceptionMessage(
+            'Failed to download file my-file.csv (123): Something went wrong internally.',
+        );
+
+        $strategy->downloadFiles([['tags' => ['my-tag'], 'overwrite' => true]], 'download');
+    }
+
+    private function createDownloadFailingStorageClient(callable $downloadFileCallback): BranchAwareClient
+    {
+        $storageClient = $this->createMock(BranchAwareClient::class);
+        $storageClient->method('listFiles')->willReturn([['id' => 123, 'name' => 'my-file.csv']]);
+        $storageClient->method('getFile')->willReturn([
+            'id' => 123,
+            'name' => 'my-file.csv',
+            'isSliced' => false,
+        ]);
+        $storageClient->method('downloadFile')->willReturnCallback($downloadFileCallback);
+
+        return $storageClient;
+    }
+
+    private function createLocalStrategyWithStorageClient(BranchAwareClient $storageClient): Local
+    {
+        $basicClient = $this->createMock(Client::class);
+        $basicClient->method('getRunId')->willReturn('run-123');
+
+        $clientWrapper = $this->createMock(ClientWrapper::class);
+        $clientWrapper->method('isDevelopmentBranch')->willReturn(false);
+        $clientWrapper->method('getClientOptionsReadOnly')->willReturn(new ClientOptions());
+        $clientWrapper->method('getTableAndFileStorageClient')->willReturn($basicClient);
+        $clientWrapper->method('getClientForBranch')->willReturn($storageClient);
+        $clientWrapper->method('getDefaultBranch')->willReturn(new Branch('123', 'main', true, null));
+
+        $staging = $this->createMock(FileStagingInterface::class);
+        $staging->method('getPath')->willReturn($this->temp->getTmpFolder());
+
+        return new Local(
+            $clientWrapper,
+            new NullLogger(),
+            $staging,
+            $staging,
+            new InputFileStateList([]),
+            FileFormat::Json,
+        );
     }
 }


### PR DESCRIPTION
## Description

Python transformation (and other component) jobs sometimes failed with a generic **"Internal Server Error occurred."** when an input **file** could not be downloaded from Storage — even though the underlying cause is user-owned (the file is missing or has expired). See SUPPORT-17151 (Datadog: the failing job's last S3 GET returned `404 NoSuchKey` for an input file).

Root cause: `File\Strategy\AbstractStrategy::downloadFiles()` caught **every** `Throwable` from the per-file download and re-wrapped it as an `InputOperationException`, which the consumer (`job-queue`'s `InputDataLoader`) treats as an application error. The Storage client already throws a clear, user-facing message for this case (`Cannot download file "…" (ID …) from Storage, please verify the contents of the file and that the file has not expired.`), but it was masked.

Fix: classify Storage `ClientException`s during file download as a user error (`InvalidInputException`, caught downstream and surfaced as a `UserException`), while keeping genuinely unexpected errors as `InputOperationException`. The job now ends as a **user error** with the actionable Storage message instead of a masked internal error.

Note: despite the name, `InputMapping\Exception\FileNotFoundException` is **not** raised for a missing/expired Storage file — it is an internal control-flow signal thrown by `InputFileStateList::getFile()` when no incremental-load *state entry* matches the file tags, and is caught locally to fall back to empty state. A file that cannot be downloaded surfaces as a Storage `ClientException`, which is what this change now classifies. https://github.com/keboola/connection/blob/5e1f562d7d4c11df964ab249a49e309267acb127/Package/StorageApiPhpClient/src/Keboola/StorageApi/Client.php#L2518

Transported from keboola/input-mapping#2 into the monorepo; the test is folded into the existing `DownloadFilesTest` rather than a dedicated class.

## Justification

See [SUPPORT-17151](https://keboola.atlassian.net/browse/SUPPORT-17151) — missing/expired input files were reported as internal errors instead of actionable user errors.

## Plans for Customer Communication

None.

## Impact Analysis

Affects error classification only for the file input-mapping download path. Failures previously reported as application/internal errors for missing/expired input files will now be reported as user errors. No change to successful runs or to genuinely unexpected errors. Not feature-flagged.

## Deployment Plan

Release a tagged version (`input-mapping/<version>`) after merge. And update IM in job-runner (to fix python transformations, the rest will update organically)

## Rollback Plan

Revert this PR.

## Post-Release Support Plan

None.


[SUPPORT-17151]: https://keboola.atlassian.net/browse/SUPPORT-17151?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ