### PR TITLE
test(output-mapping): expect the physical column type Storage records

### DIFF
--- a/libs/output-mapping/tests/Storage/TableStructureModifierTest.php
+++ b/libs/output-mapping/tests/Storage/TableStructureModifierTest.php
@@ -251,8 +251,10 @@ class TableStructureModifierTest extends AbstractTestCase
         $expectedNewColumnDefinition = [
             'name' => $newColumnName,
             'definition' => [
-                'type' => 'INTEGER',
+                // Storage records the physical column, and Snowflake resolves INT to NUMBER(38,0)
+                'type' => 'NUMBER',
                 'nullable' => true,
+                'length' => '38,0',
             ],
             'basetype' => 'INTEGER',
             'canBeFiltered' => true,

--- a/libs/output-mapping/tests/Writer/TableDefinitionTest.php
+++ b/libs/output-mapping/tests/Writer/TableDefinitionTest.php
@@ -512,8 +512,9 @@ class TableDefinitionTest extends AbstractTestCase
             'nullable' => true,
         ]);
         self::assertDataTypeDefinition($tableDetails['columnMetadata']['created'], [
+            // TIMESTAMP_TZ is not an alias, so the type survives the read back - the precision is added
             'type' => Snowflake::TYPE_TIMESTAMP_TZ,
-            'length' => null,
+            'length' => '9',
             'nullable' => true,
         ]);
     }
@@ -689,14 +690,8 @@ class TableDefinitionTest extends AbstractTestCase
             return $metadatum['key'] === Common::KBC_METADATA_KEY_LENGTH
                 && $metadatum['provider'] === 'storage';
         }));
-        // Timestamp columns no longer carry length metadata under the current native-types backend,
-        // so a null expected length means "no length metadata present".
-        if ($expectedType['length'] === null) {
-            self::assertCount(0, $lengthMetadata);
-        } else {
-            self::assertCount(1, $lengthMetadata);
-            self::assertSame($expectedType['length'], $lengthMetadata[0]['value']);
-        }
+        self::assertCount(1, $lengthMetadata);
+        self::assertSame($expectedType['length'], $lengthMetadata[0]['value']);
 
         $nullableMetadata = array_values(array_filter($metadata, function ($metadatum) {
             return $metadatum['key'] === Common::KBC_METADATA_KEY_NULLABLE

--- a/libs/output-mapping/tests/Writer/TableDefinitionTest.php
+++ b/libs/output-mapping/tests/Writer/TableDefinitionTest.php
@@ -506,7 +506,8 @@ class TableDefinitionTest extends AbstractTestCase
             'nullable' => false,
         ]);
         self::assertDataTypeDefinition($tableDetails['columnMetadata']['birthweight'], [
-            'type' => Snowflake::TYPE_DECIMAL,
+            // Storage records the physical column, and Snowflake resolves DECIMAL to NUMBER
+            'type' => Snowflake::TYPE_NUMBER,
             'length' => '10,2',
             'nullable' => true,
         ]);


### PR DESCRIPTION
## What changed on the platform side

[keboola/connection#8002](https://github.com/keboola/connection/pull/8002) (DMD-1849) aligns
**adding a column to a table definition** with **creating a table definition**.

Creating a table definition always stored the datatype the backend really created. Adding a column
did not: `Storage_Job_TableColumnAdd` had two paths for a typed table — the driver path re-read the
columns from the backend, while the legacy Snowflake path built the metadata straight from the
requested `ColumnInterface`. So the requested type survived in `KBC.datatype.*` until something
forced a re-read: a `columns[]` patch through the table-definition API takes the
`syncTypedColumnInfo()` branch and rewrote the metadata from the backend, which looked like the
column type had changed even though the column was never altered.

Snowflake `tableColumnAdd` now goes through the storage driver like BigQuery, so there is a single
add-column path and it always reads the column back — the same thing create already did.

The requests output mapping sends are unchanged. Only what Storage records for a column added
afterwards changed, so the fix belongs in the test expectations, not in `src`.

## Which expectations moved

Snowflake resolves `INT`/`INTEGER` to `NUMBER(38,0)` and `DECIMAL` to `NUMBER`, so a column added
through output mapping now reports the resolved type.

`tests/Writer/TableDefinitionTest.php` — `testWriterUpdateTableDefinitionWithNativeTypes`. The test
itself shows both sides of the old inconsistency: `Id` (`INTEGER`) and `Name` (`TEXT`) are part of
the `createTableDefinition()` payload and the test has always expected the physical
`NUMBER 38,0` / `VARCHAR 17` for them. `birthweight` is added later by the `tableColumnAdd` job of
output mapping, and only that one carried the requested type:

```diff
-            'type' => Snowflake::TYPE_DECIMAL,
+            'type' => Snowflake::TYPE_NUMBER,
             'length' => '10,2',
```

`created` keeps its type — `TIMESTAMP_TZ` is not an alias — but the read back reports the precision
Snowflake applied, so the column now carries length metadata like every other one:

```diff
             'type' => Snowflake::TYPE_TIMESTAMP_TZ,
-            'length' => null,
+            'length' => '9',
```

`'9'` is what the data providers of the neighbouring tests in the same file (and
`TableDefinitionV2Test`) have always expected for a `TIMESTAMP_TZ` column created through a table
definition — another instance of add-column now matching create. The branch in
`assertDataTypeDefinition` which tolerated a missing length has no caller left, so it is gone; the
`assertTableTypedColumnAddJob` expectation of `length => null` stays, because the request carries no
precision.

`tests/Storage/TableStructureModifierTest.php` — `testUpdateTableStructureAddColumnsFromMetadata`,
where the new column is likewise added to an existing definition:

```diff
-                'type' => 'INTEGER',
+                'type' => 'NUMBER',
                 'nullable' => true,
+                'length' => '38,0',
```

Assertions stay explicit — concrete type plus its resolved precision. The
`assertTableTypedColumnAddJob` assertions still expect `DECIMAL` in the job parameters, because the
request itself did not change.

## Verification

- `composer check` (composer validate + phpcs + phpstan) passes in `dev-output-mapping`.
- The two functional tests are verified by CI on this branch: `General tests` covers
  `tests/Storage/...`, `Native types` covers `tests/Writer/TableDefinitionTest.php`.

## Ordering

This should land before #553, whose CI is red only because of these two tests.
