### PR TITLE
fix(service-client): point Service::OAUTH at oauth-service, not legacy oauth-api

### DIFF
--- a/libs/service-client/src/Service.php
+++ b/libs/service-client/src/Service.php
@@ -63,7 +63,7 @@ enum Service
             self::GIT_SERVICE => 'git-service.git-service',
             self::IMPORT => 'sapi-importer.default',
             self::NOTIFICATION => 'notification-api.default',
-            self::OAUTH => 'oauth-api.default',
+            self::OAUTH => 'oauth-service-api.default',
             self::QUERY => 'query-service-api.query-service',
             self::QUEUE => 'job-queue-api.default',
             self::QUEUE_INTERNAL_API => 'job-queue-internal-api.default',

--- a/libs/service-client/tests/ServiceClientTest.php
+++ b/libs/service-client/tests/ServiceClientTest.php
@@ -38,7 +38,7 @@ class ServiceClientTest extends TestCase
     private const INTERNAL_GIT_SERVICE = 'http://git-service.git-service.svc.cluster.local';
     private const INTERNAL_IMPORT_SERVICE = 'http://sapi-importer.default.svc.cluster.local';
     private const INTERNAL_NOTIFICATION_SERVICE = 'http://notification-api.default.svc.cluster.local';
-    private const INTERNAL_OAUTH = 'http://oauth-api.default.svc.cluster.local';
+    private const INTERNAL_OAUTH = 'http://oauth-service-api.default.svc.cluster.local';
     private const INTERNAL_QUERY_SERVICE = 'http://query-service-api.query-service.svc.cluster.local';
     private const INTERNAL_QUEUE = 'http://job-queue-api.default.svc.cluster.local';
     private const INTERNAL_QUEUE_INTERNAL_API = 'http://job-queue-internal-api.default.svc.cluster.local';

--- a/libs/service-client/tests/ServiceTest.php
+++ b/libs/service-client/tests/ServiceTest.php
@@ -63,7 +63,7 @@ class ServiceTest extends TestCase
         yield 'git service' => [Service::GIT_SERVICE, 'git-service.git-service']; // <-- custom namespace, internal-only
         yield 'import' => [Service::IMPORT, 'sapi-importer.default'];
         yield 'notification' => [Service::NOTIFICATION, 'notification-api.default'];
-        yield 'oauth' => [Service::OAUTH, 'oauth-api.default'];
+        yield 'oauth' => [Service::OAUTH, 'oauth-service-api.default'];
         yield 'queue' => [Service::QUEUE, 'job-queue-api.default'];
         yield 'queue internal api' => [Service::QUEUE_INTERNAL_API, 'job-queue-internal-api.default'];
         yield 'scheduler' => [Service::SCHEDULER, 'scheduler-api.default'];


### PR DESCRIPTION
[link to issue](https://linear.app/keboola/issue/AJDA-3069/slsp-github-integration)

## Description

`Service::OAUTH`'s internal name still pointed at `oauth-api.default`, the legacy Node.js service. The PHP `oauth-service` that replaced it is deployed as `oauth-service-api` — the enum was simply never updated with the migration.

```
- self::OAUTH => 'oauth-api.default',
+ self::OAUTH => 'oauth-service-api.default',
```

Only `INTERNAL` DNS is affected; `PUBLIC` goes through the ingress and is unchanged, which is why nobody noticed. Surfaced while wiring sandboxes-service to oauth-service's new GitHub credential endpoints, which exist only on the PHP service.

## Release Notes

- **Justification**
    - In-cluster callers should reach the service that actually implements the API.

- **Plans for Customer Communication**
    - None.

- **Impact Analysis**
    - In-cluster OAuth traffic moves from `oauth-api` to `oauth-service`. I found no consumer using `Service::OAUTH` with `INTERNAL` DNS other than the new sandboxes-service call, but worth a look from whoever owns the migration in case something is deliberately pinned to the legacy service.
    - No change for `PUBLIC` DNS consumers.

- **Deployment Plan**
    - Release a tagged version.

- **Rollback Plan**
    - Revert this PR.

- **Post-Release Support Plan**
    - None.
